### PR TITLE
Fix missing 'that' in README disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ hide:
 
 # The Runbook
 
-Practical, open-access technical guides covering Linux, DNS, Git, databases, and development. Created for practitioners - be aware some content may be outdated and should be verified.
+Practical, open-access technical guides covering Linux, DNS, Git, databases, and development. Created for practitioners - be aware that some content may be outdated and should be verified.
 
 ## Topics
 


### PR DESCRIPTION
## Summary
- Fixes grammar in the site tagline: "be aware that some content may be outdated"
- Supersedes #67 (which had this fix but also introduced regressions)

Supersedes #67