### PR TITLE
Add interactive textbook components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ CLAUDE.local.md
 .claude-dev-helper/
 .plugin-config/
 
+# Worktrees
+.worktrees/
+
 # MkDocs
 site/
 docs/

--- a/assets/javascripts/components/code-walkthrough.js
+++ b/assets/javascripts/components/code-walkthrough.js
@@ -1,0 +1,204 @@
+/**
+ * Code Walkthrough Component
+ *
+ * Step-by-step code annotation with line highlighting,
+ * forward/back navigation, and show-all toggle.
+ *
+ * Config schema:
+ * {
+ *   language?: string,
+ *   title?: string,
+ *   code: string,
+ *   annotations: [{ line: number, text: string }]
+ * }
+ */
+
+(function () {
+  "use strict";
+
+  function initCodeWalkthrough(container, config) {
+    const code = config.code || "";
+    const lines = code.split("\n");
+    // Remove trailing empty line if present
+    if (lines.length > 0 && lines[lines.length - 1].trim() === "") {
+      lines.pop();
+    }
+    const annotations = (config.annotations || []).sort((a, b) => a.line - b.line);
+    let currentStepIndex = -1;
+    let showAll = false;
+
+    // Header
+    const header = document.createElement("div");
+    header.className = "interactive-header";
+    header.innerHTML =
+      '<span class="icon">&#128270;</span> ' + (config.title || "Code Walkthrough");
+
+    // Code area
+    const codeArea = document.createElement("div");
+    codeArea.className = "walkthrough-code";
+
+    const pre = document.createElement("pre");
+    const lineElements = [];
+
+    lines.forEach((lineText, i) => {
+      const lineEl = document.createElement("span");
+      lineEl.className = "walkthrough-line";
+
+      const lineNum = document.createElement("span");
+      lineNum.className = "line-number";
+      lineNum.textContent = i + 1;
+
+      const lineContent = document.createElement("span");
+      lineContent.className = "line-content";
+      lineContent.textContent = lineText || " "; // preserve empty lines
+
+      lineEl.appendChild(lineNum);
+      lineEl.appendChild(lineContent);
+      pre.appendChild(lineEl);
+      lineElements.push(lineEl);
+    });
+
+    codeArea.appendChild(pre);
+
+    // Annotation display
+    const annotationEl = document.createElement("div");
+    annotationEl.className = "walkthrough-annotation";
+    annotationEl.textContent = annotations.length > 0 ? "Click 'Next' to begin the walkthrough" : "No annotations available";
+
+    // Controls
+    const controls = document.createElement("div");
+    controls.className = "walkthrough-controls";
+
+    const prevBtn = document.createElement("button");
+    prevBtn.type = "button";
+    prevBtn.textContent = "Previous";
+    prevBtn.disabled = true;
+
+    const nextBtn = document.createElement("button");
+    nextBtn.type = "button";
+    nextBtn.textContent = "Next";
+    nextBtn.disabled = annotations.length === 0;
+
+    const showAllBtn = document.createElement("button");
+    showAllBtn.type = "button";
+    showAllBtn.className = "show-all-toggle";
+    showAllBtn.textContent = "Show All";
+
+    const stepInfo = document.createElement("span");
+    stepInfo.className = "walkthrough-step-info";
+
+    controls.appendChild(prevBtn);
+    controls.appendChild(nextBtn);
+    controls.appendChild(showAllBtn);
+    controls.appendChild(stepInfo);
+
+    function highlightLine(lineNum) {
+      lineElements.forEach((el) => el.classList.remove("active"));
+      if (lineNum >= 1 && lineNum <= lineElements.length) {
+        lineElements[lineNum - 1].classList.add("active");
+        // Scroll line into view within the code area
+        lineElements[lineNum - 1].scrollIntoView({ block: "nearest", behavior: "smooth" });
+      }
+    }
+
+    function showStep(index) {
+      if (showAll) return;
+      currentStepIndex = index;
+
+      if (index >= 0 && index < annotations.length) {
+        const ann = annotations[index];
+        highlightLine(ann.line);
+        annotationEl.textContent = ann.text;
+        stepInfo.textContent = `Step ${index + 1} of ${annotations.length}`;
+      }
+
+      prevBtn.disabled = index <= 0;
+      nextBtn.disabled = index >= annotations.length - 1;
+    }
+
+    function showAllAnnotations() {
+      showAll = true;
+      showAllBtn.classList.add("active");
+      showAllBtn.textContent = "Step Mode";
+      prevBtn.disabled = true;
+      nextBtn.disabled = true;
+      stepInfo.textContent = `${annotations.length} annotations`;
+
+      // Highlight all annotated lines
+      lineElements.forEach((el) => el.classList.remove("active"));
+      annotations.forEach((ann) => {
+        if (ann.line >= 1 && ann.line <= lineElements.length) {
+          lineElements[ann.line - 1].classList.add("active");
+        }
+      });
+
+      // Show all annotations in the annotation area
+      annotationEl.innerHTML = "";
+      annotations.forEach((ann) => {
+        const p = document.createElement("p");
+        p.innerHTML =
+          "<strong>Line " + ann.line + ":</strong> " + escapeHtml(ann.text);
+        p.style.margin = "0.25rem 0";
+        annotationEl.appendChild(p);
+      });
+    }
+
+    function exitShowAll() {
+      showAll = false;
+      showAllBtn.classList.remove("active");
+      showAllBtn.textContent = "Show All";
+
+      if (currentStepIndex >= 0) {
+        showStep(currentStepIndex);
+      } else if (annotations.length > 0) {
+        showStep(0);
+      }
+    }
+
+    nextBtn.addEventListener("click", () => {
+      if (currentStepIndex < annotations.length - 1) {
+        showStep(currentStepIndex + 1);
+      }
+    });
+
+    prevBtn.addEventListener("click", () => {
+      if (currentStepIndex > 0) {
+        showStep(currentStepIndex - 1);
+      }
+    });
+
+    showAllBtn.addEventListener("click", () => {
+      if (showAll) {
+        exitShowAll();
+      } else {
+        showAllAnnotations();
+      }
+    });
+
+    // Allow clicking on annotated lines
+    lineElements.forEach((el, i) => {
+      const lineNum = i + 1;
+      const annIndex = annotations.findIndex((a) => a.line === lineNum);
+      if (annIndex >= 0) {
+        el.style.cursor = "pointer";
+        el.addEventListener("click", () => {
+          if (showAll) exitShowAll();
+          showStep(annIndex);
+        });
+      }
+    });
+
+    // Assemble
+    container.innerHTML = "";
+    container.appendChild(header);
+    container.appendChild(codeArea);
+    container.appendChild(annotationEl);
+    container.appendChild(controls);
+  }
+
+  function escapeHtml(str) {
+    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  window.RunbookComponents["code-walkthrough"] = initCodeWalkthrough;
+})();

--- a/assets/javascripts/components/command-builder.js
+++ b/assets/javascripts/components/command-builder.js
@@ -1,0 +1,223 @@
+/**
+ * Command Builder Component
+ *
+ * Interactive command assembly from selectable options with
+ * real-time preview, copy button, per-flag explanations, and reset.
+ *
+ * Config schema:
+ * {
+ *   base: string,
+ *   description?: string,
+ *   options: [{
+ *     flag: string,
+ *     type: "text" | "select",
+ *     label: string,
+ *     placeholder?: string,
+ *     explanation?: string,
+ *     choices?: [[value, label], ...]   // for select type
+ *   }]
+ * }
+ */
+
+(function () {
+  "use strict";
+
+  function initCommandBuilder(container, config) {
+    const base = config.base || "command";
+    const options = config.options || [];
+
+    // Header
+    const header = document.createElement("div");
+    header.className = "interactive-header";
+    header.innerHTML = '<span class="icon">&#9881;</span> Command Builder';
+
+    // Body
+    const body = document.createElement("div");
+    body.className = "interactive-body";
+
+    // Description
+    if (config.description) {
+      const desc = document.createElement("div");
+      desc.className = "builder-description";
+      desc.textContent = config.description;
+      body.appendChild(desc);
+    }
+
+    // Result display (at top, updates live)
+    const result = document.createElement("div");
+    result.className = "builder-result";
+
+    const copyBtn = document.createElement("button");
+    copyBtn.className = "builder-copy";
+    copyBtn.type = "button";
+    copyBtn.textContent = "Copy";
+    copyBtn.addEventListener("click", () => {
+      const text = buildCommandString();
+      navigator.clipboard.writeText(text).then(
+        () => {
+          copyBtn.textContent = "Copied!";
+          setTimeout(() => (copyBtn.textContent = "Copy"), 1500);
+        },
+        () => {
+          // Fallback for older browsers
+          const textarea = document.createElement("textarea");
+          textarea.value = text;
+          textarea.style.position = "fixed";
+          textarea.style.opacity = "0";
+          document.body.appendChild(textarea);
+          textarea.select();
+          document.execCommand("copy");
+          document.body.removeChild(textarea);
+          copyBtn.textContent = "Copied!";
+          setTimeout(() => (copyBtn.textContent = "Copy"), 1500);
+        }
+      );
+    });
+    result.appendChild(copyBtn);
+
+    const resultCode = document.createElement("code");
+    result.appendChild(resultCode);
+    body.appendChild(result);
+
+    // Options
+    const optionsContainer = document.createElement("div");
+    optionsContainer.className = "builder-options";
+
+    const inputs = [];
+
+    options.forEach((opt) => {
+      const row = document.createElement("div");
+      row.className = "builder-option";
+
+      const label = document.createElement("label");
+      label.textContent = opt.label || opt.flag;
+      row.appendChild(label);
+
+      let input;
+      if (opt.type === "select") {
+        input = document.createElement("select");
+        // Add empty option
+        const emptyOpt = document.createElement("option");
+        emptyOpt.value = "";
+        emptyOpt.textContent = "-- Select --";
+        input.appendChild(emptyOpt);
+
+        (opt.choices || []).forEach((choice) => {
+          const optEl = document.createElement("option");
+          // choices can be [value, label] arrays or plain strings
+          if (Array.isArray(choice)) {
+            optEl.value = choice[0];
+            optEl.textContent = choice[1] || choice[0];
+          } else {
+            optEl.value = choice;
+            optEl.textContent = choice;
+          }
+          input.appendChild(optEl);
+        });
+      } else {
+        input = document.createElement("input");
+        input.type = "text";
+        input.placeholder = opt.placeholder || "";
+      }
+
+      input.addEventListener("input", updateCommand);
+      input.addEventListener("change", updateCommand);
+      row.appendChild(input);
+
+      // Explanation
+      if (opt.explanation) {
+        const explanation = document.createElement("div");
+        explanation.className = "option-explanation";
+        explanation.textContent = opt.explanation;
+        row.appendChild(explanation);
+      }
+
+      optionsContainer.appendChild(row);
+      inputs.push({ input, opt });
+    });
+
+    body.appendChild(optionsContainer);
+
+    // Explanations of active flags
+    const explanations = document.createElement("dl");
+    explanations.className = "builder-explanations";
+    body.appendChild(explanations);
+
+    // Actions
+    const actions = document.createElement("div");
+    actions.className = "builder-actions";
+
+    const resetBtn = document.createElement("button");
+    resetBtn.className = "builder-btn";
+    resetBtn.type = "button";
+    resetBtn.textContent = "Reset";
+    resetBtn.addEventListener("click", () => {
+      inputs.forEach(({ input }) => {
+        if (input.tagName === "SELECT") {
+          input.selectedIndex = 0;
+        } else {
+          input.value = "";
+        }
+      });
+      updateCommand();
+    });
+    actions.appendChild(resetBtn);
+    body.appendChild(actions);
+
+    function buildCommandString() {
+      let parts = [base];
+      inputs.forEach(({ input, opt }) => {
+        const val = input.value.trim();
+        if (val) {
+          parts.push(opt.flag);
+          parts.push(val);
+        }
+      });
+      return parts.join(" ");
+    }
+
+    function updateCommand() {
+      // Update result display with syntax highlighting
+      let html = '<span class="base-cmd">' + escapeHtml(base) + "</span>";
+      const activeExplanations = [];
+
+      inputs.forEach(({ input, opt }) => {
+        const val = input.value.trim();
+        if (val) {
+          html += ' <span class="flag">' + escapeHtml(opt.flag) + "</span>";
+          html += " " + escapeHtml(val);
+          if (opt.explanation) {
+            activeExplanations.push({ flag: opt.flag, text: opt.explanation });
+          }
+        }
+      });
+
+      resultCode.innerHTML = html;
+
+      // Update explanations
+      explanations.innerHTML = "";
+      activeExplanations.forEach(({ flag, text }) => {
+        const dt = document.createElement("dt");
+        dt.textContent = flag;
+        const dd = document.createElement("dd");
+        dd.textContent = text;
+        explanations.appendChild(dt);
+        explanations.appendChild(dd);
+      });
+    }
+
+    // Assemble
+    container.innerHTML = "";
+    container.appendChild(header);
+    container.appendChild(body);
+
+    // Initial render
+    updateCommand();
+  }
+
+  function escapeHtml(str) {
+    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  window.RunbookComponents["command-builder"] = initCommandBuilder;
+})();

--- a/assets/javascripts/components/exercise.js
+++ b/assets/javascripts/components/exercise.js
@@ -1,0 +1,219 @@
+/**
+ * Exercise Component
+ *
+ * Scenario-based exercises with difficulty badges, progressive hints,
+ * collapsible solutions, and completion tracking.
+ *
+ * Config schema:
+ * {
+ *   title: string,
+ *   difficulty: "beginner" | "intermediate" | "advanced",
+ *   scenario: string,
+ *   hints: [string],
+ *   solution: string
+ * }
+ */
+
+(function () {
+  "use strict";
+
+  function generateId(config) {
+    let hash = 0;
+    const str = (config.title || "") + (config.scenario || "");
+    for (let i = 0; i < str.length; i++) {
+      hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+    }
+    return "e" + Math.abs(hash).toString(36);
+  }
+
+  function renderMarkdownBasic(text) {
+    // Minimal Markdown: inline code, bold, line breaks, code blocks
+    if (!text) return "";
+    let html = text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+
+    // Fenced code blocks: ```lang\n...\n```
+    html = html.replace(/```(\w*)\n([\s\S]*?)```/g, function (_, lang, code) {
+      return '<pre><code class="language-' + (lang || "text") + '">' + code.trim() + "</code></pre>";
+    });
+
+    // Inline code
+    html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+    // Bold
+    html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+    // Line breaks (double newline = paragraph)
+    html = html.replace(/\n\n/g, "</p><p>");
+    html = "<p>" + html + "</p>";
+    // Single newlines within paragraphs
+    html = html.replace(/\n/g, "<br>");
+
+    return html;
+  }
+
+  function initExercise(container, config) {
+    const exerciseId = generateId(config);
+    const hints = config.hints || [];
+    let hintsRevealed = 0;
+    let completed = false;
+
+    const storage = window.RunbookStorage;
+    if (storage && storage.isExerciseComplete(exerciseId)) {
+      completed = true;
+    }
+
+    // Header
+    const header = document.createElement("div");
+    header.className = "interactive-header";
+    header.innerHTML = '<span class="icon">&#9998;</span> Exercise';
+
+    // Body
+    const body = document.createElement("div");
+    body.className = "interactive-body";
+
+    // Meta: title + difficulty
+    const meta = document.createElement("div");
+    meta.className = "exercise-meta";
+
+    if (config.title) {
+      const title = document.createElement("strong");
+      title.textContent = config.title;
+      meta.appendChild(title);
+    }
+
+    if (config.difficulty) {
+      const badge = document.createElement("span");
+      badge.className = "exercise-difficulty " + config.difficulty;
+      badge.textContent = config.difficulty;
+      meta.appendChild(badge);
+    }
+
+    body.appendChild(meta);
+
+    // Scenario
+    if (config.scenario) {
+      const scenario = document.createElement("div");
+      scenario.className = "exercise-scenario";
+      scenario.innerHTML = renderMarkdownBasic(config.scenario);
+      body.appendChild(scenario);
+    }
+
+    // Hints container
+    const hintsContainer = document.createElement("div");
+    hintsContainer.className = "exercise-hints";
+
+    const hintElements = hints.map((hintText) => {
+      const hint = document.createElement("div");
+      hint.className = "exercise-hint";
+      hint.innerHTML = renderMarkdownBasic(hintText);
+      hintsContainer.appendChild(hint);
+      return hint;
+    });
+
+    body.appendChild(hintsContainer);
+
+    // Actions
+    const actions = document.createElement("div");
+    actions.className = "exercise-actions";
+
+    // Show Hint button
+    let hintBtn = null;
+    if (hints.length > 0) {
+      hintBtn = document.createElement("button");
+      hintBtn.className = "exercise-btn";
+      hintBtn.type = "button";
+      hintBtn.textContent = `Show Hint (1/${hints.length})`;
+      hintBtn.addEventListener("click", () => {
+        if (hintsRevealed < hints.length) {
+          hintElements[hintsRevealed].classList.add("visible");
+          hintsRevealed++;
+          if (hintsRevealed >= hints.length) {
+            hintBtn.style.display = "none";
+          } else {
+            hintBtn.textContent = `Show Hint (${hintsRevealed + 1}/${hints.length})`;
+          }
+        }
+      });
+      actions.appendChild(hintBtn);
+    }
+
+    // Show Solution button
+    const solutionContainer = document.createElement("div");
+    solutionContainer.className = "exercise-solution";
+
+    if (config.solution) {
+      const solutionBtn = document.createElement("button");
+      solutionBtn.className = "exercise-btn";
+      solutionBtn.type = "button";
+      solutionBtn.textContent = "Show Solution";
+
+      const solutionContent = document.createElement("div");
+      solutionContent.className = "exercise-solution-content";
+      solutionContent.innerHTML = renderMarkdownBasic(config.solution);
+      solutionContainer.appendChild(solutionContent);
+
+      solutionBtn.addEventListener("click", () => {
+        const isVisible = solutionContainer.classList.contains("visible");
+        if (isVisible) {
+          solutionContainer.classList.remove("visible");
+          solutionBtn.textContent = "Show Solution";
+        } else {
+          solutionContainer.classList.add("visible");
+          solutionBtn.textContent = "Hide Solution";
+        }
+      });
+
+      actions.appendChild(solutionBtn);
+    }
+
+    // Mark Complete button
+    const completeBtn = document.createElement("button");
+    completeBtn.className = "exercise-btn";
+    completeBtn.type = "button";
+    completeBtn.textContent = completed ? "Completed" : "Mark Complete";
+    if (completed) completeBtn.disabled = true;
+
+    completeBtn.addEventListener("click", () => {
+      completed = true;
+      completeBtn.textContent = "Completed";
+      completeBtn.disabled = true;
+
+      if (storage) {
+        storage.markExerciseComplete(exerciseId);
+      }
+
+      // Show completion indicator
+      const completeIndicator = document.createElement("div");
+      completeIndicator.className = "exercise-complete";
+      completeIndicator.textContent = "Exercise completed";
+      body.appendChild(completeIndicator);
+
+      container.dispatchEvent(
+        new CustomEvent("exercise-completed", {
+          bubbles: true,
+          detail: { exerciseId },
+        })
+      );
+    });
+
+    actions.appendChild(completeBtn);
+    body.appendChild(actions);
+    body.appendChild(solutionContainer);
+
+    // Assemble
+    container.innerHTML = "";
+    container.appendChild(header);
+    container.appendChild(body);
+
+    // Show completion state if previously completed
+    if (completed) {
+      const completeIndicator = document.createElement("div");
+      completeIndicator.className = "exercise-complete";
+      completeIndicator.textContent = "Exercise completed";
+      body.appendChild(completeIndicator);
+    }
+  }
+
+  window.RunbookComponents.exercise = initExercise;
+})();

--- a/assets/javascripts/components/progress.js
+++ b/assets/javascripts/components/progress.js
@@ -1,0 +1,231 @@
+/**
+ * Progress Tracking Component
+ *
+ * - In-guide progress bar showing sections read
+ * - IntersectionObserver for section-read tracking
+ * - Quiz/exercise event integration
+ * - Landing page topic progress bars
+ * - Reset functionality
+ */
+
+(function () {
+  "use strict";
+
+  // Known topic paths and their guide counts for landing page progress
+  const TOPICS = {
+    "Linux Essentials": {
+      prefix: "Linux Essentials/",
+      guides: [
+        "shell-basics",
+        "streams-and-redirection",
+        "text-processing",
+        "finding-files",
+        "file-permissions",
+        "job-control",
+        "scripting-fundamentals",
+        "disk-and-filesystem",
+        "networking",
+        "system-information",
+        "archiving-and-compression",
+        "best-practices",
+      ],
+    },
+    "DNS Administration": {
+      prefix: "DNS Administration/",
+      guides: [
+        "dns-fundamentals",
+        "zone-files-and-records",
+        "dns-tools",
+        "bind",
+        "nsd-and-unbound",
+        "powerdns",
+        "dnssec",
+        "dns-architecture",
+      ],
+    },
+  };
+
+  function init() {
+    const storage = window.RunbookStorage;
+    if (!storage) return;
+
+    setupSectionTracking(storage);
+    setupProgressBar(storage);
+    setupEventListeners(storage);
+    setupLandingPageProgress(storage);
+  }
+
+  function setupSectionTracking(storage) {
+    // Find all h2 headings (major sections) in the content area
+    const content = document.querySelector(".md-content");
+    if (!content) return;
+
+    const headings = content.querySelectorAll("h2[id]");
+    if (headings.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const sectionId = entry.target.id;
+            storage.markSectionRead(sectionId);
+            updateProgressBar(storage, headings.length);
+          }
+        });
+      },
+      {
+        rootMargin: "0px 0px -30% 0px",
+        threshold: 0.1,
+      }
+    );
+
+    headings.forEach((heading) => observer.observe(heading));
+  }
+
+  function setupProgressBar(storage) {
+    const content = document.querySelector(".md-content__inner");
+    if (!content) return;
+
+    // Don't add progress bars to the landing page
+    const isLanding = document.querySelector(".tx-container");
+    if (isLanding) return;
+
+    const headings = document.querySelectorAll(".md-content h2[id]");
+    if (headings.length === 0) return;
+
+    const progressContainer = document.createElement("div");
+    progressContainer.className = "runbook-progress-bar";
+    progressContainer.id = "runbook-page-progress";
+
+    const fill = document.createElement("div");
+    fill.className = "progress-fill";
+
+    const label = document.createElement("span");
+    label.className = "progress-label";
+
+    progressContainer.appendChild(fill);
+    progressContainer.appendChild(label);
+
+    // Insert before first heading or first child
+    const firstH1 = content.querySelector("h1");
+    if (firstH1 && firstH1.nextSibling) {
+      content.insertBefore(progressContainer, firstH1.nextSibling);
+    } else {
+      content.prepend(progressContainer);
+    }
+
+    updateProgressBar(storage, headings.length);
+  }
+
+  function updateProgressBar(storage, totalSections) {
+    const bar = document.getElementById("runbook-page-progress");
+    if (!bar) return;
+
+    const sectionsRead = storage.getSectionsRead().length;
+    const pct = totalSections > 0 ? Math.min(100, Math.round((sectionsRead / totalSections) * 100)) : 0;
+
+    const fill = bar.querySelector(".progress-fill");
+    const label = bar.querySelector(".progress-label");
+
+    if (fill) fill.style.width = pct + "%";
+    if (label) label.textContent = `${sectionsRead}/${totalSections} sections`;
+  }
+
+  function setupEventListeners(storage) {
+    // Listen for quiz and exercise completion events
+    document.addEventListener("quiz-answered", (e) => {
+      if (e.detail && e.detail.correct) {
+        const headings = document.querySelectorAll(".md-content h2[id]");
+        updateProgressBar(storage, headings.length);
+      }
+    });
+
+    document.addEventListener("exercise-completed", () => {
+      const headings = document.querySelectorAll(".md-content h2[id]");
+      updateProgressBar(storage, headings.length);
+    });
+  }
+
+  function setupLandingPageProgress(storage) {
+    // Only run on landing page
+    const topicCards = document.querySelectorAll(".tx-topics a");
+    if (topicCards.length === 0) return;
+
+    const allProgress = storage.getAllProgress();
+
+    topicCards.forEach((card) => {
+      const href = card.getAttribute("href") || "";
+
+      // Find which topic this card belongs to
+      let topicKey = null;
+      for (const [name, info] of Object.entries(TOPICS)) {
+        if (href.includes(info.prefix) || href.includes(name.replace(/ /g, "%20"))) {
+          topicKey = name;
+          break;
+        }
+      }
+
+      if (!topicKey) return;
+      const topicInfo = TOPICS[topicKey];
+
+      // Count guides with any progress
+      let guidesWithProgress = 0;
+      for (const guide of topicInfo.guides) {
+        // Check all progress keys for this guide
+        for (const key of Object.keys(allProgress)) {
+          if (key.includes(guide)) {
+            const pageData = allProgress[key];
+            const hasActivity =
+              (pageData.sections_read && pageData.sections_read.length > 0) ||
+              (pageData.quizzes && Object.keys(pageData.quizzes).length > 0) ||
+              (pageData.exercises && Object.keys(pageData.exercises).length > 0);
+            if (hasActivity) {
+              guidesWithProgress++;
+              break;
+            }
+          }
+        }
+      }
+
+      if (guidesWithProgress === 0) return;
+
+      // Add progress bar to card
+      const progressDiv = document.createElement("span");
+      progressDiv.className = "topic-progress";
+
+      const pct = Math.round((guidesWithProgress / topicInfo.guides.length) * 100);
+
+      progressDiv.innerHTML =
+        '<span class="topic-progress-bar"><span class="topic-progress-fill" style="width:' +
+        pct +
+        '%"></span></span>' +
+        '<span class="topic-progress-text">' +
+        guidesWithProgress +
+        "/" +
+        topicInfo.guides.length +
+        " guides started</span>";
+
+      card.appendChild(progressDiv);
+    });
+  }
+
+  // Register as a component that auto-initializes
+  window.RunbookComponents.progress = function () {
+    // no-op: progress initializes itself
+  };
+
+  // Initialize when DOM is ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    // Small delay to ensure storage.js is loaded
+    setTimeout(init, 100);
+  }
+
+  // Re-initialize on instant navigation
+  const content = document.querySelector('[data-md-component="content"]');
+  if (content) {
+    const observer = new MutationObserver(() => setTimeout(init, 150));
+    observer.observe(content, { childList: true, subtree: false });
+  }
+})();

