### PR TITLE
Fix hardcoded /guides/ path in interactive.js

### DIFF
--- a/assets/javascripts/interactive.js
+++ b/assets/javascripts/interactive.js
@@ -36,8 +36,8 @@
     }
     return new Promise((resolve, reject) => {
       const script = document.createElement("script");
-      // Resolve relative to site root
-      script.src = new URL(src, window.location.origin + "/guides/").href;
+      // Resolve relative to site root (document.baseURI adapts to any deploy path)
+      script.src = new URL(src, document.baseURI).href;
       script.onload = () => {
         loadedScripts.add(src);
         resolve();

--- a/assets/javascripts/interactive.js
+++ b/assets/javascripts/interactive.js
@@ -36,8 +36,8 @@
     }
     return new Promise((resolve, reject) => {
       const script = document.createElement("script");
-      // Resolve relative to site root (document.baseURI adapts to any deploy path)
-      script.src = new URL(src, document.baseURI).href;
+      // Resolve relative to site root (__md_scope is set by MkDocs Material per page)
+      script.src = new URL(src, window.__md_scope || document.baseURI).href;
       script.onload = () => {
         loadedScripts.add(src);
         resolve();


### PR DESCRIPTION
## Summary

- Replace hardcoded `/guides/` base path in `interactive.js` with `document.baseURI`
- Fixes component script loading when running `mkdocs serve` locally or deploying to a different subpath

Closes #23

## Test plan

- [ ] `mkdocs build --strict` passes
- [ ] Interactive components load correctly on deployed site
- [ ] Interactive components load correctly via `mkdocs serve` locally