### PR TITLE
Add interactive components to Git and Perl guides

### DIFF
--- a/Dev Zero/Perl/perl_dev0_introduction.md
+++ b/Dev Zero/Perl/perl_dev0_introduction.md
@@ -224,6 +224,46 @@ options:
     feedback: "Perl's syntax is famously flexible (and sometimes cryptic). Its strength for sysadmin work is powerful built-in features for text and system operations, not syntactic simplicity."
 ```
 
+```terminal
+title: Perl One-Liners in Action
+steps:
+  - command: "perl -e 'print \"Hello, Perl!\\n\"'"
+    output: "Hello, Perl!"
+    narration: "The -e flag executes code directly from the command line. No script file needed. This is the foundation of every Perl one-liner."
+  - command: "printf 'INFO  server started\\nERROR connection refused\\nINFO  request handled\\nERROR disk full\\nINFO  shutting down\\n' > server.log && cat server.log"
+    output: |
+      INFO  server started
+      ERROR connection refused
+      INFO  request handled
+      ERROR disk full
+      INFO  shutting down
+    narration: "Create a sample log file to work with. Five lines, two of which contain ERROR."
+  - command: "perl -ne 'print if /ERROR/' server.log"
+    output: |
+      ERROR connection refused
+      ERROR disk full
+    narration: "The -n flag wraps your code in a while(<>){...} loop that reads input line by line. Each line is placed in $_ automatically, so /ERROR/ tests the current line."
+  - command: "perl -pe 's/ERROR/WARNING/' server.log"
+    output: |
+      INFO  server started
+      WARNING connection refused
+      INFO  request handled
+      WARNING disk full
+      INFO  shutting down
+    narration: "The -p flag works like -n but also prints each line after processing. Combined with s///, it becomes a search-and-replace tool across the entire file."
+  - command: "perl -lane 'print $F[0]' server.log"
+    output: |
+      INFO
+      ERROR
+      INFO
+      ERROR
+      INFO
+    narration: "The -a flag auto-splits each line on whitespace into the @F array. The -l flag handles newlines automatically. Together, -lane gives you column extraction like awk."
+  - command: "perl -ne '$c++ if /ERROR/; END { print \"$c errors\\n\" }' server.log"
+    output: "2 errors"
+    narration: "Combine -n with an END block to accumulate results across all lines and print a summary. The END block runs once after all input is processed."
+```
+
 ---
 
 ## Perl in the Unix Tool Ecosystem

--- a/Dev Zero/Perl/perl_developer_roadmap.md
+++ b/Dev Zero/Perl/perl_developer_roadmap.md
@@ -340,7 +340,7 @@ annotations:
   - line: 6
     text: "A scalar ($total) declared with the $ sigil and initialized to 0. Scalars hold a single value - a number, string, or reference."
   - line: 8
-    text: "The diamond operator <STDIN> reads one line at a time from standard input. The while loop processes the file line by line, storing each line in the lexical variable $line."
+    text: "The filehandle read operator <STDIN> reads one line at a time from standard input. The while loop processes the file line by line, storing each line in the lexical variable $line."
   - line: 9
     text: "chomp removes the trailing newline character from $line. Without this, string comparisons and output would include unwanted newlines."
   - line: 10

--- a/Dev Zero/Perl/perl_developer_roadmap.md
+++ b/Dev Zero/Perl/perl_developer_roadmap.md
@@ -2,7 +2,7 @@
 
 ## The Road to Perl Developer Mastery
 
-**Version:** 1.6
+**Version:** 1.7
 **Year:** 2026
 
 ---
@@ -149,7 +149,7 @@ To help with the learning process, here are some engaging and helpful resources:
 
 - [Vim Adventures](https://vim-adventures.com) – a game-based way to learn Vim
 - [Vimcasts](http://vimcasts.org) – screencasts teaching practical Vim usage
-- [Vimbook on GitHub](https://github.com)
+- [Learn-Vim on GitHub](https://github.com/iggredible/Learn-Vim)
 
 Practice regularly, and you'll soon find Vim indispensable.
 
@@ -303,6 +303,55 @@ Developing fluency in Perl starts with a clear understanding of its foundational
 - **Code Style**: Perl's expressiveness allows multiple ways to solve problems, making it essential to develop good habits around clarity, consistency, and maintainability.
 
 The goal is not just to write functional code, but to write code that is efficient, idiomatic, and easy to understand—hallmarks of an experienced Perl developer.
+
+```code-walkthrough
+title: "A First Perl Script: Log Summary"
+description: A practical script that counts log levels from STDIN, demonstrating the core concepts from Learning the Ropes in a single working program.
+language: perl
+code: |
+  #!/usr/bin/env perl
+  use strict;
+  use warnings;
+
+  my %count;
+  my $total = 0;
+
+  while (my $line = <STDIN>) {
+      chomp $line;
+      if ($line =~ /\b(ERROR|WARN|INFO)\b/) {
+          $count{$1}++;
+          $total++;
+      }
+  }
+
+  for my $level (sort keys %count) {
+      printf "%s: %d (%.0f%%)\n", $level, $count{$level},
+          $count{$level} / $total * 100;
+  }
+annotations:
+  - line: 1
+    text: "The env shebang finds perl in the user's PATH, making the script portable across systems where Perl is installed in different locations."
+  - line: 2
+    text: "use strict forces you to declare variables with my and catches common mistakes like typos in variable names. Always include this."
+  - line: 3
+    text: "use warnings alerts you to questionable constructs like using an undefined value. Together with strict, these two pragmas are the first lines of every serious Perl script."
+  - line: 5
+    text: "A hash (%count) declared with the % sigil. Hashes store key-value pairs - here each log level maps to its count. Perl auto-creates entries on first use (auto-vivification)."
+  - line: 6
+    text: "A scalar ($total) declared with the $ sigil and initialized to 0. Scalars hold a single value - a number, string, or reference."
+  - line: 8
+    text: "The diamond operator <STDIN> reads one line at a time from standard input. The while loop processes the file line by line, storing each line in the lexical variable $line."
+  - line: 9
+    text: "chomp removes the trailing newline character from $line. Without this, string comparisons and output would include unwanted newlines."
+  - line: 10
+    text: "The =~ operator applies a regex match. \\b matches a word boundary, and the parentheses capture the matched level (ERROR, WARN, or INFO) into the special variable $1."
+  - line: 11
+    text: "Hash auto-vivification in action: $count{$1}++ creates the key if it doesn't exist (starting at 0) and increments it. No need to check if the key exists first."
+  - line: 16
+    text: "sort keys %count returns the hash keys in alphabetical order. The for loop assigns each key to the lexical variable $level."
+  - line: 17
+    text: "printf provides C-style formatted output. %s inserts a string, %d an integer, and %.0f%% a float with zero decimal places followed by a literal percent sign."
+```
 
 **References and Error Handling**
 

--- a/Git/branches-and-merging.md
+++ b/Git/branches-and-merging.md
@@ -141,6 +141,49 @@ git checkout -b new-branch        # Create and switch
 !!! warning "Uncommitted changes and switching"
     If you have uncommitted changes that would conflict with the branch you're switching to, Git refuses the switch to prevent data loss. You have three options: commit the changes, stash them (`git stash`), or discard them (`git restore .`).
 
+```terminal
+title: Branch, Switch, and Merge
+steps:
+  - command: "mkdir branch-demo && cd branch-demo && git init"
+    output: "Initialized empty Git repository in /home/user/branch-demo/.git/"
+    narration: "Create a fresh repository to work through a complete branching workflow."
+  - command: "echo '# My Project' > README.md && git add README.md && git commit -m 'Initial commit'"
+    output: "[main (root-commit) a1b2c3d] Initial commit"
+    narration: "Start with a single commit on main. Right now there's only one branch and one commit."
+  - command: "git branch"
+    output: "* main"
+    narration: "The asterisk marks the current branch. Only main exists so far."
+  - command: "git switch -c feature/greeting"
+    output: "Switched to a new branch 'feature/greeting'"
+    narration: "Create and switch to a new branch in one step. Git creates a new pointer at the current commit and moves HEAD to point at it."
+  - command: "echo 'Hello from the feature branch!' >> README.md && git add README.md && git commit -m 'Add greeting to README'"
+    output: "[feature/greeting d4e5f6a] Add greeting to README"
+    narration: "Make a commit on the feature branch. The feature/greeting pointer advances to the new commit, but main stays where it was."
+  - command: "git switch main"
+    output: "Switched to branch 'main'"
+    narration: "Switch back to main. Your working directory reverts to main's version of the files - the greeting line disappears."
+  - command: "git branch -v"
+    output: |
+        feature/greeting d4e5f6a Add greeting to README
+      * main             a1b2c3d Initial commit
+    narration: "Both branches with their latest commits. main is still at the initial commit, while feature/greeting is one commit ahead."
+  - command: "git merge feature/greeting"
+    output: |
+      Updating a1b2c3d..d4e5f6a
+      Fast-forward
+       README.md | 1 +
+       1 file changed, 1 insertion(+)
+    narration: "Since main had no new commits, Git performs a fast-forward merge. It moves the main pointer forward to the same commit as feature/greeting. No merge commit is needed."
+  - command: "git log --oneline --graph --all"
+    output: |
+      * d4e5f6a (HEAD -> main, feature/greeting) Add greeting to README
+      * a1b2c3d Initial commit
+    narration: "Both branches now point to the same commit. The history is linear because the fast-forward just moved the pointer."
+  - command: "git branch -d feature/greeting"
+    output: "Deleted branch feature/greeting (was d4e5f6a)."
+    narration: "Clean up the merged branch. The -d flag only works if the branch is fully merged, preventing accidental data loss. The commits remain in the history."
+```
+
 ---
 
 ## Renaming and Deleting Branches

--- a/Git/branches-and-merging.md
+++ b/Git/branches-and-merging.md
@@ -141,49 +141,6 @@ git checkout -b new-branch        # Create and switch
 !!! warning "Uncommitted changes and switching"
     If you have uncommitted changes that would conflict with the branch you're switching to, Git refuses the switch to prevent data loss. You have three options: commit the changes, stash them (`git stash`), or discard them (`git restore .`).
 
-```terminal
-title: Branch, Switch, and Merge
-steps:
-  - command: "mkdir branch-demo && cd branch-demo && git init"
-    output: "Initialized empty Git repository in /home/user/branch-demo/.git/"
-    narration: "Create a fresh repository to work through a complete branching workflow."
-  - command: "echo '# My Project' > README.md && git add README.md && git commit -m 'Initial commit'"
-    output: "[main (root-commit) a1b2c3d] Initial commit"
-    narration: "Start with a single commit on main. Right now there's only one branch and one commit."
-  - command: "git branch"
-    output: "* main"
-    narration: "The asterisk marks the current branch. Only main exists so far."
-  - command: "git switch -c feature/greeting"
-    output: "Switched to a new branch 'feature/greeting'"
-    narration: "Create and switch to a new branch in one step. Git creates a new pointer at the current commit and moves HEAD to point at it."
-  - command: "echo 'Hello from the feature branch!' >> README.md && git add README.md && git commit -m 'Add greeting to README'"
-    output: "[feature/greeting d4e5f6a] Add greeting to README"
-    narration: "Make a commit on the feature branch. The feature/greeting pointer advances to the new commit, but main stays where it was."
-  - command: "git switch main"
-    output: "Switched to branch 'main'"
-    narration: "Switch back to main. Your working directory reverts to main's version of the files - the greeting line disappears."
-  - command: "git branch -v"
-    output: |
-        feature/greeting d4e5f6a Add greeting to README
-      * main             a1b2c3d Initial commit
-    narration: "Both branches with their latest commits. main is still at the initial commit, while feature/greeting is one commit ahead."
-  - command: "git merge feature/greeting"
-    output: |
-      Updating a1b2c3d..d4e5f6a
-      Fast-forward
-       README.md | 1 +
-       1 file changed, 1 insertion(+)
-    narration: "Since main had no new commits, Git performs a fast-forward merge. It moves the main pointer forward to the same commit as feature/greeting. No merge commit is needed."
-  - command: "git log --oneline --graph --all"
-    output: |
-      * d4e5f6a (HEAD -> main, feature/greeting) Add greeting to README
-      * a1b2c3d Initial commit
-    narration: "Both branches now point to the same commit. The history is linear because the fast-forward just moved the pointer."
-  - command: "git branch -d feature/greeting"
-    output: "Deleted branch feature/greeting (was d4e5f6a)."
-    narration: "Clean up the merged branch. The -d flag only works if the branch is fully merged, preventing accidental data loss. The commits remain in the history."
-```
-
 ---
 
 ## Renaming and Deleting Branches
@@ -280,6 +237,47 @@ git merge --no-ff feature
 ```
 
 This is common in workflows where you want the history to show that features were developed on separate branches, even if the history could be linear.