--- a/assets/javascripts/components/quiz.js
+++ b/assets/javascripts/components/quiz.js
@@ -1,0 +1,183 @@
+/**
+ * Quiz Component
+ *
+ * Renders multiple-choice quizzes with per-option feedback,
+ * correct/incorrect highlighting, retry, and score persistence.
+ *
+ * Config schema:
+ * {
+ *   question: string,
+ *   type: "multiple-choice",
+ *   options: [{ text: string, correct?: boolean, feedback?: string }]
+ * }
+ */
+
+(function () {
+  "use strict";
+
+  function generateId(config) {
+    // Deterministic ID from question text
+    let hash = 0;
+    const str = config.question || "";
+    for (let i = 0; i < str.length; i++) {
+      hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+    }
+    return "q" + Math.abs(hash).toString(36);
+  }
+
+  function initQuiz(container, config) {
+    const quizId = generateId(config);
+    const options = config.options || [];
+    const correctIndex = options.findIndex((o) => o.correct);
+    let attempts = 0;
+    let answered = false;
+
+    // Restore previous state
+    const storage = window.RunbookStorage;
+    const saved = storage ? storage.getQuizScore(quizId) : null;
+    if (saved) {
+      attempts = saved.attempts;
+    }
+
+    // Build DOM
+    const header = document.createElement("div");
+    header.className = "interactive-header";
+    header.innerHTML = '<span class="icon">?</span> Quiz';
+
+    const body = document.createElement("div");
+    body.className = "interactive-body";
+
+    const questionEl = document.createElement("div");
+    questionEl.className = "quiz-question";
+    questionEl.textContent = config.question || "Question";
+    body.appendChild(questionEl);
+
+    const optionsEl = document.createElement("div");
+    optionsEl.className = "quiz-options";
+
+    const feedbackEl = document.createElement("div");
+    feedbackEl.className = "quiz-feedback";
+
+    const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    const optionButtons = options.map((opt, i) => {
+      const btn = document.createElement("button");
+      btn.className = "quiz-option";
+      btn.type = "button";
+
+      const marker = document.createElement("span");
+      marker.className = "option-marker";
+      marker.textContent = letters[i] || i + 1;
+
+      const text = document.createElement("span");
+      text.className = "option-text";
+      text.textContent = opt.text;
+
+      btn.appendChild(marker);
+      btn.appendChild(text);
+
+      btn.addEventListener("click", () => {
+        if (answered) return;
+
+        attempts++;
+        const isCorrect = i === correctIndex;
+
+        // Disable all options
+        optionButtons.forEach((b) => b.classList.add("disabled"));
+
+        // Highlight selected
+        btn.classList.add(isCorrect ? "correct" : "incorrect");
+
+        // If correct, also highlight the correct one (already done)
+        // If wrong, show the correct answer too
+        if (!isCorrect && correctIndex >= 0) {
+          optionButtons[correctIndex].classList.add("correct");
+        }
+
+        // Show feedback
+        const feedback = opt.feedback || (isCorrect ? "Correct!" : "Not quite.");
+        feedbackEl.textContent = feedback;
+        feedbackEl.className = "quiz-feedback visible " + (isCorrect ? "correct" : "incorrect");
+
+        // Show score
+        scoreEl.textContent = isCorrect
+          ? `Correct on attempt ${attempts}`
+          : `Incorrect - attempt ${attempts}`;
+        scoreEl.style.display = "block";
+
+        // Show retry if wrong
+        if (!isCorrect) {
+          retryBtn.style.display = "inline-block";
+        } else {
+          answered = true;
+          retryBtn.style.display = "none";
+        }
+
+        // Save to storage
+        if (storage) {
+          storage.saveQuizScore(quizId, isCorrect ? 1 : 0, attempts);
+        }
+
+        // Dispatch event for progress tracking
+        container.dispatchEvent(
+          new CustomEvent("quiz-answered", {
+            bubbles: true,
+            detail: { quizId, correct: isCorrect, attempts },
+          })
+        );
+      });
+
+      optionsEl.appendChild(btn);
+      return btn;
+    });
+
+    body.appendChild(optionsEl);
+    body.appendChild(feedbackEl);
+
+    // Actions row
+    const actionsEl = document.createElement("div");
+    actionsEl.className = "quiz-actions";
+
+    const retryBtn = document.createElement("button");
+    retryBtn.className = "quiz-retry";
+    retryBtn.type = "button";
+    retryBtn.textContent = "Try Again";
+    retryBtn.style.display = "none";
+    retryBtn.addEventListener("click", () => {
+      // Reset visual state but keep attempt count
+      optionButtons.forEach((b) => {
+        b.classList.remove("correct", "incorrect", "disabled");
+      });
+      feedbackEl.className = "quiz-feedback";
+      retryBtn.style.display = "none";
+      scoreEl.style.display = "none";
+    });
+
+    const scoreEl = document.createElement("div");
+    scoreEl.className = "quiz-score";
+    scoreEl.style.display = "none";
+
+    actionsEl.appendChild(retryBtn);
+    actionsEl.appendChild(scoreEl);
+    body.appendChild(actionsEl);
+
+    // Assemble
+    container.innerHTML = "";
+    container.appendChild(header);
+    container.appendChild(body);
+
+    // If previously answered correctly, show that state
+    if (saved && saved.score === 1 && correctIndex >= 0) {
+      answered = true;
+      optionButtons.forEach((b) => b.classList.add("disabled"));
+      optionButtons[correctIndex].classList.add("correct");
+      const correctOpt = options[correctIndex];
+      feedbackEl.textContent = correctOpt.feedback || "Correct!";
+      feedbackEl.className = "quiz-feedback visible correct";
+      scoreEl.textContent = `Previously answered correctly (${saved.attempts} attempt${saved.attempts !== 1 ? "s" : ""})`;
+      scoreEl.style.display = "block";
+    }
+  }
+
+  window.RunbookComponents.quiz = initQuiz;
+})();

