### PR TITLE
Scope down CI permissions from contents:write

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,15 @@ on:
       - main
 
 permissions:
-  contents: write
+  pages: write
+  id-token: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -31,5 +35,11 @@ jobs:
       - name: Build site (strict mode)
         run: mkdocs build --strict
 
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Migrate deploy workflow from legacy `gh-pages` branch deployment (`mkdocs gh-deploy`) to modern GitHub Pages artifact deployment (`upload-pages-artifact` + `deploy-pages`)
- Narrows permissions from `contents: write` to `pages: write` + `id-token: write`
- Repo Pages source already switched to "GitHub Actions"

Closes #8