+
+```terminal
+title: Branch, Switch, and Merge
+steps:
+  - command: "mkdir merge-demo && cd merge-demo && git init"
+    output: "Initialized empty Git repository in /home/user/merge-demo/.git/"
+    narration: "Create a fresh repository to work through a complete branching workflow."
+  - command: "echo '# My Project' > README.md && git add README.md && git commit -m 'Initial commit'"
+    output: "[main (root-commit) a1b2c3d] Initial commit"
+    narration: "Start with a single commit on main. Right now there's only one branch and one commit."
+  - command: "git branch"
+    output: "* main"
+    narration: "The asterisk marks the current branch. Only main exists so far."
+  - command: "git switch -c feature/greeting"
+    output: "Switched to a new branch 'feature/greeting'"
+    narration: "Create and switch to a new branch in one step. Git creates a new pointer at the current commit and moves HEAD to point at it."
+  - command: "echo 'Hello from the feature branch!' >> README.md && git add README.md && git commit -m 'Add greeting to README'"
+    output: "[feature/greeting d4e5f6a] Add greeting to README"
+    narration: "Make a commit on the feature branch. The feature/greeting pointer advances to the new commit, but main stays where it was."
+  - command: "git switch main"
+    output: "Switched to branch 'main'"
+    narration: "Switch back to main. Your working directory reverts to main's version of the files - the greeting line disappears."
+  - command: "git branch -v"
+    output: "  feature/greeting d4e5f6a Add greeting to README\n* main             a1b2c3d Initial commit"
+    narration: "Both branches with their latest commits. main is still at the initial commit, while feature/greeting is one commit ahead."
+  - command: "git merge feature/greeting"
+    output: |
+      Updating a1b2c3d..d4e5f6a
+      Fast-forward
+       README.md | 1 +
+       1 file changed, 1 insertion(+)
+    narration: "Since main had no new commits, Git performs a fast-forward merge. It moves the main pointer forward to the same commit as feature/greeting. No merge commit is needed."
+  - command: "git log --oneline --graph --all"
+    output: |
+      * d4e5f6a (HEAD -> main, feature/greeting) Add greeting to README
+      * a1b2c3d Initial commit
+    narration: "Both branches now point to the same commit. The history is linear because the fast-forward just moved the pointer."
+  - command: "git branch -d feature/greeting"
+    output: "Deleted branch feature/greeting (was d4e5f6a)."
+    narration: "Clean up the merged branch. The -d flag only works if the branch is fully merged, preventing accidental data loss. The commits remain in the history."
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Add **terminal simulation** to Git branches-and-merging guide covering branch creation, switching, fast-forward merge, and cleanup workflow (closes #39)
- Add **terminal simulation** to Perl introduction guide stepping through one-liner flags (`-e`, `-n`, `-p`, `-lane`) with a sample log file (closes #43)
- Add **code-walkthrough** to Perl developer roadmap with a log summary script demonstrating scalars, hashes, regex, loops, and printf (closes #45)

Also closes #40 - the git log command-builder already exists in commits-and-history.md.

## Test plan

- [ ] `./setup-docs.sh && mkdocs build --strict` passes
- [ ] Terminal components render and step through correctly
- [ ] Code-walkthrough annotations highlight the correct lines
- [ ] Components display properly in both light and dark mode