--- a/assets/javascripts/components/terminal.js
+++ b/assets/javascripts/components/terminal.js
@@ -1,0 +1,230 @@
+/**
+ * Simulated Terminal Component
+ *
+ * Renders a terminal with typing animation, step-by-step command execution,
+ * narration callouts, and replay. Always dark-themed.
+ *
+ * Config schema:
+ * {
+ *   title: string,
+ *   prompt?: string,  // default: "user@linux:~$ "
+ *   steps: [{
+ *     command: string,
+ *     output?: string,
+ *     narration?: string
+ *   }]
+ * }
+ */
+
+(function () {
+  "use strict";
+
+  const DEFAULT_PROMPT = "user@linux:~$ ";
+  const TYPING_SPEED = 40; // ms per character
+
+  function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function initTerminal(container, config) {
+    const steps = config.steps || [];
+    const prompt = config.prompt || DEFAULT_PROMPT;
+    let currentStep = -1;
+    let isAnimating = false;
+
+    // Header
+    const header = document.createElement("div");
+    header.className = "interactive-header";
+    // Terminal dots
+    header.innerHTML =
+      '<span style="display:flex;gap:6px;margin-right:8px">' +
+      '<span style="width:10px;height:10px;border-radius:50%;background:#ff5f56"></span>' +
+      '<span style="width:10px;height:10px;border-radius:50%;background:#ffbd2e"></span>' +
+      '<span style="width:10px;height:10px;border-radius:50%;background:#27c93f"></span>' +
+      "</span>" +
+      (config.title || "Terminal");
+
+    // Terminal window
+    const terminalWindow = document.createElement("div");
+    terminalWindow.className = "terminal-window";
+
+    // Narration area
+    const narration = document.createElement("div");
+    narration.className = "terminal-narration";
+    narration.style.display = "none";
+
+    // Controls
+    const controls = document.createElement("div");
+    controls.className = "terminal-controls";
+
+    const prevBtn = document.createElement("button");
+    prevBtn.className = "terminal-btn";
+    prevBtn.type = "button";
+    prevBtn.textContent = "Previous";
+
+    const nextBtn = document.createElement("button");
+    nextBtn.className = "terminal-btn";
+    nextBtn.type = "button";
+    nextBtn.textContent = "Next";
+
+    const replayBtn = document.createElement("button");
+    replayBtn.className = "terminal-btn";
+    replayBtn.type = "button";
+    replayBtn.textContent = "Replay";
+
+    const stepIndicator = document.createElement("span");
+    stepIndicator.className = "terminal-step-indicator";
+
+    controls.appendChild(prevBtn);
+    controls.appendChild(nextBtn);
+    controls.appendChild(replayBtn);
+    controls.appendChild(stepIndicator);
+
+    function updateControls() {
+      prevBtn.disabled = currentStep <= 0 || isAnimating;
+      nextBtn.disabled = currentStep >= steps.length - 1 || isAnimating;
+      replayBtn.disabled = isAnimating;
+      stepIndicator.textContent =
+        steps.length > 0 ? `Step ${currentStep + 1} of ${steps.length}` : "";
+    }
+
+    function renderPreviousSteps() {
+      // Render all steps up to (but not including) current step as static text
+      terminalWindow.innerHTML = "";
+      for (let i = 0; i < currentStep; i++) {
+        const step = steps[i];
+        appendStaticStep(step);
+      }
+    }
+
+    function appendStaticStep(step) {
+      // Prompt + command
+      const cmdLine = document.createElement("div");
+      cmdLine.className = "terminal-line";
+      cmdLine.innerHTML =
+        '<span class="terminal-prompt">' +
+        escapeHtml(prompt) +
+        '</span><span class="terminal-command">' +
+        escapeHtml(step.command) +
+        "</span>";
+      terminalWindow.appendChild(cmdLine);
+
+      // Output
+      if (step.output) {
+        const outputLines = step.output.split("\n");
+        outputLines.forEach((line) => {
+          const outputEl = document.createElement("div");
+          outputEl.className = "terminal-line terminal-output";
+          outputEl.textContent = line;
+          terminalWindow.appendChild(outputEl);
+        });
+      }
+    }
+
+    async function animateStep(stepIndex) {
+      if (isAnimating) return;
+      isAnimating = true;
+      currentStep = stepIndex;
+      updateControls();
+
+      renderPreviousSteps();
+
+      const step = steps[stepIndex];
+
+      // Create the command line with cursor
+      const cmdLine = document.createElement("div");
+      cmdLine.className = "terminal-line";
+      const promptSpan = document.createElement("span");
+      promptSpan.className = "terminal-prompt";
+      promptSpan.textContent = prompt;
+      const cmdSpan = document.createElement("span");
+      cmdSpan.className = "terminal-command";
+      const cursor = document.createElement("span");
+      cursor.className = "terminal-cursor";
+
+      cmdLine.appendChild(promptSpan);
+      cmdLine.appendChild(cmdSpan);
+      cmdLine.appendChild(cursor);
+      terminalWindow.appendChild(cmdLine);
+      terminalWindow.scrollTop = terminalWindow.scrollHeight;
+
+      // Type the command character by character
+      for (let i = 0; i < step.command.length; i++) {
+        cmdSpan.textContent = step.command.substring(0, i + 1);
+        terminalWindow.scrollTop = terminalWindow.scrollHeight;
+        await sleep(TYPING_SPEED);
+      }
+
+      // Remove cursor, "execute" command
+      cursor.remove();
+      await sleep(300);
+
+      // Show output
+      if (step.output) {
+        const outputLines = step.output.split("\n");
+        for (const line of outputLines) {
+          const outputEl = document.createElement("div");
+          outputEl.className = "terminal-line terminal-output";
+          outputEl.textContent = line;
+          terminalWindow.appendChild(outputEl);
+          terminalWindow.scrollTop = terminalWindow.scrollHeight;
+          await sleep(30);
+        }
+      }
+
+      // Show narration
+      if (step.narration) {
+        narration.textContent = step.narration;
+        narration.style.display = "block";
+      } else {
+        narration.style.display = "none";
+      }
+
+      isAnimating = false;
+      updateControls();
+    }
+
+    nextBtn.addEventListener("click", () => {
+      if (currentStep < steps.length - 1 && !isAnimating) {
+        animateStep(currentStep + 1);
+      }
+    });
+
+    prevBtn.addEventListener("click", () => {
+      if (currentStep > 0 && !isAnimating) {
+        animateStep(currentStep - 1);
+      }
+    });
+
+    replayBtn.addEventListener("click", () => {
+      if (!isAnimating) {
+        currentStep = -1;
+        terminalWindow.innerHTML = "";
+        narration.style.display = "none";
+        if (steps.length > 0) {
+          animateStep(0);
+        }
+      }
+    });
+
+    // Assemble
+    container.innerHTML = "";
+    container.appendChild(header);
+    container.appendChild(terminalWindow);
+    container.appendChild(narration);
+    container.appendChild(controls);
+
+    // Auto-start first step
+    if (steps.length > 0) {
+      animateStep(0);
+    }
+
+    updateControls();
+  }
+
+  function escapeHtml(str) {
+    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  window.RunbookComponents.terminal = initTerminal;
+})();

--- a/assets/javascripts/interactive.js
+++ b/assets/javascripts/interactive.js
@@ -1,0 +1,105 @@
+/**
+ * Interactive Textbook - Entry Point
+ *
+ * Discovers interactive component divs in the page and initializes them.
+ * Components are loaded as separate script files and register themselves
+ * on window.RunbookComponents.
+ *
+ * Works with MkDocs Material's instant navigation by re-initializing
+ * on each page load event.
+ */
+
+(function () {
+  "use strict";
+
+  // Registry for component initializers
+  window.RunbookComponents = window.RunbookComponents || {};
+
+  // Component type -> JS file mapping
+  const COMPONENT_SCRIPTS = {
+    quiz: "assets/javascripts/components/quiz.js",
+    terminal: "assets/javascripts/components/terminal.js",
+    "command-builder": "assets/javascripts/components/command-builder.js",
+    exercise: "assets/javascripts/components/exercise.js",
+    "code-walkthrough": "assets/javascripts/components/code-walkthrough.js",
+    progress: "assets/javascripts/components/progress.js",
+  };
+
+  const loadedScripts = new Set();
+
+  function loadScript(src) {
+    if (loadedScripts.has(src)) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      // Resolve relative to site root
+      script.src = new URL(src, window.location.origin + "/guides/").href;
+      script.onload = () => {
+        loadedScripts.add(src);
+        resolve();
+      };
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+  }
+
+  function initComponents() {
+    // Find all interactive divs on the page
+    const types = Object.keys(COMPONENT_SCRIPTS);
+    types.forEach((type) => {
+      const divs = document.querySelectorAll(`.interactive-${type}`);
+      if (divs.length === 0) return;
+
+      const scriptSrc = COMPONENT_SCRIPTS[type];
+      loadScript(scriptSrc)
+        .then(() => {
+          const init = window.RunbookComponents[type];
+          if (typeof init === "function") {
+            divs.forEach((div) => {
+              // Skip already-initialized divs
+              if (div.dataset.initialized) return;
+              try {
+                const config = JSON.parse(div.dataset.config || "{}");
+                init(div, config);
+                div.dataset.initialized = "true";
+              } catch (e) {
+                console.error(`[Runbook] Error initializing ${type}:`, e);
+              }
+            });
+          }
+        })
+        .catch((err) => console.error(`[Runbook]`, err));
+    });
+
+    // Always load progress tracker if storage is available
+    loadScript(COMPONENT_SCRIPTS.progress).catch(() => {});
+
+    // Load storage library
+    loadScript("assets/javascripts/lib/storage.js").catch(() => {});
+  }
+
+  // Initialize on DOMContentLoaded (first page load)
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initComponents);
+  } else {
+    initComponents();
+  }
+
+  // Re-initialize on MkDocs Material instant navigation
+  // Material dispatches a custom "DOMContentSwitch" or uses location$.subscribe
+  // We use the MutationObserver approach for reliability
+  const contentEl = document.querySelector('[data-md-component="content"]');
+  if (contentEl) {
+    const observer = new MutationObserver(() => {
+      // Small delay to let Material finish rendering
+      setTimeout(initComponents, 50);
+    });
+    observer.observe(contentEl, { childList: true, subtree: false });
+  }
+
+  // Also hook into Material's navigation events if available
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(() => setTimeout(initComponents, 50));
+  }
+})();

--- a/assets/javascripts/lib/storage.js
+++ b/assets/javascripts/lib/storage.js
@@ -1,0 +1,119 @@
+/**
+ * localStorage wrapper for progress tracking.
+ *
+ * Schema:
+ * {
+ *   "runbook_progress": {
+ *     "<page-path>": {
+ *       "sections_read": ["section-id", ...],
+ *       "quizzes": { "<id>": { "score": N, "attempts": N } },
+ *       "exercises": { "<id>": { "completed": bool } }
+ *     }
+ *   }
+ * }
+ */
+
+const STORAGE_KEY = "runbook_progress";
+
+const RunbookStorage = {
+  _read() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch {
+      return {};
+    }
+  },
+
+  _write(data) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {
+      // localStorage full or unavailable - silently ignore
+    }
+  },
+
+  _pagePath() {
+    // Derive a stable key from the current URL path
+    return window.location.pathname.replace(/\/$/, "").replace(/^\/guides\//, "");
+  },
+
+  _getPage(path) {
+    const data = this._read();
+    const key = path || this._pagePath();
+    if (!data[key]) {
+      data[key] = { sections_read: [], quizzes: {}, exercises: {} };
+      this._write(data);
+    }
+    return { data, key, page: data[key] };
+  },
+
+  // --- Sections ---
+
+  markSectionRead(sectionId) {
+    const { data, page } = this._getPage();
+    if (!page.sections_read.includes(sectionId)) {
+      page.sections_read.push(sectionId);
+      this._write(data);
+    }
+  },
+
+  getSectionsRead(path) {
+    const { page } = this._getPage(path);
+    return page.sections_read;
+  },
+
+  // --- Quizzes ---
+
+  saveQuizScore(quizId, score, attempts) {
+    const { data, page } = this._getPage();
+    page.quizzes[quizId] = { score, attempts };
+    this._write(data);
+  },
+
+  getQuizScore(quizId) {
+    const { page } = this._getPage();
+    return page.quizzes[quizId] || null;
+  },
+
+  // --- Exercises ---
+
+  markExerciseComplete(exerciseId) {
+    const { data, page } = this._getPage();
+    page.exercises[exerciseId] = { completed: true };
+    this._write(data);
+  },
+
+  isExerciseComplete(exerciseId) {
+    const { page } = this._getPage();
+    return page.exercises[exerciseId]?.completed || false;
+  },
+
+  // --- Aggregate ---
+
+  getPageProgress(path) {
+    const { page } = this._getPage(path);
+    return page;
+  },
+
+  getAllProgress() {
+    return this._read();
+  },
+
+  resetPage(path) {
+    const data = this._read();
+    const key = path || this._pagePath();
+    delete data[key];
+    this._write(data);
+  },
+
+  resetAll() {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  },
+};
+
+window.RunbookStorage = RunbookStorage;

--- a/assets/stylesheets/interactive.css
+++ b/assets/stylesheets/interactive.css
@@ -1,7 +1,35 @@
 /* ============================================================
    Interactive Textbook Components - Theme-Aware Styles
    Uses Material CSS custom properties for light/dark mode.
+
+   Semantic color variables defined below adapt to the active
+   color scheme. Terminal colors are intentionally fixed (always
+   dark) to match real terminal aesthetics.
    ============================================================ */
+
+/* ---- Semantic color tokens ---- */
+
+:root {
+  --rb-color-correct: #2e7d32;
+  --rb-color-correct-bg: color-mix(in srgb, #2e7d32 10%, transparent);
+  --rb-color-correct-bg-strong: color-mix(in srgb, #2e7d32 20%, transparent);
+  --rb-color-incorrect: #c62828;
+  --rb-color-incorrect-bg: color-mix(in srgb, #c62828 10%, transparent);
+  --rb-color-incorrect-bg-strong: color-mix(in srgb, #c62828 20%, transparent);
+  --rb-color-warning: #f57f17;
+  --rb-color-warning-bg: color-mix(in srgb, #f57f17 20%, transparent);
+}
+
+[data-md-color-scheme="slate"] {
+  --rb-color-correct: #66bb6a;
+  --rb-color-correct-bg: color-mix(in srgb, #66bb6a 12%, transparent);
+  --rb-color-correct-bg-strong: color-mix(in srgb, #66bb6a 20%, transparent);
+  --rb-color-incorrect: #ef5350;
+  --rb-color-incorrect-bg: color-mix(in srgb, #ef5350 12%, transparent);
+  --rb-color-incorrect-bg-strong: color-mix(in srgb, #ef5350 20%, transparent);
+  --rb-color-warning: #ffb74d;
+  --rb-color-warning-bg: color-mix(in srgb, #ffb74d 20%, transparent);
+}
 
 /* ---- Shared ---- */
 
@@ -88,24 +116,24 @@
 }
 
 .interactive-quiz .quiz-option.correct {
-  border-color: #2e7d32;
-  background: color-mix(in srgb, #2e7d32 10%, transparent);
+  border-color: var(--rb-color-correct);
+  background: var(--rb-color-correct-bg);
 }
 
 .interactive-quiz .quiz-option.correct .option-marker {
-  background: #2e7d32;
-  border-color: #2e7d32;
+  background: var(--rb-color-correct);
+  border-color: var(--rb-color-correct);
   color: white;
 }
 
 .interactive-quiz .quiz-option.incorrect {
-  border-color: #c62828;
-  background: color-mix(in srgb, #c62828 10%, transparent);
+  border-color: var(--rb-color-incorrect);
+  background: var(--rb-color-incorrect-bg);
 }
 
 .interactive-quiz .quiz-option.incorrect .option-marker {
-  background: #c62828;
-  border-color: #c62828;
+  background: var(--rb-color-incorrect);
+  border-color: var(--rb-color-incorrect);
   color: white;
 }
 
@@ -128,15 +156,15 @@
 }
 
 .interactive-quiz .quiz-feedback.correct {
-  background: color-mix(in srgb, #2e7d32 12%, transparent);
+  background: var(--rb-color-correct-bg);
   color: var(--md-default-fg-color);
-  border-left: 3px solid #2e7d32;
+  border-left: 3px solid var(--rb-color-correct);
 }
 
 .interactive-quiz .quiz-feedback.incorrect {
-  background: color-mix(in srgb, #c62828 12%, transparent);
+  background: var(--rb-color-incorrect-bg);
   color: var(--md-default-fg-color);
-  border-left: 3px solid #c62828;
+  border-left: 3px solid var(--rb-color-incorrect);
 }
 
 .interactive-quiz .quiz-actions {
@@ -196,28 +224,18 @@
 }
 
 .interactive-exercise .exercise-difficulty.beginner {
-  background: color-mix(in srgb, #2e7d32 20%, transparent);
-  color: #2e7d32;
+  background: var(--rb-color-correct-bg-strong);
+  color: var(--rb-color-correct);
 }
 
 .interactive-exercise .exercise-difficulty.intermediate {
-  background: color-mix(in srgb, #f57f17 20%, transparent);
-  color: #f57f17;
+  background: var(--rb-color-warning-bg);
+  color: var(--rb-color-warning);
 }
 
 .interactive-exercise .exercise-difficulty.advanced {
-  background: color-mix(in srgb, #c62828 20%, transparent);
-  color: #c62828;
-}
-
-[data-md-color-scheme="slate"] .exercise-difficulty.beginner {
-  color: #66bb6a;
-}
-[data-md-color-scheme="slate"] .exercise-difficulty.intermediate {
-  color: #ffb74d;
-}
-[data-md-color-scheme="slate"] .exercise-difficulty.advanced {
-  color: #ef5350;
+  background: var(--rb-color-incorrect-bg-strong);
+  color: var(--rb-color-incorrect);
 }
 
 .interactive-exercise .exercise-scenario {
@@ -276,12 +294,8 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.8rem;
-  color: #2e7d32;
+  color: var(--rb-color-correct);
   font-weight: 600;
-}
-
-[data-md-color-scheme="slate"] .exercise-complete {
-  color: #66bb6a;
 }
 
 .interactive-exercise .exercise-actions {
@@ -290,7 +304,9 @@
   flex-wrap: wrap;
 }
 
-/* ---- Simulated Terminal ---- */
+/* ---- Simulated Terminal ----
+   Terminal colors are intentionally fixed (always dark) to match
+   real terminal aesthetics regardless of the site theme. */
 
 .interactive-terminal {
   border-color: #1a1a2e;

--- a/assets/stylesheets/interactive.css
+++ b/assets/stylesheets/interactive.css
@@ -1,0 +1,644 @@
+/* ============================================================
+   Interactive Textbook Components - Theme-Aware Styles
+   Uses Material CSS custom properties for light/dark mode.
+   ============================================================ */
+
+/* ---- Shared ---- */
+
+.interactive-quiz,
+.interactive-exercise,
+.interactive-terminal,
+.interactive-command-builder,
+.interactive-code-walkthrough {
+  margin: 1.5rem 0;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.interactive-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  background: var(--md-code-bg-color);
+}
+
+.interactive-header .icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.interactive-body {
+  padding: 1rem;
+}
+
+/* ---- Quiz ---- */
+
+.interactive-quiz .quiz-question {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--md-default-fg-color);
+}
+
+.interactive-quiz .quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.interactive-quiz .quiz-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.875rem;
+  border: 2px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  background: transparent;
+  color: var(--md-default-fg-color);
+  font-size: 0.9rem;
+  text-align: left;
+  width: 100%;
+  font-family: inherit;
+}
+
+.interactive-quiz .quiz-option:hover:not(.selected):not(.disabled) {
+  border-color: var(--md-accent-fg-color);
+  background: color-mix(in srgb, var(--md-accent-fg-color) 8%, transparent);
+}
+
+.interactive-quiz .quiz-option .option-marker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  border: 2px solid var(--md-default-fg-color--lighter);
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+
+.interactive-quiz .quiz-option.correct {
+  border-color: #2e7d32;
+  background: color-mix(in srgb, #2e7d32 10%, transparent);
+}
+
+.interactive-quiz .quiz-option.correct .option-marker {
+  background: #2e7d32;
+  border-color: #2e7d32;
+  color: white;
+}
+
+.interactive-quiz .quiz-option.incorrect {
+  border-color: #c62828;
+  background: color-mix(in srgb, #c62828 10%, transparent);
+}
+
+.interactive-quiz .quiz-option.incorrect .option-marker {
+  background: #c62828;
+  border-color: #c62828;
+  color: white;
+}
+
+.interactive-quiz .quiz-option.disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.interactive-quiz .quiz-feedback {
+  margin-top: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.375rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  display: none;
+}
+
+.interactive-quiz .quiz-feedback.visible {
+  display: block;
+}
+
+.interactive-quiz .quiz-feedback.correct {
+  background: color-mix(in srgb, #2e7d32 12%, transparent);
+  color: var(--md-default-fg-color);
+  border-left: 3px solid #2e7d32;
+}
+
+.interactive-quiz .quiz-feedback.incorrect {
+  background: color-mix(in srgb, #c62828 12%, transparent);
+  color: var(--md-default-fg-color);
+  border-left: 3px solid #c62828;
+}
+
+.interactive-quiz .quiz-actions {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.interactive-quiz .quiz-retry,
+.interactive-exercise .exercise-btn,
+.interactive-terminal .terminal-btn,
+.interactive-command-builder .builder-btn {
+  padding: 0.375rem 0.875rem;
+  border: 1px solid var(--md-primary-fg-color);
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--md-primary-fg-color);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  font-family: inherit;
+}
+
+.interactive-quiz .quiz-retry:hover,
+.interactive-exercise .exercise-btn:hover,
+.interactive-terminal .terminal-btn:hover,
+.interactive-command-builder .builder-btn:hover {
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+}
+
+.interactive-quiz .quiz-score {
+  font-size: 0.8rem;
+  color: var(--md-default-fg-color--light);
+  padding: 0.375rem 0;
+  line-height: 1.5;
+}
+
+/* ---- Exercise ---- */
+
+.interactive-exercise .exercise-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.interactive-exercise .exercise-difficulty {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 1rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.interactive-exercise .exercise-difficulty.beginner {
+  background: color-mix(in srgb, #2e7d32 20%, transparent);
+  color: #2e7d32;
+}
+
+.interactive-exercise .exercise-difficulty.intermediate {
+  background: color-mix(in srgb, #f57f17 20%, transparent);
+  color: #f57f17;
+}
+
+.interactive-exercise .exercise-difficulty.advanced {
+  background: color-mix(in srgb, #c62828 20%, transparent);
+  color: #c62828;
+}
+
+[data-md-color-scheme="slate"] .exercise-difficulty.beginner {
+  color: #66bb6a;
+}
+[data-md-color-scheme="slate"] .exercise-difficulty.intermediate {
+  color: #ffb74d;
+}
+[data-md-color-scheme="slate"] .exercise-difficulty.advanced {
+  color: #ef5350;
+}
+
+.interactive-exercise .exercise-scenario {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin-bottom: 1rem;
+  color: var(--md-default-fg-color);
+}
+
+.interactive-exercise .exercise-hints {
+  margin-bottom: 1rem;
+}
+
+.interactive-exercise .exercise-hint {
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.375rem;
+  border-left: 3px solid var(--md-accent-fg-color);
+  background: color-mix(in srgb, var(--md-accent-fg-color) 8%, transparent);
+  border-radius: 0 0.25rem 0.25rem 0;
+  font-size: 0.85rem;
+  display: none;
+}
+
+.interactive-exercise .exercise-hint.visible {
+  display: block;
+}
+
+.interactive-exercise .exercise-solution {
+  margin-top: 1rem;
+  display: none;
+}
+
+.interactive-exercise .exercise-solution.visible {
+  display: block;
+}
+
+.interactive-exercise .exercise-solution-content {
+  padding: 0.75rem;
+  background: var(--md-code-bg-color);
+  border-radius: 0.375rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.interactive-exercise .exercise-solution-content pre {
+  margin: 0.5rem 0;
+}
+
+.interactive-exercise .exercise-solution-content code {
+  font-size: 0.85em;
+}
+
+.interactive-exercise .exercise-complete {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: #2e7d32;
+  font-weight: 600;
+}
+
+[data-md-color-scheme="slate"] .exercise-complete {
+  color: #66bb6a;
+}
+
+.interactive-exercise .exercise-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* ---- Simulated Terminal ---- */
+
+.interactive-terminal {
+  border-color: #1a1a2e;
+}
+
+.interactive-terminal .interactive-header {
+  background: #1a1a2e;
+  color: #a0a0b0;
+  border-bottom-color: #2a2a3e;
+}
+
+.interactive-terminal .terminal-window {
+  background: #0d1117;
+  padding: 1rem;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  min-height: 6rem;
+  color: #e6edf3;
+  overflow-x: auto;
+}
+
+.interactive-terminal .terminal-line {
+  margin-bottom: 0.25rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.interactive-terminal .terminal-prompt {
+  color: #7ee787;
+}
+
+.interactive-terminal .terminal-command {
+  color: #e6edf3;
+}
+
+.interactive-terminal .terminal-output {
+  color: #8b949e;
+}
+
+.interactive-terminal .terminal-cursor {
+  display: inline-block;
+  width: 0.55em;
+  height: 1.1em;
+  background: #58a6ff;
+  vertical-align: text-bottom;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}
+
+.interactive-terminal .terminal-narration {
+  padding: 0.625rem 1rem;
+  background: color-mix(in srgb, var(--md-accent-fg-color) 10%, var(--md-code-bg-color));
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  font-size: 0.85rem;
+  color: var(--md-default-fg-color);
+  font-family: var(--md-text-font-family);
+}
+
+.interactive-terminal .terminal-controls {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: var(--md-code-bg-color);
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.interactive-terminal .terminal-step-indicator {
+  font-size: 0.75rem;
+  color: var(--md-default-fg-color--light);
+  padding: 0.375rem 0;
+  margin-left: auto;
+}
+
+/* ---- Command Builder ---- */
+
+.interactive-command-builder .builder-description {
+  font-size: 0.9rem;
+  color: var(--md-default-fg-color--light);
+  margin-bottom: 1rem;
+}
+
+.interactive-command-builder .builder-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.interactive-command-builder .builder-option {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: 0.5rem;
+  align-items: start;
+}
+
+@media (max-width: 600px) {
+  .interactive-command-builder .builder-option {
+    grid-template-columns: 1fr;
+  }
+}
+
+.interactive-command-builder .builder-option label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--md-default-fg-color);
+  padding-top: 0.375rem;
+}
+
+.interactive-command-builder .builder-option input,
+.interactive-command-builder .builder-option select {
+  padding: 0.375rem 0.625rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.25rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font-family: inherit;
+  font-size: 0.85rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.interactive-command-builder .builder-option input:focus,
+.interactive-command-builder .builder-option select:focus {
+  outline: 2px solid var(--md-accent-fg-color);
+  outline-offset: -1px;
+  border-color: transparent;
+}
+
+.interactive-command-builder .builder-option .option-explanation {
+  grid-column: 1 / -1;
+  font-size: 0.8rem;
+  color: var(--md-default-fg-color--light);
+  padding-left: 0.25rem;
+}
+
+.interactive-command-builder .builder-result {
+  position: relative;
+  background: var(--md-code-bg-color);
+  border-radius: 0.375rem;
+  padding: 0.75rem 1rem;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color);
+  word-break: break-all;
+  margin-bottom: 0.75rem;
+}
+
+.interactive-command-builder .builder-result .base-cmd {
+  color: var(--md-primary-fg-color);
+  font-weight: 600;
+}
+
+.interactive-command-builder .builder-result .flag {
+  color: var(--md-accent-fg-color);
+}
+
+.interactive-command-builder .builder-copy {
+  position: absolute;
+  top: 0.375rem;
+  right: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.7rem;
+  background: var(--md-default-fg-color--lightest);
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  color: var(--md-default-fg-color);
+  font-family: inherit;
+}
+
+.interactive-command-builder .builder-copy:hover {
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+}
+
+.interactive-command-builder .builder-explanations {
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.interactive-command-builder .builder-explanations dt {
+  font-weight: 600;
+  color: var(--md-accent-fg-color);
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 0.85em;
+}
+
+.interactive-command-builder .builder-explanations dd {
+  margin-left: 0;
+  margin-bottom: 0.5rem;
+  color: var(--md-default-fg-color--light);
+}
+
+.interactive-command-builder .builder-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ---- Code Walkthrough ---- */
+
+.interactive-code-walkthrough .walkthrough-code {
+  position: relative;
+  background: var(--md-code-bg-color);
+  overflow-x: auto;
+}
+
+.interactive-code-walkthrough .walkthrough-code pre {
+  margin: 0;
+  padding: 0.75rem 0;
+}
+
+.interactive-code-walkthrough .walkthrough-line {
+  display: block;
+  padding: 0 1rem 0 3.5rem;
+  position: relative;
+  line-height: 1.6;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+  font-size: 0.85rem;
+  color: var(--md-default-fg-color);
+  transition: background 0.2s;
+}
+
+.interactive-code-walkthrough .walkthrough-line .line-number {
+  position: absolute;
+  left: 0;
+  width: 2.5rem;
+  text-align: right;
+  padding-right: 0.5rem;
+  color: var(--md-default-fg-color--lighter);
+  user-select: none;
+}
+
+.interactive-code-walkthrough .walkthrough-line.active {
+  background: color-mix(in srgb, var(--md-primary-fg-color) 12%, transparent);
+}
+
+.interactive-code-walkthrough .walkthrough-annotation {
+  padding: 0.625rem 1rem;
+  background: color-mix(in srgb, var(--md-primary-fg-color) 8%, var(--md-code-bg-color));
+  border-top: 2px solid var(--md-primary-fg-color);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color);
+  min-height: 2.5rem;
+}
+
+.interactive-code-walkthrough .walkthrough-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: var(--md-code-bg-color);
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.interactive-code-walkthrough .walkthrough-step-info {
+  font-size: 0.75rem;
+  color: var(--md-default-fg-color--light);
+  margin-left: auto;
+}
+
+.interactive-code-walkthrough .walkthrough-controls button {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--md-primary-fg-color);
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--md-primary-fg-color);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, color 0.15s;
+}
+
+.interactive-code-walkthrough .walkthrough-controls button:hover:not(:disabled) {
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+}
+
+.interactive-code-walkthrough .walkthrough-controls button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.interactive-code-walkthrough .walkthrough-controls .show-all-toggle {
+  border-color: var(--md-default-fg-color--lighter);
+  color: var(--md-default-fg-color--light);
+}
+
+.interactive-code-walkthrough .walkthrough-controls .show-all-toggle.active {
+  border-color: var(--md-accent-fg-color);
+  color: var(--md-accent-fg-color);
+}
+
+/* ---- Progress Bar ---- */
+
+.runbook-progress-bar {
+  position: relative;
+  height: 4px;
+  background: var(--md-default-fg-color--lightest);
+  border-radius: 2px;
+  margin-bottom: 1.5rem;
+  overflow: hidden;
+}
+
+.runbook-progress-bar .progress-fill {
+  height: 100%;
+  background: var(--md-primary-fg-color);
+  border-radius: 2px;
+  transition: width 0.5s ease;
+  width: 0;
+}
+
+.runbook-progress-bar .progress-label {
+  position: absolute;
+  right: 0;
+  top: 8px;
+  font-size: 0.7rem;
+  color: var(--md-default-fg-color--light);
+}
+
+/* Topic card progress on landing page */
+.tx-topics a .topic-progress {
+  display: block;
+  margin-top: 0.5rem;
+}
+
+.tx-topics a .topic-progress-bar {
+  height: 3px;
+  background: var(--md-default-fg-color--lightest);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.tx-topics a .topic-progress-fill {
+  height: 100%;
+  background: var(--md-primary-fg-color);
+  border-radius: 2px;
+  transition: width 0.5s ease;
+}
+
+.tx-topics a .topic-progress-text {
+  font-size: 0.7rem;
+  color: var(--md-default-fg-color--lighter);
+  margin-top: 0.25rem;
+}

--- a/hooks/interactive.py
+++ b/hooks/interactive.py
@@ -1,0 +1,62 @@
+"""MkDocs hook that converts custom interactive fences to HTML divs.
+
+Supported fence types: quiz, terminal, command-builder, exercise, code-walkthrough
+
+Each fence contains YAML that gets parsed and embedded as a JSON data attribute
+on a div element. The corresponding JS component picks it up on page load.
+"""
+
+import json
+import re
+
+import yaml
+
+FENCE_TYPES = ("quiz", "terminal", "command-builder", "exercise", "code-walkthrough")
+
+# Match ```<type>\n<yaml>\n``` blocks. Handles optional leading whitespace and
+# fences with 3+ backticks.
+FENCE_RE = re.compile(
+    r"^(`{3,})("
+    + "|".join(re.escape(t) for t in FENCE_TYPES)
+    + r")\s*\n(.*?)\n\1\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _fence_to_html(match: re.Match) -> str:
+    """Convert a single fence match to an HTML div with embedded config."""
+    fence_type = match.group(2)
+    yaml_content = match.group(3)
+
+    try:
+        config = yaml.safe_load(yaml_content)
+    except yaml.YAMLError:
+        # If YAML is invalid, render as a warning
+        return (
+            f'<div class="admonition warning">'
+            f"<p>Invalid interactive component configuration ({fence_type})</p>"
+            f"</div>"
+        )
+
+    if config is None:
+        config = {}
+
+    config_json = json.dumps(config, ensure_ascii=False)
+    # Escape for safe embedding in an HTML attribute
+    config_attr = config_json.replace("&", "&amp;").replace("'", "&#39;").replace('"', "&quot;")
+
+    title = config.get("title", config.get("question", fence_type.replace("-", " ").title()))
+
+    # Build noscript fallback
+    noscript = f"<noscript><p><strong>{title}</strong> (requires JavaScript)</p></noscript>"
+
+    return (
+        f'<div class="interactive-{fence_type}" data-config="{config_attr}">'
+        f"{noscript}"
+        f"</div>"
+    )
+
+
+def on_page_markdown(markdown: str, **kwargs) -> str:
+    """MkDocs hook entry point: transform custom fences in page markdown."""
+    return FENCE_RE.sub(_fence_to_html, markdown)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,9 @@ theme:
     - navigation.sections
     - navigation.expand
     - navigation.top
+    - navigation.instant
+    - navigation.tracking
+    - navigation.indexes
     - search.suggest
     - search.highlight
     - content.code.copy
@@ -38,21 +41,39 @@ plugins:
   - search
   - open-in-new-tab
 
+hooks:
+  - hooks/interactive.py
+
 markdown_extensions:
   - toc:
       permalink: true
   - tables
+  - admonition
+  - pymdownx.details
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
-  - codehilite
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.mark
+  - pymdownx.critic
+  - pymdownx.keys
   - attr_list
   - md_in_html
 
 extra_css:
   - assets/stylesheets/extra.css
+  - assets/stylesheets/interactive.css
+
+extra_javascript:
+  - assets/javascripts/interactive.js
 
 nav:
   - Home: README.md


### PR DESCRIPTION
## Summary

- Add interactive learning components (quiz, exercise, terminal simulation, command builder, code walkthrough) authored via YAML-in-Markdown custom fences
- Build pipeline: Python MkDocs hook parses fences into HTML divs, vanilla JS initializes components on page load
- Progress tracking via localStorage (section reads, quiz scores, exercise completion)
- Enable MkDocs Material features: admonitions, tabbed content, instant navigation, modern syntax highlighting
- Pilot interactive content added to Linux Essentials/shell-basics.md (5 quizzes, 2 exercises, 2 terminal sims, 1 code walkthrough, 4 admonitions)

## Test plan

- [ ] Run `./setup-docs.sh && mkdocs build --strict` - should pass with no new warnings
- [ ] Run `mkdocs serve` and navigate to Linux Essentials > Shell Basics
- [ ] Verify quiz renders: select answers, check correct/incorrect feedback, retry
- [ ] Verify terminal simulation: typing animation, step navigation, replay
- [ ] Verify exercise: progressive hints, solution toggle, mark complete
- [ ] Verify code walkthrough: step-by-step line highlighting, show all toggle
- [ ] Toggle dark mode - all components should adapt
- [ ] Refresh page - quiz scores and progress should persist (localStorage)
- [ ] Check admonitions (tip, warning, note, danger) render with Material styling

🤖 Generated with [Claude Code](https://claude.ai/claude-code)