### PR TITLE
Expand thin guides with comprehensive content and interactive components

### DIFF
--- a/Databases/mongodb.md
+++ b/Databases/mongodb.md
@@ -100,6 +100,23 @@ const last = (coll, n = 5) => db[coll].find().sort({ _id: -1 }).limit(n);
 const count = (coll, query = {}) => db[coll].countDocuments(query);
 ```
 
+```terminal
+scenario: "Practice basic shell commands in mongosh."
+steps:
+  - command: "show dbs"
+    output: "admin   0.000GB\nconfig  0.000GB\nlocal   0.000GB"
+    narration: "Start by listing the available databases."
+  - command: "use myapp"
+    output: "switched to db myapp"
+    narration: "Switch to a new database named 'myapp'. MongoDB won't actually create it until you perform your first write."
+  - command: "db.users.insertOne({ name: 'Junie', role: 'admin' })"
+    output: "{\n  acknowledged: true,\n  insertedId: ObjectId(\"65a1b2c3d4e5f6a7b8c9d0e1\")\n}"
+    narration: "Insert a document into a new 'users' collection."
+  - command: "show collections"
+    output: "users"
+    narration: "Now that we've performed a write, the 'users' collection (and 'myapp' database) are visible."
+```
+
 ---
 
 ## CRUD Operations

--- a/Databases/sql-essentials.md
+++ b/Databases/sql-essentials.md
@@ -408,6 +408,22 @@ RIGHT JOIN departments d ON s.dept_id = d.id;
 
 Both unmatched sides appear: Dijkstra (no department) and Legal (no staff).
 
+```exercise
+scenario: "Retrieve a list of all departments and the count of staff in each. Include departments that have no staff (count should be 0)."
+initial_code: |
+  SELECT d.name, COUNT(s.id) AS staff_count
+  FROM departments d
+  -- Add your JOIN and GROUP BY here
+  ORDER BY staff_count DESC;
+solution: |
+  SELECT d.name, COUNT(s.id) AS staff_count
+  FROM departments d
+  LEFT JOIN staff s ON d.id = s.dept_id
+  GROUP BY d.name
+  ORDER BY staff_count DESC;
+hint: "Use a LEFT JOIN starting from the departments table to ensure all departments are included even if they have no matches in the staff table."
+```
+
 ### CROSS JOIN
 
 Returns the **Cartesian product** - every row from the left table combined with every row from the right table. If the left table has 5 rows and the right has 4, the result has 20 rows. Use CROSS JOIN when you genuinely need all combinations, such as generating a schedule grid.

--- a/Dev Zero/Python/data-structures-and-logic.md
+++ b/Dev Zero/Python/data-structures-and-logic.md
@@ -447,13 +447,14 @@ options:
 
 ```exercise
 title: "Parse and Analyze Server Logs"
-description: "Write a Python script that reads a list of log entries, counts occurrences by status level, and identifies the most frequent error messages."
-requirements:
-  - "Given a list of log entry dictionaries (each with 'level', 'message', and 'timestamp' keys), count entries per level"
-  - "Use Counter from the collections module for counting"
-  - "Group error messages (level == 'ERROR') into a list"
-  - "Print the top 3 most common log levels and all unique error messages"
-  - "Handle the case where the log list is empty"
+scenario: |
+  You have a list of log entry dictionaries, each with `level`, `message`, and `timestamp` keys. Write a function that:
+
+  1. Counts entries per level using `Counter` from the `collections` module
+  2. Prints the top 3 most common log levels with their counts
+  3. Groups error messages (level == `ERROR`) into a list
+  4. Prints all unique error messages, sorted alphabetically
+  5. Handles the case where the log list is empty
 hints:
   - "Counter([entry['level'] for entry in logs]) counts all levels in one line"
   - "Use a list comprehension to filter: [e['message'] for e in logs if e['level'] == 'ERROR']"
@@ -470,7 +471,7 @@ solution: |
       # Count entries per level
       levels = Counter(entry["level"] for entry in logs)
       print("Log level counts:")
-      for level, count in levels.most_common():
+      for level, count in levels.most_common(3):
           print(f"  {level}: {count}")
 
       # Collect unique error messages

--- a/Dev Zero/Python/data-structures-and-logic.md
+++ b/Dev Zero/Python/data-structures-and-logic.md
@@ -1,6 +1,6 @@
 # Data Structures and Logic (Python)
 
-**Version:** 0.1  
+**Version:** 0.2
 **Year:** 2026
 
 ---
@@ -11,40 +11,104 @@ Copyright (c) 2025-2026 Ryan Thomas Robson / Robworks Software LLC. Licensed und
 
 ---
 
-Modern sysadmin tasks involve more than just parsing single lines of text. We often need to store collections of data, transform them, and make decisions based on their contents. Python's built-in data structures and clean control flow logic are designed for exactly these scenarios.
+Modern sysadmin tasks involve more than parsing single lines of text. You need to store collections of data, transform them, and make decisions based on their contents. Python's built-in data structures and clean control flow are designed for exactly these scenarios - from parsing log files to building configuration management tools.
 
 ## Core Data Structures
 
 Python has four primary collection types, each with unique properties and use cases.
 
-### Lists: Ordered Collections
+```mermaid
+graph TD
+    Collections[Python Collections] --> Indexed[Indexed / Ordered]
+    Collections --> Unordered[Unordered]
+    Indexed --> MutableIndexed[Mutable]
+    Indexed --> ImmutableIndexed[Immutable]
+    Unordered --> Set[Sets - Unique Items]
+    Unordered --> Dict[Dictionaries - Key-Value]
+    MutableIndexed --> List[Lists]
+    ImmutableIndexed --> Tuple[Tuples]
+```
 
-[**`List`**](https://docs.python.org/3/tutorial/introduction.html#lists) is the most versatile data structure. It's an ordered sequence of elements, which can be modified after creation (mutable).
+---
+
+## Lists
+
+A [**list**](https://docs.python.org/3/tutorial/introduction.html#lists) is an ordered, mutable sequence. It's the most versatile collection and the one you'll reach for most often.
 
 ```python
 # A list of server names
 servers = ["web01", "web02", "db01", "db02"]
 
 # Adding elements
-servers.append("cache01")
+servers.append("cache01")           # Add to end
+servers.insert(0, "lb01")           # Insert at position
 
 # Accessing by index (0-indexed)
-primary_db = servers[2]  # "db01"
+primary_db = servers[2]             # "web02" (shifted after insert)
+last = servers[-1]                  # "cache01" (negative index = from end)
 
-# Slicing (start:stop:step)
-web_servers = servers[0:2]  # ["web01", "web02"]
+# Slicing [start:stop:step] - stop is exclusive
+web_servers = servers[1:3]          # ["web01", "web02"]
+every_other = servers[::2]          # Every second element
+reversed_list = servers[::-1]       # Reversed copy
 
-# Iterating over a list
-for server in servers:
-    print(f"Checking status for {server}...")
+# Removing elements
+servers.remove("db02")              # Remove by value (first occurrence)
+popped = servers.pop()              # Remove and return last element
 ```
 
-### Dictionaries: Key-Value Pairs
-
-[**`Dictionary`**](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) (or "dict") is a collection of key-value pairs. Keys must be unique and immutable (like strings or integers).
+### Iterating Over Lists
 
 ```python
-# A dictionary representing server configuration
+# Basic iteration
+for server in servers:
+    print(f"Checking {server}...")
+
+# With index using enumerate()
+for i, server in enumerate(servers):
+    print(f"[{i}] {server}")
+
+# Iterate over two lists in parallel
+names = ["web01", "web02", "db01"]
+ips = ["10.0.0.1", "10.0.0.2", "10.0.1.1"]
+
+for name, ip in zip(names, ips):
+    print(f"{name} -> {ip}")
+```
+
+### List Comprehensions
+
+A **list comprehension** creates a new list by applying an expression to each item in an iterable, optionally filtering items. It's a concise alternative to a `for` loop with `append`.
+
+```python
+# Standard for loop
+log_files = []
+for f in os.listdir("/var/log"):
+    if f.endswith(".log"):
+        log_files.append(f)
+
+# Equivalent list comprehension
+log_files = [f for f in os.listdir("/var/log") if f.endswith(".log")]
+
+# Transform values: convert strings to uppercase
+hostnames = [s.upper() for s in servers]
+
+# Nested comprehension: flatten a list of lists
+groups = [["web01", "web02"], ["db01"], ["cache01", "cache02"]]
+all_servers = [s for group in groups for s in group]
+```
+
+!!! tip "When to use list comprehensions"
+    If the comprehension fits on one line or is easy to read at a glance, use it. If you need multiple conditions, nested transformations, or side effects (like printing), use a regular `for` loop. Readability beats cleverness.
+
+---
+
+## Dictionaries
+
+A [**dictionary**](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) maps keys to values. Keys must be unique and immutable (strings, numbers, tuples). Dictionaries are Python's answer to hash maps, associative arrays, and lookup tables.
+
+```python
+# Server configuration
 config = {
     "hostname": "app01",
     "ip_address": "10.0.0.5",
@@ -52,37 +116,131 @@ config = {
     "uptime_days": 142
 }
 
-# Accessing values
-print(config["ip_address"])  # "10.0.0.5"
+# Access values
+print(config["ip_address"])              # "10.0.0.5"
 
-# Adding or updating
+# Safe access with .get() (returns None instead of raising KeyError)
+backup = config.get("backup_enabled")    # None
+backup = config.get("backup_enabled", False)  # False (custom default)
+
+# Add or update
 config["environment"] = "production"
+config["uptime_days"] = 143
 
-# Checking if a key exists
-if "backup_enabled" not in config:
-    config["backup_enabled"] = False
+# Remove a key
+del config["uptime_days"]
+removed = config.pop("environment")      # Remove and return value
 ```
 
-### Tuples and Sets
-
-- **Tuples**: Like lists, but **immutable** (cannot be changed after creation). Used for data that should not be accidentally modified (e.g., a coordinate pair `(latitude, longitude)`).
-- **Sets**: An unordered collection of **unique** elements. Excellent for deduplication and set operations like unions and intersections.
+### Iterating Over Dictionaries
 
 ```python
-# A set of unique IP addresses from a log file
-unique_ips = {"192.168.1.1", "10.0.0.5", "192.168.1.1"}
-print(unique_ips)  # {"192.168.1.1", "10.0.0.5"} - duplicates are removed
+# Keys only (default)
+for key in config:
+    print(key)
+
+# Keys and values together
+for key, value in config.items():
+    print(f"{key}: {value}")
+
+# Values only
+for value in config.values():
+    print(value)
+```
+
+### Dictionary Comprehensions
+
+```python
+# Build a lookup table from two lists
+names = ["web01", "web02", "db01"]
+ips = ["10.0.0.1", "10.0.0.2", "10.0.1.1"]
+
+host_map = {name: ip for name, ip in zip(names, ips)}
+# {"web01": "10.0.0.1", "web02": "10.0.0.2", "db01": "10.0.1.1"}
+
+# Filter while building
+prod_hosts = {name: ip for name, ip in host_map.items() if name.startswith("web")}
+```
+
+### Useful Patterns
+
+```python
+from collections import Counter, defaultdict
+
+# Count occurrences
+status_codes = [200, 200, 404, 500, 200, 404, 200]
+counts = Counter(status_codes)
+# Counter({200: 4, 404: 2, 500: 1})
+print(counts.most_common(2))   # [(200, 4), (404, 2)]
+
+# Group items by key
+logs = [
+    {"level": "ERROR", "msg": "Disk full"},
+    {"level": "INFO", "msg": "Service started"},
+    {"level": "ERROR", "msg": "Connection timeout"},
+]
+
+by_level = defaultdict(list)
+for entry in logs:
+    by_level[entry["level"]].append(entry["msg"])
+# {"ERROR": ["Disk full", "Connection timeout"], "INFO": ["Service started"]}
 ```
 
 ---
 
-## Control Flow Logic
+## Tuples
 
-Python uses standard logical operators (`if`, `elif`, `else`) and loops (`for`, `while`) to control the execution path.
+A **tuple** is like a list but **immutable** - once created, you cannot add, remove, or change its elements. Use tuples for data that should not be accidentally modified.
+
+```python
+# Coordinates, version numbers, database rows
+coordinates = (40.7128, -74.0060)
+version = (3, 12, 1)
+
+# Tuple unpacking (assign multiple variables in one line)
+lat, lon = coordinates
+major, minor, patch = version
+
+# Functions often return tuples
+import shutil
+total, used, free = shutil.disk_usage("/")
+
+# Swap variables without a temp variable
+a, b = 1, 2
+a, b = b, a   # a=2, b=1
+```
+
+---
+
+## Sets
+
+A **set** is an unordered collection of **unique** elements. Sets are optimized for membership testing and mathematical set operations.
+
+```python
+# Deduplicate a list of IPs from a log file
+all_ips = ["10.0.0.1", "10.0.0.2", "10.0.0.1", "10.0.0.3", "10.0.0.2"]
+unique_ips = set(all_ips)   # {"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+
+# Set operations
+allowed = {"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+active = {"10.0.0.2", "10.0.0.4", "10.0.0.5"}
+
+authorized = allowed & active          # Intersection: {"10.0.0.2"}
+all_known = allowed | active           # Union: all 5 IPs
+unauthorized = active - allowed        # Difference: {"10.0.0.4", "10.0.0.5"}
+
+# Fast membership testing (O(1) vs O(n) for lists)
+if "10.0.0.4" in allowed:
+    print("IP is allowed")
+```
+
+---
+
+## Control Flow
 
 ### Conditionals
 
-Python's `if` statements are clean and readable, using `and`, `or`, and `not` for complex logic.
+Python uses `if`, `elif`, and `else` with the boolean operators `and`, `or`, and `not`.
 
 ```python
 load_average = 4.5
@@ -98,82 +256,255 @@ else:
     print("System health is OK.")
 ```
 
-### For Loops and List Comprehensions
+### Truthiness
 
-The `for` loop is primarily used to iterate over a collection.
+Python evaluates these values as **False** (everything else is **True**):
+
+| Value | Type |
+|-------|------|
+| `False` | bool |
+| `None` | NoneType |
+| `0`, `0.0` | numeric |
+| `""`, `[]`, `{}`, `set()`, `()` | empty sequences/collections |
+
+This means you can write concise checks:
 
 ```python
-# Transforming a list of filenames to absolute paths
-files = ["access.log", "error.log", "auth.log"]
-log_dir = "/var/log"
+errors = []
+if errors:
+    print(f"Found {len(errors)} errors")
+else:
+    print("No errors")
 
-# Standard for loop
-absolute_paths = []
-for f in files:
-    absolute_paths.append(f"{log_dir}/{f}")
+# None handling
+result = config.get("timeout")
+timeout = result if result is not None else 30
+# Or more concisely (but be careful - this also replaces 0):
+timeout = config.get("timeout") or 30
+```
 
-# List Comprehension (concise Pythonic way)
-absolute_paths = [f"{log_dir}/{f}" for f in files]
+!!! warning "Mutable default arguments"
+    Never use a mutable object (list, dict) as a function's default argument. Python creates the default once and reuses it across all calls, so modifications accumulate unexpectedly.
+
+    ```python
+    # WRONG - the same list is shared across all calls
+    def add_server(name, servers=[]):
+        servers.append(name)
+        return servers
+
+    # RIGHT - use None and create a new list each time
+    def add_server(name, servers=None):
+        if servers is None:
+            servers = []
+        servers.append(name)
+        return servers
+    ```
+
+### For Loops
+
+The `for` loop iterates over any iterable - lists, dicts, strings, files, ranges.
+
+```python
+# Loop with range (0 to 4)
+for i in range(5):
+    print(f"Attempt {i + 1}")
+
+# Loop over a string
+for char in "hello":
+    print(char)
+
+# Loop over a file line by line
+with open("/etc/hosts") as f:
+    for line in f:
+        if not line.startswith("#"):
+            print(line.strip())
+```
+
+### While Loops
+
+Use `while` when you don't know in advance how many iterations you need.
+
+```python
+import time
+
+retries = 0
+max_retries = 5
+
+while retries < max_retries:
+    if check_service("web01"):
+        print("Service is up!")
+        break
+    retries += 1
+    print(f"Attempt {retries}/{max_retries} failed, retrying in 5s...")
+    time.sleep(5)
+else:
+    # The else clause runs if the loop completes without break
+    print("Service did not recover after all retries.")
 ```
 
 ---
 
-## Interactive Quizzes: Data Structures and Logic
+## Exception Handling Patterns
 
-Test your knowledge of Python's collections and control flow.
+Beyond basic `try`/`except` (covered in the introduction), you'll use these patterns frequently:
+
+```python
+# Catch multiple exception types
+try:
+    data = json.loads(raw_input)
+    value = data["key"]
+except (json.JSONDecodeError, KeyError) as e:
+    print(f"Invalid data: {e}")
+
+# finally runs no matter what (cleanup)
+try:
+    conn = connect_to_db()
+    result = conn.execute(query)
+finally:
+    conn.close()
+
+# Raise your own exceptions
+def deploy(version):
+    if not version.startswith("v"):
+        raise ValueError(f"Version must start with 'v', got: {version}")
+```
+
+---
+
+```terminal
+scenario: "Explore Python data structures interactively"
+steps:
+  - command: "python3 -c \"servers = ['web01', 'web02', 'db01']; print(servers)\""
+    output: "['web01', 'web02', 'db01']"
+    narration: "Create a list of server names. Lists are ordered and mutable - you can add, remove, and reorder elements."
+  - command: "python3 -c \"servers = ['web01', 'web02', 'db01']; servers.append('cache01'); print(servers)\""
+    output: "['web01', 'web02', 'db01', 'cache01']"
+    narration: "Append adds an element to the end of the list. The list grows dynamically."
+  - command: "python3 -c \"config = {'host': 'db01', 'port': 5432, 'ssl': True}; print(config['host']); print(config.get('timeout', 30))\""
+    output: "db01\n30"
+    narration: "Dictionaries map keys to values. Use bracket notation for keys you know exist, and .get() with a default for optional keys."
+  - command: "python3 -c \"ips = ['10.0.0.1', '10.0.0.2', '10.0.0.1', '10.0.0.3']; print(set(ips))\""
+    output: "{'10.0.0.1', '10.0.0.2', '10.0.0.3'}"
+    narration: "Converting a list to a set removes duplicates automatically. Sets are unordered, so the output order may vary."
+  - command: "python3 -c \"names = ['web01', 'db01']; ips = ['10.0.0.1', '10.0.1.1']; print(dict(zip(names, ips)))\""
+    output: "{'web01': '10.0.0.1', 'db01': '10.0.1.1'}"
+    narration: "zip() pairs elements from two lists. Wrapping in dict() creates a lookup table. This pattern is common when combining related data from different sources."
+  - command: "python3 -c \"from collections import Counter; codes = [200, 200, 404, 500, 200, 404]; print(Counter(codes).most_common())\""
+    output: "[(200, 3), (404, 2), (500, 1)]"
+    narration: "Counter from the collections module counts occurrences and provides most_common() for ranked results. Useful for log analysis and reporting."
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
 question: "Which data structure would be most appropriate for storing a collection of unique usernames from a large CSV file?"
 type: multiple-choice
 options:
   - text: "List"
-    feedback: "Lists allow duplicates. If you need unique usernames, a list is not the most efficient choice."
+    feedback: "Lists allow duplicates. You would need to check for existence before each append, which is O(n) per check."
   - text: "Tuple"
-    feedback: "Tuples allow duplicates and are immutable. Not ideal for gathering a collection of unique items."
+    feedback: "Tuples are immutable - you can't add elements to them as you read the file."
   - text: "Set"
     correct: true
-    feedback: "Correct! A Set is ideal because it automatically handles deduplication, ensuring that each username appears only once regardless of how many times it appeared in the source file."
+    feedback: "Correct! A set automatically handles deduplication and membership testing in O(1) time. Just use add() for each username and duplicates are ignored."
   - text: "Dictionary"
-    feedback: "While dictionary keys must be unique, a Set is simpler for storing a collection of unique values."
+    feedback: "Dictionary keys must be unique, but if you only need values (not key-value pairs), a set is simpler and more semantically correct."
 ```
 
 ```quiz
-question: "What is the result of the following list slice? `['a', 'b', 'c', 'd'][1:3]`"
+question: "What is the result of `['a', 'b', 'c', 'd'][1:3]`?"
 type: multiple-choice
 options:
   - text: "['a', 'b']"
-    feedback: "Slice starts at index 1 ('b'), not index 0 ('a')."
+    feedback: "Slicing starts at index 1, not index 0."
   - text: "['b', 'c']"
     correct: true
-    feedback: "Correct! List slicing is inclusive of the start index (1) and exclusive of the stop index (3). Index 1 is 'b' and index 2 is 'c'. Index 3 ('d') is excluded."
+    feedback: "Correct! Slicing is inclusive of the start index (1) and exclusive of the stop index (3). Index 1 is 'b' and index 2 is 'c'."
   - text: "['b', 'c', 'd']"
     feedback: "Index 3 ('d') is the stop index, so it's excluded from the slice."
   - text: "['a', 'b', 'c']"
-    feedback: "Slice starts at index 1 ('b'), not index 0 ('a')."
+    feedback: "Slicing starts at index 1 ('b'), not index 0 ('a')."
 ```
 
 ```quiz
-question: "Which keyword is used to add an alternative condition to an `if` statement if the first condition is False?"
+question: "Why should you never use a mutable object (like a list) as a function's default argument?"
 type: multiple-choice
 options:
-  - text: "else if"
-    feedback: "This is used in languages like Java or C, but not Python."
-  - text: "elseif"
-    feedback: "This is used in languages like PHP or Perl, but not Python."
-  - text: "elif"
+  - text: "It causes a syntax error."
+    feedback: "Python accepts mutable defaults without error - the problem is behavioral, not syntactic."
+  - text: "Python creates the default once and reuses it across all calls, so modifications accumulate."
     correct: true
-    feedback: "Correct! Python uses the `elif` keyword (short for 'else if') to provide additional conditional branches."
-  - text: "otherwise"
-    feedback: "This is not a Python keyword."
+    feedback: "Correct! Default arguments are evaluated once at function definition time, not at each call. A mutable default like [] is shared across all invocations, so appending to it in one call affects subsequent calls."
+  - text: "Mutable objects cannot be used as function arguments."
+    feedback: "You can pass mutable objects as arguments. The issue is specifically with mutable default values."
+  - text: "It makes the function slower."
+    feedback: "The performance impact is negligible. The problem is that the function behaves incorrectly by sharing state between calls."
+```
+
+---
+
+```exercise
+title: "Parse and Analyze Server Logs"
+description: "Write a Python script that reads a list of log entries, counts occurrences by status level, and identifies the most frequent error messages."
+requirements:
+  - "Given a list of log entry dictionaries (each with 'level', 'message', and 'timestamp' keys), count entries per level"
+  - "Use Counter from the collections module for counting"
+  - "Group error messages (level == 'ERROR') into a list"
+  - "Print the top 3 most common log levels and all unique error messages"
+  - "Handle the case where the log list is empty"
+hints:
+  - "Counter([entry['level'] for entry in logs]) counts all levels in one line"
+  - "Use a list comprehension to filter: [e['message'] for e in logs if e['level'] == 'ERROR']"
+  - "Counter.most_common(3) returns the top 3 as a list of (value, count) tuples"
+  - "Check 'if not logs:' before processing to handle the empty case"
+solution: |
+  from collections import Counter
+
+  def analyze_logs(logs):
+      if not logs:
+          print("No log entries to analyze.")
+          return
+
+      # Count entries per level
+      levels = Counter(entry["level"] for entry in logs)
+      print("Log level counts:")
+      for level, count in levels.most_common():
+          print(f"  {level}: {count}")
+
+      # Collect unique error messages
+      errors = [entry["message"] for entry in logs if entry["level"] == "ERROR"]
+      unique_errors = set(errors)
+
+      if unique_errors:
+          print(f"\nUnique error messages ({len(unique_errors)}):")
+          for msg in sorted(unique_errors):
+              print(f"  - {msg}")
+      else:
+          print("\nNo errors found.")
+
+  # Example usage
+  sample_logs = [
+      {"level": "INFO", "message": "Service started", "timestamp": "2026-03-25T10:00:00"},
+      {"level": "ERROR", "message": "Connection timeout", "timestamp": "2026-03-25T10:01:00"},
+      {"level": "INFO", "message": "Request processed", "timestamp": "2026-03-25T10:02:00"},
+      {"level": "ERROR", "message": "Disk full", "timestamp": "2026-03-25T10:03:00"},
+      {"level": "WARNING", "message": "High memory", "timestamp": "2026-03-25T10:04:00"},
+      {"level": "ERROR", "message": "Connection timeout", "timestamp": "2026-03-25T10:05:00"},
+  ]
+
+  analyze_logs(sample_logs)
 ```
 
 ---
 
 ## Further Reading
 
-- [**Python Tutorial: Data Structures**](https://docs.python.org/3/tutorial/datastructures.html)  
-- [**W3Schools: Python Dictionaries**](https://www.w3schools.com/python/python_dictionaries.asp)  
-- [**Real Python: List Comprehensions**](https://realpython.com/list-comprehension-python/)  
+- [Python Tutorial: Data Structures](https://docs.python.org/3/tutorial/datastructures.html) - official guide to lists, dicts, sets, tuples, and their methods
+- [Real Python: List Comprehensions](https://realpython.com/list-comprehension-python/) - when to use them and when not to
+- [Python Collections Module](https://docs.python.org/3/library/collections.html) - Counter, defaultdict, OrderedDict, and other specialized containers
+- [Real Python: Dictionaries](https://realpython.com/python-dicts/) - comprehensive guide to dictionary patterns and best practices
 
 ---
 

--- a/Dev Zero/Python/files-and-apis.md
+++ b/Dev Zero/Python/files-and-apis.md
@@ -381,13 +381,14 @@ options:
 
 ```exercise
 title: "Build a Configuration-Driven API Client"
-description: "Write a Python script that reads API configuration from a JSON file, makes authenticated requests, handles errors gracefully, and saves results to a local file."
-requirements:
-  - "Read a config.json file containing: api_url, auth_token, output_file, and timeout"
-  - "Make a GET request to the API URL with the auth token in an Authorization header"
-  - "Handle connection errors, timeouts, and HTTP errors with meaningful messages"
-  - "Parse the JSON response and save it to the output file with pretty formatting"
-  - "Print a summary: status code, response size, and output file path"
+scenario: |
+  You need a reusable script that reads its configuration from a JSON file and makes authenticated API requests. Write a script that:
+
+  1. Reads a `config.json` file containing: `api_url`, `auth_token`, `output_file`, and `timeout`
+  2. Makes a GET request to the API URL with the auth token in an Authorization header
+  3. Handles connection errors, timeouts, and HTTP errors with meaningful messages
+  4. Parses the JSON response and saves it to the output file with pretty formatting
+  5. Prints a summary: status code, response size, and output file path
 hints:
   - "Use json.load() to read the config, requests.get() for the API call, json.dump() to write results"
   - "Set headers={'Authorization': f'Bearer {config[\"auth_token\"]}'}"

--- a/Dev Zero/Python/files-and-apis.md
+++ b/Dev Zero/Python/files-and-apis.md
@@ -1,6 +1,6 @@
 # Working with Files and APIs (Python)
 
-**Version:** 0.1  
+**Version:** 0.2
 **Year:** 2026
 
 ---
@@ -11,166 +11,451 @@ Copyright (c) 2025-2026 Ryan Thomas Robson / Robworks Software LLC. Licensed und
 
 ---
 
-Sysadmin automation often involves interacting with external data sources—whether they are local configuration files, system logs, or remote web services. Python makes these tasks straightforward with its built-in `json` module and the widely used `requests` library.
+Sysadmin automation usually boils down to two things: reading data from somewhere and acting on it. The "somewhere" is either the local filesystem (config files, logs, CSVs) or a remote API (monitoring services, cloud providers, notification systems). Python handles both with clean, consistent patterns.
+
+---
 
 ## Local File Operations
 
-Python uses the **context manager** pattern (`with` statement) to handle files safely. This ensures that a file is properly closed even if an error occurs during processing.
+Python uses the **context manager** pattern (`with` statement) to handle files safely. The file is guaranteed to close when the block exits, even if an error occurs mid-read.
 
 ### Reading and Writing
 
-[**`open()`**](https://docs.python.org/3/library/functions.html#open) is the primary function for file access.
+[**`open()`**](https://docs.python.org/3/library/functions.html#open) is the built-in function for file access.
 
 ```python
-# Reading a file line-by-line
+# Read an entire file into a string
 with open("/etc/hostname", "r") as f:
     hostname = f.read().strip()
-    print(f"System hostname is: {hostname}")
 
-# Writing to a new file
+# Read line by line (memory-efficient for large files)
+with open("/var/log/auth.log", "r") as f:
+    for line in f:
+        if "Failed password" in line:
+            print(line.strip())
+
+# Write to a file (overwrites existing content)
 with open("inventory.txt", "w") as f:
     f.write("web01\nweb02\ndb01\n")
 
-# Appending to an existing file
+# Append to an existing file
 with open("audit.log", "a") as f:
     f.write("2026-03-25: Updated server inventory.\n")
 ```
+
+### File Modes
+
+| Mode | Description | Creates File? | Truncates? |
+|------|-------------|---------------|------------|
+| `"r"` | Read (text) | No - raises FileNotFoundError | No |
+| `"w"` | Write (text) | Yes | Yes - empties the file |
+| `"a"` | Append (text) | Yes | No - adds to end |
+| `"x"` | Exclusive create | Yes - raises FileExistsError if exists | N/A |
+| `"rb"` | Read (binary) | No | No |
+| `"wb"` | Write (binary) | Yes | Yes |
+
+Binary modes (`"rb"`, `"wb"`) are needed for non-text files: images, compressed archives, protocol buffers, database dumps.
+
+### Modern Path Handling with `pathlib`
+
+The [**`pathlib`**](https://docs.python.org/3/library/pathlib.html) module (Python 3.4+) provides an object-oriented interface for filesystem paths. It's cleaner and more portable than string manipulation with `os.path`.
+
+```python
+from pathlib import Path
+
+# Build paths without worrying about separators
+log_dir = Path("/var/log")
+auth_log = log_dir / "auth.log"      # PosixPath('/var/log/auth.log')
+
+# Check existence and type
+auth_log.exists()                     # True
+auth_log.is_file()                    # True
+log_dir.is_dir()                      # True
+
+# Read and write in one step
+content = auth_log.read_text()
+Path("output.txt").write_text("hello\n")
+
+# List directory contents
+for p in log_dir.iterdir():
+    if p.suffix == ".log":
+        print(f"{p.name}: {p.stat().st_size} bytes")
+
+# Glob for pattern matching
+for p in log_dir.glob("*.log"):
+    print(p)
+
+# Recursive glob
+for p in Path("/etc").rglob("*.conf"):
+    print(p)
+```
+
+!!! tip "Prefer `pathlib` over `os.path`"
+    `os.path.join("/var", "log", "auth.log")` works, but `Path("/var") / "log" / "auth.log"` is more readable and gives you methods like `.read_text()`, `.exists()`, and `.glob()` for free. Most modern Python code and libraries accept `Path` objects wherever a string path works.
 
 ---
 
 ## Working with JSON
 
-JSON is the standard format for configuration files and API responses. Python's [**`json`**](https://docs.python.org/3/library/json.html) module converts JSON strings into Python dictionaries and lists.
+JSON is the standard format for configuration files and API responses. Python's [**`json`**](https://docs.python.org/3/library/json.html) module converts JSON strings to Python dictionaries and lists, and vice versa.
 
 ```python
 import json
 
-# Parsing a JSON file
-with open("config.json", "r") as f:
-    config = json.load(f)
+# Parse a JSON file
+with open("config.json") as f:
+    config = json.load(f)          # File -> dict/list
 
-# Accessing nested data
-log_level = config["logging"]["level"]
+# Parse a JSON string
+raw = '{"status": "ok", "count": 42}'
+data = json.loads(raw)             # String -> dict/list
 
-# Saving data to JSON
-new_config = {"debug": True, "port": 8080}
+# Write Python data as JSON
+new_config = {"debug": True, "port": 8080, "hosts": ["web01", "web02"]}
 with open("settings.json", "w") as f:
-    json.dump(new_config, f, indent=4)
+    json.dump(new_config, f, indent=2)  # indent for human-readable output
+
+# Convert Python data to a JSON string
+json_str = json.dumps(new_config, indent=2)
 ```
+
+**`json.load()`** reads from a file object. **`json.loads()`** parses a string. The "s" stands for "string." This is the most common source of confusion.
+
+---
+
+## Working with CSV
+
+Many sysadmin data sources (inventory exports, billing reports, monitoring data) come as CSV files.
+
+```python
+import csv
+
+# Read a CSV file
+with open("servers.csv") as f:
+    reader = csv.DictReader(f)       # Each row becomes a dict
+    for row in reader:
+        print(f"{row['hostname']}: {row['ip_address']}")
+
+# Write a CSV file
+servers = [
+    {"hostname": "web01", "ip": "10.0.0.1", "role": "frontend"},
+    {"hostname": "db01", "ip": "10.0.1.1", "role": "database"},
+]
+
+with open("inventory.csv", "w", newline="") as f:
+    writer = csv.DictWriter(f, fieldnames=["hostname", "ip", "role"])
+    writer.writeheader()
+    writer.writerows(servers)
+```
+
+`csv.DictReader` is almost always what you want - it maps each row to a dictionary using the header row as keys, so you access fields by name instead of index.
+
+---
+
+## Working with YAML
+
+YAML is common in configuration management (Ansible, Kubernetes, Docker Compose). It's not in the standard library, so you need the [**`PyYAML`**](https://pyyaml.org/) package.
+
+```bash
+pip install pyyaml
+```
+
+```python
+import yaml
+
+# Read a YAML file
+with open("playbook.yml") as f:
+    config = yaml.safe_load(f)        # Always use safe_load, never load()
+
+# Write YAML
+data = {"services": {"web": {"image": "nginx", "ports": ["80:80"]}}}
+with open("compose.yml", "w") as f:
+    yaml.dump(data, f, default_flow_style=False)
+```
+
+!!! warning "Always use `yaml.safe_load()`"
+    `yaml.load()` (without `safe_`) can execute arbitrary Python code embedded in the YAML file. This is a remote code execution vulnerability if you're loading untrusted input. Always use `yaml.safe_load()` unless you have a specific, verified reason not to.
 
 ---
 
 ## Interacting with APIs
 
-While Python's standard library includes `urllib`, the [**`requests`**](https://requests.readthedocs.io/) library is the industry standard for making HTTP calls. It must be installed via `pip`.
+While Python's standard library includes `urllib`, the [**`requests`**](https://requests.readthedocs.io/) library is the industry standard for HTTP calls. It handles encoding, sessions, headers, and error reporting with a clean interface.
 
 ```bash
 pip install requests
 ```
 
-### Making a GET Request
-
-Many modern monitoring and cloud services provide REST APIs.
+### GET Requests
 
 ```python
 import requests
 
-def get_service_status(service_id):
-    url = f"https://api.monitoring.io/v1/services/{service_id}"
-    response = requests.get(url)
-    
-    if response.status_code == 200:
-        data = response.json()
-        return data["status"]
-    else:
-        return f"Error: Received {response.status_code}"
+response = requests.get("https://api.github.com/repos/python/cpython")
 
-status = get_service_status("web-cluster-01")
-print(f"Service status: {status}")
+if response.status_code == 200:
+    repo = response.json()          # Parse JSON response body
+    print(f"Stars: {repo['stargazers_count']}")
+    print(f"Language: {repo['language']}")
+else:
+    print(f"Error: HTTP {response.status_code}")
 ```
 
-### Making a POST Request
-
-Use POST to send data, such as triggering a deployment or sending an alert.
+### POST Requests
 
 ```python
 import requests
-import json
 
-alert_payload = {
+alert = {
     "severity": "critical",
     "message": "CPU usage exceeded 95% on app01",
     "timestamp": "2026-03-25T14:30:00Z"
 }
 
 response = requests.post(
-    "https://api.pagerduty.com/alerts",
-    data=json.dumps(alert_payload),
-    headers={"Content-Type": "application/json"}
+    "https://hooks.slack.com/services/T00000/B00000/XXXXX",
+    json=alert                      # Automatically serializes and sets Content-Type
 )
 
-if response.ok:
+if response.ok:                     # True for any 2xx status
     print("Alert sent successfully.")
+```
+
+### Authentication and Headers
+
+```python
+import requests
+
+# API key in headers
+headers = {
+    "Authorization": "Bearer your-api-token-here",
+    "Accept": "application/json"
+}
+
+response = requests.get(
+    "https://api.cloudprovider.com/v1/instances",
+    headers=headers
+)
+
+# Basic auth
+response = requests.get(
+    "https://monitoring.internal/api/status",
+    auth=("username", "password")
+)
+```
+
+### Sessions and Connection Reuse
+
+When making multiple requests to the same host, use a **Session** to reuse TCP connections and persist headers:
+
+```python
+import requests
+
+session = requests.Session()
+session.headers.update({
+    "Authorization": "Bearer your-token",
+    "Accept": "application/json"
+})
+
+# All requests through this session include the headers above
+instances = session.get("https://api.cloud.com/v1/instances").json()
+volumes = session.get("https://api.cloud.com/v1/volumes").json()
+```
+
+### Handling Timeouts and Errors
+
+Network calls fail. Always set timeouts and handle errors:
+
+```python
+import requests
+
+try:
+    response = requests.get(
+        "https://api.example.com/status",
+        timeout=10                   # 10 seconds (connect + read)
+    )
+    response.raise_for_status()      # Raises HTTPError for 4xx/5xx
+    data = response.json()
+except requests.ConnectionError:
+    print("Could not connect to the API.")
+except requests.Timeout:
+    print("Request timed out after 10 seconds.")
+except requests.HTTPError as e:
+    print(f"API returned error: {e}")
+```
+
+### Pagination
+
+Many APIs return results in pages. You need to loop until there are no more pages:
+
+```python
+import requests
+
+def get_all_items(base_url, headers):
+    items = []
+    url = base_url
+
+    while url:
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+
+        items.extend(data["results"])
+        url = data.get("next")      # None when there are no more pages
+
+    return items
 ```
 
 ---
 
-## Interactive Quizzes: Files and APIs
+```terminal
+scenario: "Read a JSON config file, query an API, and write the results"
+steps:
+  - command: "cat config.json"
+    output: "{\n  \"api_url\": \"https://api.github.com/repos/python/cpython\",\n  \"output_file\": \"repo_info.json\",\n  \"timeout\": 10\n}"
+    narration: "A JSON configuration file that specifies the API endpoint, output file, and timeout. This separates configuration from code - a fundamental operations pattern."
+  - command: "python3 -c \"import json; config = json.load(open('config.json')); print(f'URL: {config[\\\"api_url\\\"]}')\""
+    output: "URL: https://api.github.com/repos/python/cpython"
+    narration: "Load and parse the JSON config file with json.load(). The result is a Python dictionary that you can access with bracket notation."
+  - command: "python3 -c \"import requests; r = requests.get('https://api.github.com/repos/python/cpython', timeout=10); print(f'Status: {r.status_code}'); print(f'Stars: {r.json()[\\\"stargazers_count\\\"]}')\""
+    output: "Status: 200\nStars: 65432"
+    narration: "Make a GET request to the GitHub API. The response.json() method parses the response body directly into a Python dictionary."
+  - command: "python3 -c \"import json; data = {'repo': 'cpython', 'stars': 65432}; print(json.dumps(data, indent=2))\""
+    output: "{\n  \"repo\": \"cpython\",\n  \"stars\": 65432\n}"
+    narration: "json.dumps() converts a Python dictionary back to a formatted JSON string. Use indent=2 for human-readable output when writing config files or API responses."
+  - command: "python3 -c \"from pathlib import Path; p = Path('/var/log'); logs = sorted(p.glob('*.log')); print(f'Found {len(logs)} log files'); [print(f'  {f.name}: {f.stat().st_size:,} bytes') for f in logs[:3]]\""
+    output: "Found 12 log files\n  auth.log: 245,678 bytes\n  kern.log: 89,012 bytes\n  syslog: 1,456,789 bytes"
+    narration: "pathlib makes file discovery clean and readable. The glob() method finds files by pattern, and stat() provides metadata like size."
+```
 
-Verify your understanding of Python's I/O and networking capabilities.
+---
+
+## Interactive Quizzes
 
 ```quiz
-question: "What is the primary benefit of using the `with open(...) as f:` syntax in Python?"
+question: "What is the primary benefit of using the `with open(...) as f:` syntax?"
 type: multiple-choice
 options:
-  - text: "It makes the code run significantly faster."
-    feedback: "The with statement is for safe resource management, not performance."
-  - text: "It automatically handles file closing, even if an exception occurs."
+  - text: "It makes file operations faster."
+    feedback: "The with statement is about safe resource management, not performance."
+  - text: "It automatically closes the file when the block exits, even if an exception occurs."
     correct: true
-    feedback: "Correct! The context manager (`with` statement) ensures that the file's `close()` method is called automatically when the block is exited, preventing resource leaks and potential file corruption."
-  - text: "It encrypts the file contents while they are open in memory."
-    feedback: "Encryption is a separate process. The with statement doesn't encrypt data."
-  - text: "It allows multiple processes to write to the same file simultaneously."
-    feedback: "Simultaneous access depends on OS file locks and how you open the file. The with statement doesn't solve this."
+    feedback: "Correct! The context manager ensures close() is called regardless of how the block exits - normal completion, return, or exception. Without it, an error mid-read could leave the file handle open."
+  - text: "It encrypts the file contents."
+    feedback: "The with statement handles resource lifecycle, not encryption."
+  - text: "It allows multiple processes to write simultaneously."
+    feedback: "Concurrent file access requires explicit file locking, not context managers."
 ```
 
 ```quiz
-question: "Which method in the `json` module should you use to parse a JSON-formatted string that is already in memory?"
+question: "What is the difference between `json.load()` and `json.loads()`?"
 type: multiple-choice
 options:
-  - text: "json.load()"
-    feedback: "json.load() is used to read and parse from a file-like object."
-  - text: "json.parse()"
-    feedback: "Python's json module doesn't have a parse() method."
-  - text: "json.loads()"
+  - text: "load() is faster than loads()."
+    feedback: "Performance isn't the distinction. They accept different input types."
+  - text: "load() reads from a file object, loads() parses a string."
     correct: true
-    feedback: "Correct! `json.loads()` (short for 'load string') is used to parse a JSON string, while `json.load()` is used to read and parse from a file-like object."
-  - text: "json.read()"
-    feedback: "The method is loads(), not read()."
+    feedback: "Correct! json.load(file_object) reads and parses from a file. json.loads(string) parses a JSON-formatted string already in memory. The 's' stands for 'string'."
+  - text: "loads() can parse YAML as well as JSON."
+    feedback: "loads() only handles JSON. You need the PyYAML library for YAML."
+  - text: "load() is deprecated in favor of loads()."
+    feedback: "Both functions are current and serve different purposes."
 ```
 
 ```quiz
-question: "How do you access the JSON response body from a `requests` Response object?"
+question: "Why should you always set a `timeout` parameter when using `requests.get()`?"
 type: multiple-choice
 options:
-  - text: "response.data"
-    feedback: "Response objects don't have a .data attribute by default in requests."
-  - text: "response.json()"
+  - text: "It makes the request faster."
+    feedback: "Timeouts don't speed up successful requests - they limit how long you wait for unresponsive servers."
+  - text: "Without a timeout, the request can hang indefinitely if the server doesn't respond."
     correct: true
-    feedback: "Correct! The `requests` library provides a convenient `.json()` method on the response object that automatically parses the response body as JSON."
-  - text: "json.parse(response.text)"
-    feedback: "While you could use json.loads(response.text), the .json() method is the more Pythonic way."
-  - text: "response.body"
-    feedback: "The attribute is usually .text or .content, but the method for JSON is .json()."
+    feedback: "Correct! The default timeout is None (wait forever). If a server stops responding, your script blocks indefinitely. Always set a reasonable timeout so your automation can detect failures and move on."
+  - text: "The server requires a timeout header."
+    feedback: "Timeouts are client-side. The server doesn't know or care about your timeout value."
+  - text: "It prevents rate limiting."
+    feedback: "Timeouts and rate limits are separate concepts. A timeout protects against unresponsive servers."
+```
+
+---
+
+```exercise
+title: "Build a Configuration-Driven API Client"
+description: "Write a Python script that reads API configuration from a JSON file, makes authenticated requests, handles errors gracefully, and saves results to a local file."
+requirements:
+  - "Read a config.json file containing: api_url, auth_token, output_file, and timeout"
+  - "Make a GET request to the API URL with the auth token in an Authorization header"
+  - "Handle connection errors, timeouts, and HTTP errors with meaningful messages"
+  - "Parse the JSON response and save it to the output file with pretty formatting"
+  - "Print a summary: status code, response size, and output file path"
+hints:
+  - "Use json.load() to read the config, requests.get() for the API call, json.dump() to write results"
+  - "Set headers={'Authorization': f'Bearer {config[\"auth_token\"]}'}"
+  - "Wrap the request in try/except for requests.ConnectionError, requests.Timeout, requests.HTTPError"
+  - "Use response.raise_for_status() after the request to convert HTTP errors to exceptions"
+solution: |
+  #!/usr/bin/env python3
+  """Configuration-driven API client with error handling."""
+
+  import json
+  import sys
+  import requests
+
+  def main():
+      # Load configuration
+      try:
+          with open("config.json") as f:
+              config = json.load(f)
+      except FileNotFoundError:
+          print("Error: config.json not found")
+          sys.exit(1)
+      except json.JSONDecodeError as e:
+          print(f"Error: Invalid JSON in config.json: {e}")
+          sys.exit(1)
+
+      # Make the API request
+      headers = {"Authorization": f"Bearer {config['auth_token']}"}
+
+      try:
+          response = requests.get(
+              config["api_url"],
+              headers=headers,
+              timeout=config.get("timeout", 10)
+          )
+          response.raise_for_status()
+      except requests.ConnectionError:
+          print(f"Error: Could not connect to {config['api_url']}")
+          sys.exit(1)
+      except requests.Timeout:
+          print(f"Error: Request timed out after {config.get('timeout', 10)}s")
+          sys.exit(1)
+      except requests.HTTPError as e:
+          print(f"Error: API returned {e.response.status_code}")
+          sys.exit(1)
+
+      # Save results
+      data = response.json()
+      output_path = config["output_file"]
+
+      with open(output_path, "w") as f:
+          json.dump(data, f, indent=2)
+
+      print(f"Status: {response.status_code}")
+      print(f"Response size: {len(response.content):,} bytes")
+      print(f"Saved to: {output_path}")
+
+  if __name__ == "__main__":
+      main()
 ```
 
 ---
 
 ## Further Reading
 
-- [**Python Docs: Reading and Writing Files**](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files)  
-- [**Requests: Quickstart Guide**](https://requests.readthedocs.io/en/latest/user/quickstart/)  
-- [**Working with JSON Data in Python**](https://realpython.com/python-json/)  
+- [Python Docs: Reading and Writing Files](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files) - official guide to file I/O
+- [Python Docs: pathlib](https://docs.python.org/3/library/pathlib.html) - object-oriented filesystem path handling
+- [Requests: Quickstart Guide](https://requests.readthedocs.io/en/latest/user/quickstart/) - getting started with the requests library
+- [Real Python: Working with JSON](https://realpython.com/python-json/) - complete guide to JSON parsing, serialization, and best practices
 
 ---
 

--- a/Dev Zero/Python/python_dev0_introduction.md
+++ b/Dev Zero/Python/python_dev0_introduction.md
@@ -1,6 +1,6 @@
 # Introduction to Python for Sysadmins
 
-**Version:** 0.1  
+**Version:** 0.2
 **Year:** 2026
 
 ---
@@ -11,35 +11,108 @@ Copyright (c) 2025-2026 Ryan Thomas Robson / Robworks Software LLC. Licensed und
 
 ---
 
-Python has become the de facto standard for systems automation and tool building. Its clean syntax and extensive standard library make it an ideal choice for replacing complex shell scripts and integrating with modern APIs.
+Python has become the de facto standard for systems automation and tool building. Its clean syntax and extensive standard library make it an ideal choice for replacing complex shell scripts and integrating with modern APIs. If you can write a Bash one-liner, you can learn Python - and the payoff is scripts that are easier to read, test, and maintain.
+
+```mermaid
+graph TD
+    A[Python Source Code .py] --> B[Interpreter]
+    B --> C[Standard Library]
+    B --> D[External Packages pip]
+    B --> E[System Operations]
+    E --> F[Files]
+    E --> G[Network]
+    E --> H[Subprocesses]
+```
+
+---
+
+## Python 2 vs Python 3
+
+Python 2 reached end of life on January 1, 2020. No security patches, no bug fixes, nothing. Every new project should use Python 3, and most distributions now ship Python 3 as the default `python3` binary.
+
+The practical differences you'll encounter:
+
+| Feature | Python 2 | Python 3 |
+|---------|---------|---------|
+| Print | `print "hello"` (statement) | `print("hello")` (function) |
+| Division | `5 / 2` returns `2` | `5 / 2` returns `2.5` |
+| Strings | ASCII by default | Unicode by default |
+| Input | `raw_input()` | `input()` |
+
+If you encounter a legacy script that starts with `#!/usr/bin/python` (without the `3`), check which version it targets before running it.
+
+!!! tip "Always use `python3` explicitly"
+    On many systems, `python` may point to Python 2 or may not exist at all. Always use `python3` and `pip3` (or `python3 -m pip`) in your scripts and documentation. This avoids ambiguity on systems where both versions are installed.
+
+---
 
 ## Environment Setup
 
-One of the most important concepts in Python development is the **Virtual Environment**. It allows you to create isolated spaces for your projects, ensuring that dependencies for one script don't break another.
+One of the most important concepts in Python development is the **virtual environment**. It creates an isolated space for each project's dependencies, so installing a library for one script doesn't break another.
+
+### Why Virtual Environments Matter
+
+Without a virtual environment, `pip install` puts packages in the system Python's `site-packages` directory. This causes problems:
+
+- Two projects need different versions of the same library.
+- A `pip install --upgrade` breaks a working script because another script depended on the old version.
+- System tools written in Python (like `apt` on Ubuntu) can break if you modify the system Python's packages.
 
 ### Using `venv`
 
-[**`venv`**](https://docs.python.org/3/library/venv.html) is the standard tool for creating virtual environments in Python 3.
+[**`venv`**](https://docs.python.org/3/library/venv.html) is the standard tool for creating virtual environments. It ships with Python 3 - no installation needed.
 
 ```bash
-# Create a virtual environment in a folder named 'venv'
+# Create a virtual environment in a directory named 'venv'
 python3 -m venv venv
 
-# Activate the environment
+# Activate the environment (your prompt changes to show it's active)
 source venv/bin/activate
 
-# Install a package (e.g., requests)
+# Now pip installs go into this environment only
 pip install requests
+
+# See what's installed in this environment
+pip list
+
+# Save dependencies to a file (for reproducibility)
+pip freeze > requirements.txt
 
 # Deactivate when finished
 deactivate
 ```
 
+```terminal
+scenario: "Set up a virtual environment, install a package, and manage dependencies"
+steps:
+  - command: "python3 -m venv venv"
+    output: ""
+    narration: "Create a virtual environment directory named 'venv' in the current project folder. This copies the Python interpreter and creates an isolated site-packages directory."
+  - command: "source venv/bin/activate"
+    output: "(venv) $"
+    narration: "Activate the environment. Your shell prompt changes to show you're working inside the virtual environment. All python3 and pip commands now use this environment."
+  - command: "pip install requests"
+    output: "Collecting requests\n  Downloading requests-2.31.0-py3-none-any.whl (62 kB)\nCollecting urllib3<3,>=1.21.1\nCollecting certifi>=2017.4.17\nCollecting charset-normalizer<4,>=2\nCollecting idna<4,>=2.5\nInstalling collected packages: urllib3, certifi, charset-normalizer, idna, requests\nSuccessfully installed certifi-2024.2.2 charset-normalizer-3.3.2 idna-3.6 requests-2.31.0 urllib3-2.2.1"
+    narration: "Install the requests library. Notice pip also installs its dependencies (urllib3, certifi, etc.). These are installed only within this virtual environment, not system-wide."
+  - command: "pip freeze"
+    output: "certifi==2024.2.2\ncharset-normalizer==3.3.2\nidna==3.6\nrequests==2.31.0\nurllib3==2.2.1"
+    narration: "pip freeze lists every installed package with exact versions. Redirect this to requirements.txt so others can recreate your environment."
+  - command: "pip freeze > requirements.txt"
+    output: ""
+    narration: "Save the dependency list. Another developer (or your production server) can now run pip install -r requirements.txt to get the exact same packages."
+  - command: "deactivate"
+    output: "$"
+    narration: "Exit the virtual environment and return to your system Python. The packages you installed are still inside the venv directory but are no longer on your PATH."
+```
+
+!!! warning "System Python vs user Python"
+    On Ubuntu 23.04+, `pip install` outside a virtual environment is blocked by default (PEP 668). You'll see an "externally-managed-environment" error. This is by design - it prevents you from accidentally breaking system tools. Always use a virtual environment for project dependencies.
+
 ---
 
 ## Basic Syntax
 
-Python uses **indentation** to define blocks of code, rather than braces or keywords. This enforces readability but can be a trap for those used to other languages.
+Python uses **indentation** to define blocks of code, rather than braces or keywords. This enforces readability but can trip you up if you mix tabs and spaces (don't - use spaces, and configure your editor for 4-space indentation).
 
 ```python
 # A simple script to check disk usage
@@ -48,7 +121,7 @@ import shutil
 def check_disk(path):
     total, used, free = shutil.disk_usage(path)
     percent_used = (used / total) * 100
-    
+
     if percent_used > 90:
         print(f"WARNING: Disk usage at {percent_used:.2f}% on {path}")
     else:
@@ -59,69 +132,296 @@ check_disk("/")
 
 ### Key Differences from Shell Scripting
 
-- **Variables**: No `$` prefix (e.g., `name = "Junie"` instead of `name="Junie"`).
-- **Strings**: Single and double quotes are interchangeable; f-strings (`f"{var}"`) are the preferred way to format.
-- **Lists and Dictionaries**: Built-in support for complex data structures that are cumbersome in shell.
-- **Import System**: Access powerful functionality via modules (`import os`, `import json`).
+| Shell | Python | Notes |
+|-------|--------|-------|
+| `name="Junie"` | `name = "Junie"` | No `$` prefix, spaces around `=` |
+| `echo "$name"` | `print(name)` or `print(f"{name}")` | f-strings for formatting |
+| Arrays are awkward | Lists, dicts, sets built in | First-class data structures |
+| `source util.sh` | `import util` | Module system with namespaces |
+| `$1`, `$2` | `sys.argv[1]`, `sys.argv[2]` | Or use `argparse` for flags |
+| `[[ -f file ]]` | `os.path.isfile("file")` | Or `pathlib.Path("file").is_file()` |
+
+### The REPL
+
+Python ships with an interactive interpreter - the **REPL** (Read-Eval-Print Loop). It's invaluable for testing snippets, exploring modules, and debugging.
+
+```bash
+$ python3
+>>> import os
+>>> os.cpu_count()
+8
+>>> os.getenv("HOME")
+'/home/admin'
+>>> help(os.path.isfile)
+>>> exit()
+```
 
 ---
 
-## Interactive Quizzes: Python Basics
+## Variables and Types
 
-Verify your understanding of Python fundamentals.
+Python is **dynamically typed** - you don't declare variable types. The interpreter infers them from the assigned value.
+
+```python
+hostname = "web01"           # str
+port = 8080                  # int
+load_average = 2.45          # float
+is_active = True             # bool
+tags = ["prod", "us-east"]   # list
+config = {"debug": False}    # dict
+```
+
+### Type Checking at Runtime
+
+```python
+# Check a variable's type
+type(hostname)    # <class 'str'>
+type(port)        # <class 'int'>
+
+# Convert between types
+str(port)         # "8080"
+int("8080")       # 8080
+float("2.45")     # 2.45
+```
+
+### Common Built-in Functions
+
+These are functions you'll use constantly:
+
+| Function | Purpose | Example |
+|----------|---------|---------|
+| `len()` | Length of a collection or string | `len("hello")` returns `5` |
+| `range()` | Generate a sequence of numbers | `range(5)` produces `0, 1, 2, 3, 4` |
+| `type()` | Check a value's type | `type(42)` returns `<class 'int'>` |
+| `str()`, `int()`, `float()` | Type conversion | `int("42")` returns `42` |
+| `sorted()` | Return a sorted copy | `sorted([3, 1, 2])` returns `[1, 2, 3]` |
+| `enumerate()` | Loop with index | `for i, v in enumerate(items)` |
+| `zip()` | Loop over multiple lists | `for a, b in zip(names, ips)` |
+| `input()` | Read user input | `name = input("Enter name: ")` |
+
+---
+
+## Error Handling
+
+Things go wrong: files are missing, networks are down, users provide bad input. Python uses `try`/`except` blocks to handle errors gracefully instead of crashing.
+
+```python
+import json
+
+def load_config(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Config file not found: {path}")
+        return {}
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON in {path}: {e}")
+        return {}
+
+config = load_config("settings.json")
+```
+
+The pattern is: `try` the operation, `except` specific errors you expect, and handle them meaningfully. Avoid bare `except:` (catches everything including keyboard interrupts) - always catch specific exception types.
+
+---
+
+## Making Scripts Executable
+
+To run a Python script like a regular command (without typing `python3` every time):
+
+```python
+#!/usr/bin/env python3
+"""Check disk usage and warn if above threshold."""
+
+import shutil
+import sys
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "/"
+    total, used, free = shutil.disk_usage(path)
+    percent = (used / total) * 100
+
+    if percent > 90:
+        print(f"CRITICAL: {path} at {percent:.1f}%")
+        sys.exit(2)
+    elif percent > 75:
+        print(f"WARNING: {path} at {percent:.1f}%")
+        sys.exit(1)
+    else:
+        print(f"OK: {path} at {percent:.1f}%")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+```
+
+```bash
+# Make it executable
+chmod +x check_disk.py
+
+# Run it directly
+./check_disk.py /home
+```
+
+The `#!/usr/bin/env python3` shebang line tells the OS to use whichever `python3` is on the PATH. The `if __name__ == "__main__"` guard ensures `main()` only runs when the script is executed directly, not when it's imported as a module by another script.
+
+```code-walkthrough
+title: "Anatomy of a Python Script"
+description: "The structure and conventions of a well-organized Python CLI script."
+code: |
+  #!/usr/bin/env python3
+  """Check disk usage and warn if above threshold."""
+
+  import shutil
+  import sys
+
+  def main():
+      path = sys.argv[1] if len(sys.argv) > 1 else "/"
+      total, used, free = shutil.disk_usage(path)
+      percent = (used / total) * 100
+
+      if percent > 90:
+          print(f"CRITICAL: {path} at {percent:.1f}%")
+          sys.exit(2)
+      elif percent > 75:
+          print(f"WARNING: {path} at {percent:.1f}%")
+          sys.exit(1)
+      else:
+          print(f"OK: {path} at {percent:.1f}%")
+          sys.exit(0)
+
+  if __name__ == "__main__":
+      main()
+annotations:
+  - line: 1
+    text: "The shebang line. '#!/usr/bin/env python3' uses env to find python3 on the PATH, making the script portable across systems where Python is installed in different locations."
+  - line: 2
+    text: "A docstring at the top of the file documents what the script does. This shows up in help() and in tools that generate documentation."
+  - line: 4
+    text: "Standard library imports come first, one per line, in alphabetical order. This is the convention enforced by tools like isort."
+  - line: 7
+    text: "Wrapping logic in a main() function keeps the global namespace clean and makes the script testable - you can import and call main() from a test."
+  - line: 8
+    text: "A conditional expression (ternary) provides a default value if no argument is given. sys.argv[0] is always the script name, sys.argv[1] is the first argument."
+  - line: 9
+    text: "Tuple unpacking assigns all three return values from disk_usage() in one line. This is more readable than accessing them by index."
+  - line: 13
+    text: "Exit codes follow the Nagios/monitoring convention: 0 = OK, 1 = WARNING, 2 = CRITICAL. This makes the script usable as a monitoring check."
+  - line: 22
+    text: "The __name__ guard. When Python runs a file directly, __name__ is set to '__main__'. When the file is imported by another script, __name__ is set to the module name - so main() won't run on import."
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
-question: "What is the primary reason for using a Virtual Environment in Python?"
+question: "What is the primary reason for using a virtual environment in Python?"
 type: multiple-choice
 options:
   - text: "To make Python scripts run faster."
-    feedback: "Virtual environments are for isolation, not performance optimization."
+    feedback: "Virtual environments are for dependency isolation, not performance."
   - text: "To isolate project dependencies and avoid version conflicts."
     correct: true
-    feedback: "Correct! Virtual environments ensure that each project has its own set of libraries, preventing 'dependency hell' where one project needs version A of a library and another needs version B."
+    feedback: "Correct! Virtual environments ensure that each project has its own set of libraries, preventing conflicts where one project needs version A and another needs version B."
   - text: "To encrypt the source code for security."
-    feedback: "Isolation does not mean encryption. The source code remains visible."
+    feedback: "Virtual environments don't provide encryption - they isolate package installations."
   - text: "To compile Python into a binary executable."
-    feedback: "Tools like PyInstaller are used for compilation, not venv."
+    feedback: "Tools like PyInstaller handle compilation. Virtual environments manage dependencies."
 ```
 
 ```quiz
-question: "How does Python primarily define blocks of code (like the body of a function or a loop)?"
+question: "How does Python define blocks of code (function bodies, loop bodies, conditionals)?"
 type: multiple-choice
 options:
-  - text: "Using curly braces `{ }`."
-    feedback: "Languages like C, Java, and Perl use braces. Python does not."
-  - text: "Using `BEGIN` and `END` keywords."
-    feedback: "Languages like Ruby or Pascal use BEGIN/END. Python uses whitespace."
+  - text: "Using curly braces { }."
+    feedback: "C, Java, and JavaScript use braces. Python uses indentation."
+  - text: "Using BEGIN and END keywords."
+    feedback: "Ruby and Pascal use BEGIN/END. Python relies on whitespace."
   - text: "Using consistent indentation (whitespace)."
     correct: true
-    feedback: "Correct! Python is unique in using whitespace (indentation) to define block structure. This is one of the features that contributes to its readability."
-  - text: "Using semicolons `;` at the end of every line."
-    feedback: "Semicolons are optional in Python and are not used to define blocks."
+    feedback: "Correct! Python uses indentation (conventionally 4 spaces) to define block structure. This enforced consistency is one of the reasons Python code tends to be readable."
+  - text: "Using semicolons at the end of every line."
+    feedback: "Semicolons are optional statement separators in Python and are rarely used."
 ```
 
 ```quiz
-question: "Which tool is the standard package manager for Python?"
+question: "What does `if __name__ == '__main__':` do in a Python script?"
 type: multiple-choice
 options:
-  - text: "apt"
-    feedback: "apt is a system package manager for Debian-based Linux distributions."
-  - text: "npm"
-    feedback: "npm is the package manager for Node.js."
-  - text: "pip"
+  - text: "It's required syntax to start a Python program."
+    feedback: "Python scripts run fine without it. It's a convention, not a requirement."
+  - text: "It ensures the code only runs when the script is executed directly, not when imported as a module."
     correct: true
-    feedback: "Correct! `pip` is the standard tool for installing and managing Python packages from the Python Package Index (PyPI)."
-  - text: "cpan"
-    feedback: "cpan is the package manager for Perl."
+    feedback: "Correct! When Python runs a file directly, __name__ is set to '__main__'. When the file is imported, __name__ is set to the module name. This guard lets you write files that work both as scripts and as importable modules."
+  - text: "It runs the code with elevated privileges."
+    feedback: "Python doesn't have a built-in privilege escalation mechanism. Use sudo or setuid for that."
+  - text: "It compiles the script before execution."
+    feedback: "Python compiles to bytecode automatically. The __name__ guard controls execution flow, not compilation."
+```
+
+---
+
+```exercise
+title: "Write a CLI Disk Usage Checker"
+description: "Create a Python script that checks disk usage for one or more paths and reports their status using exit codes compatible with monitoring systems."
+requirements:
+  - "Accept one or more filesystem paths as command-line arguments (default to '/' if none provided)"
+  - "For each path, display the usage percentage formatted to one decimal place"
+  - "Exit with code 2 if any path exceeds 90%, code 1 if any exceeds 75%, code 0 otherwise"
+  - "Handle the case where a path doesn't exist (print an error message and skip it)"
+  - "Use a shebang line and __name__ guard"
+hints:
+  - "Use shutil.disk_usage(path) to get total, used, and free bytes"
+  - "sys.argv[1:] gives you all arguments after the script name - default to ['/'] if empty"
+  - "Track the worst exit code across all paths and use it as the final exit code"
+  - "Wrap disk_usage() in a try/except to catch OSError for invalid paths"
+solution: |
+  #!/usr/bin/env python3
+  """Check disk usage for one or more paths."""
+
+  import shutil
+  import sys
+
+  def check_path(path):
+      """Return (message, exit_code) for a single path."""
+      try:
+          total, used, free = shutil.disk_usage(path)
+      except OSError as e:
+          return f"ERROR: {path} - {e}", 2
+
+      percent = (used / total) * 100
+      if percent > 90:
+          return f"CRITICAL: {path} at {percent:.1f}%", 2
+      elif percent > 75:
+          return f"WARNING: {path} at {percent:.1f}%", 1
+      else:
+          return f"OK: {path} at {percent:.1f}%", 0
+
+  def main():
+      paths = sys.argv[1:] or ["/"]
+      worst_code = 0
+
+      for path in paths:
+          message, code = check_path(path)
+          print(message)
+          worst_code = max(worst_code, code)
+
+      sys.exit(worst_code)
+
+  if __name__ == "__main__":
+      main()
 ```
 
 ---
 
 ## Further Reading
 
-- [**Python Official Documentation**](https://docs.python.org/)  
-- [**Real Python: Virtual Environments**](https://realpython.com/python-virtual-environments-a-primer/)  
-- [**Automate the Boring Stuff with Python**](https://automatetheboringstuff.com/)  
+- [Python Official Documentation](https://docs.python.org/) - the definitive reference for all standard library modules
+- [Real Python: Virtual Environments](https://realpython.com/python-virtual-environments-a-primer/) - in-depth guide to venv, virtualenv, and environment management
+- [Automate the Boring Stuff with Python](https://automatetheboringstuff.com/) - practical guide focused on automation tasks
+- [PEP 8 Style Guide](https://peps.python.org/pep-0008/) - the official Python style conventions
 
 ---
 

--- a/Dev Zero/Python/python_dev0_introduction.md
+++ b/Dev Zero/Python/python_dev0_introduction.md
@@ -306,7 +306,7 @@ annotations:
     text: "A conditional expression (ternary) provides a default value if no argument is given. sys.argv[0] is always the script name, sys.argv[1] is the first argument."
   - line: 9
     text: "Tuple unpacking assigns all three return values from disk_usage() in one line. This is more readable than accessing them by index."
-  - line: 13
+  - line: 14
     text: "Exit codes follow the Nagios/monitoring convention: 0 = OK, 1 = WARNING, 2 = CRITICAL. This makes the script usable as a monitoring check."
   - line: 22
     text: "The __name__ guard. When Python runs a file directly, __name__ is set to '__main__'. When the file is imported by another script, __name__ is set to the module name - so main() won't run on import."
@@ -365,13 +365,14 @@ options:
 
 ```exercise
 title: "Write a CLI Disk Usage Checker"
-description: "Create a Python script that checks disk usage for one or more paths and reports their status using exit codes compatible with monitoring systems."
-requirements:
-  - "Accept one or more filesystem paths as command-line arguments (default to '/' if none provided)"
-  - "For each path, display the usage percentage formatted to one decimal place"
-  - "Exit with code 2 if any path exceeds 90%, code 1 if any exceeds 75%, code 0 otherwise"
-  - "Handle the case where a path doesn't exist (print an error message and skip it)"
-  - "Use a shebang line and __name__ guard"
+scenario: |
+  You need a monitoring script that checks disk usage across multiple filesystems. Write a Python script that:
+
+  1. Accepts one or more filesystem paths as command-line arguments (default to `/` if none provided)
+  2. For each path, displays the usage percentage formatted to one decimal place
+  3. Exits with code 2 if any path exceeds 90%, code 1 if any exceeds 75%, code 0 otherwise
+  4. Handles the case where a path doesn't exist (prints an error message and skips it)
+  5. Uses a shebang line and `__name__` guard
 hints:
   - "Use shutil.disk_usage(path) to get total, used, and free bytes"
   - "sys.argv[1:] gives you all arguments after the script name - default to ['/'] if empty"

--- a/Dev Zero/Python/system-automation.md
+++ b/Dev Zero/Python/system-automation.md
@@ -504,14 +504,15 @@ options:
 
 ```exercise
 title: "Write a System Health Checker"
-description: "Create a command-line tool that checks disk usage, service status, and port reachability, then reports results with proper logging and exit codes."
-requirements:
-  - "Accept --services (list of systemd service names) and --disk-paths (list of filesystem paths) as arguments"
-  - "Check each service with systemctl is-active via subprocess"
-  - "Check each disk path with shutil.disk_usage, warning at 80% and critical at 90%"
-  - "Use the logging module for all output (not print)"
-  - "Support --verbose flag that enables DEBUG-level logging"
-  - "Exit with code 0 if all checks pass, 1 for warnings, 2 for critical failures"
+scenario: |
+  Your team needs a monitoring tool that can be run from cron or a monitoring system. Write a command-line health checker that:
+
+  1. Accepts `--services` (list of systemd service names) and `--disk-paths` (list of filesystem paths) as arguments
+  2. Checks each service with `systemctl is-active` via subprocess
+  3. Checks each disk path with `shutil.disk_usage`, warning at 80% and critical at 90%
+  4. Uses the `logging` module for all output (not `print`)
+  5. Supports a `--verbose` flag that enables DEBUG-level logging
+  6. Exits with code 0 if all checks pass, 1 for warnings, 2 for critical failures
 hints:
   - "Use argparse with nargs='+' for arguments that accept multiple values"
   - "subprocess.run(['systemctl', 'is-active', name], capture_output=True, text=True) returns the status"

--- a/Dev Zero/Python/system-automation.md
+++ b/Dev Zero/Python/system-automation.md
@@ -1,6 +1,6 @@
 # System Automation with Python
 
-**Version:** 0.1  
+**Version:** 0.2
 **Year:** 2026
 
 ---
@@ -11,173 +11,593 @@ Copyright (c) 2025-2026 Ryan Thomas Robson / Robworks Software LLC. Licensed und
 
 ---
 
-Python's real power for sysadmins lies in its ability to interact with the underlying operating system. Whether you are managing files, running external commands, or parsing command-line arguments, Python provides robust modules that are often more reliable and readable than complex Bash scripts.
-
-## Core Automation Modules
-
-Python includes several built-in modules specifically designed for system tasks.
-
-- [**`os`**](https://docs.python.org/3/library/os.html): Miscellaneous operating system interfaces (env vars, directory listing).
-- [**`sys`**](https://docs.python.org/3/library/sys.html): System-specific parameters and functions (command-line arguments, exit codes).
-- [**`shutil`**](https://docs.python.org/3/library/shutil.html): High-level file operations (copying, moving, archiving).
-- [**`subprocess`**](https://docs.python.org/3/library/subprocess.html): Running external commands and capturing their output.
+Python's real power for sysadmins lies in its ability to interact with the operating system. Whether you're managing files, running external commands, parsing arguments, or building monitoring checks, Python provides robust modules that are more reliable, testable, and readable than complex Bash scripts.
 
 ---
 
-## Managing Files and Directories
+## File and Directory Operations
 
-While Bash is great for quick file operations, Python's `os` and `shutil` modules provide better error handling and cross-platform compatibility.
+### `os` Module Basics
 
-### Directory Listing and Navigation
+The [**`os`**](https://docs.python.org/3/library/os.html) module provides low-level operating system interfaces.
 
 ```python
 import os
 
-# Get current working directory
+# Current working directory
 cwd = os.getcwd()
 
-# List all files in a directory
-for filename in os.listdir("/var/log"):
-    if filename.endswith(".log"):
-        print(f"Found log file: {filename}")
+# Environment variables
+home = os.getenv("HOME")
+debug = os.getenv("DEBUG", "false")    # Default if not set
 
-# Check if a path exists and is a file
-if os.path.isfile("/etc/hosts"):
-    print("Hosts file exists.")
+# List directory contents
+for entry in os.listdir("/var/log"):
+    full_path = os.path.join("/var/log", entry)
+    if os.path.isfile(full_path):
+        size = os.path.getsize(full_path)
+        print(f"{entry}: {size:,} bytes")
+
+# Create directories
+os.makedirs("/tmp/backup/2026/03", exist_ok=True)  # Creates parents, no error if exists
 ```
 
-### High-Level File Operations
+### `pathlib` for Modern File Operations
+
+[**`pathlib`**](https://docs.python.org/3/library/pathlib.html) provides a cleaner interface for everything `os.path` does.
+
+```python
+from pathlib import Path
+
+# Build paths
+log_dir = Path("/var/log")
+backup_dir = Path("/tmp/backup") / "2026" / "03"
+backup_dir.mkdir(parents=True, exist_ok=True)
+
+# Find files by pattern
+for log_file in log_dir.glob("*.log"):
+    print(f"{log_file.name}: {log_file.stat().st_size:,} bytes")
+
+# Recursive search
+for conf in Path("/etc").rglob("*.conf"):
+    print(conf)
+```
+
+### `shutil` for High-Level Operations
+
+[**`shutil`**](https://docs.python.org/3/library/shutil.html) handles operations that work on entire files and directory trees.
 
 ```python
 import shutil
-import os
 
-# Copy a file
-shutil.copy2("config.yaml", "config.yaml.bak")  # copy2 preserves metadata
+# Copy a file (preserves metadata with copy2)
+shutil.copy2("config.yaml", "config.yaml.bak")
 
 # Move a file
 shutil.move("temp_data.csv", "/data/archives/")
 
-# Recursively delete a directory (equivalent to rm -rf)
-if os.path.exists("old_project"):
-    shutil.rmtree("old_project")
+# Copy an entire directory tree
+shutil.copytree("/etc/nginx", "/tmp/nginx-backup")
+
+# Delete a directory tree (equivalent to rm -rf)
+shutil.rmtree("/tmp/nginx-backup")
+
+# Create a compressed archive
+shutil.make_archive("/tmp/logs-backup", "gztar", "/var/log")
+# Creates /tmp/logs-backup.tar.gz
+```
+
+### `tempfile` for Safe Temporary Files
+
+The [**`tempfile`**](https://docs.python.org/3/library/tempfile.html) module creates temporary files and directories that are cleaned up automatically.
+
+```python
+import tempfile
+
+# Temporary file (auto-deleted when closed)
+with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+    tmp.write('{"status": "processing"}')
+    print(f"Temp file: {tmp.name}")
+
+# Temporary directory (auto-deleted when context exits)
+with tempfile.TemporaryDirectory() as tmpdir:
+    work_file = Path(tmpdir) / "output.txt"
+    work_file.write_text("intermediate results")
+    # Process files in tmpdir...
+# Directory and contents are gone here
 ```
 
 ---
 
 ## Running External Commands
 
-The [**`subprocess`**](https://docs.python.org/3/library/subprocess.html) module is the modern way to run shell commands from Python.
+The [**`subprocess`**](https://docs.python.org/3/library/subprocess.html) module is the standard way to run shell commands from Python.
 
-### Capturing Output
+### `subprocess.run()` - The Default Choice
 
-The `subprocess.run()` function is the recommended approach for most tasks.
+`subprocess.run()` executes a command, waits for it to finish, and returns the result.
 
 ```python
 import subprocess
 
-# Run a simple command and capture its output
-result = subprocess.run(["df", "-h", "/"], capture_output=True, text=True)
+# Run a command and capture output
+result = subprocess.run(
+    ["df", "-h", "/"],
+    capture_output=True,
+    text=True                        # Return strings, not bytes
+)
 
 if result.returncode == 0:
-    print("Disk usage for root partition:")
     print(result.stdout)
 else:
-    print(f"Error running df: {result.stderr}")
+    print(f"Error: {result.stderr}")
+```
+
+### Capturing stdout and stderr Separately
+
+```python
+# Capture both streams
+result = subprocess.run(
+    ["systemctl", "status", "nginx"],
+    capture_output=True,
+    text=True
+)
+
+print(f"Exit code: {result.returncode}")
+print(f"stdout:\n{result.stdout}")
+print(f"stderr:\n{result.stderr}")
+```
+
+### Checking Return Codes
+
+```python
+# Raise an exception if the command fails
+try:
+    result = subprocess.run(
+        ["nginx", "-t"],
+        capture_output=True,
+        text=True,
+        check=True                   # Raises CalledProcessError on non-zero exit
+    )
+    print("Nginx config is valid")
+except subprocess.CalledProcessError as e:
+    print(f"Nginx config error:\n{e.stderr}")
 ```
 
 ### Passing Input to Commands
 
 ```python
-# Pass a string as stdin to a command
-process = subprocess.run(
-    ["grep", "ERROR"], 
-    input="INFO: All good\nERROR: Disk full\nINFO: Syncing...", 
-    capture_output=True, 
+# Pipe a string as stdin
+result = subprocess.run(
+    ["grep", "ERROR"],
+    input="INFO: All good\nERROR: Disk full\nINFO: Syncing...\nERROR: Timeout",
+    capture_output=True,
     text=True
 )
-print(process.stdout)  # "ERROR: Disk full"
+print(result.stdout)
+# ERROR: Disk full
+# ERROR: Timeout
+```
+
+!!! warning "`shell=True` is a security risk"
+    Never pass user input to `subprocess.run()` with `shell=True`. It enables shell injection attacks where a malicious input like `; rm -rf /` gets executed. Always pass commands as a list of arguments (which bypasses the shell entirely), or use `shlex.quote()` if you absolutely must use `shell=True`.
+
+    ```python
+    # DANGEROUS - user_input could contain shell metacharacters
+    subprocess.run(f"grep {user_input} /var/log/syslog", shell=True)
+
+    # SAFE - each argument is passed directly to the program
+    subprocess.run(["grep", user_input, "/var/log/syslog"])
+    ```
+
+### `subprocess.run()` vs `subprocess.Popen()`
+
+| Feature | `run()` | `Popen()` |
+|---------|---------|-----------|
+| Waits for completion | Yes (blocking) | No (non-blocking) |
+| Returns | `CompletedProcess` | `Popen` object |
+| Use when | You need the result before proceeding | You need to interact with the process while it runs |
+
+Use `run()` for 95% of cases. Use `Popen()` when you need to stream output line by line, send input interactively, or run commands concurrently.
+
+```python
+# Popen for streaming output
+process = subprocess.Popen(
+    ["tail", "-f", "/var/log/syslog"],
+    stdout=subprocess.PIPE,
+    text=True
+)
+
+for line in process.stdout:
+    if "ERROR" in line:
+        print(f"ALERT: {line.strip()}")
+        process.terminate()
+        break
 ```
 
 ---
 
-## Handling Command-Line Arguments
+## Logging
 
-For simple scripts, use `sys.argv`. For complex tools with flags and help menus, use the built-in [**`argparse`**](https://docs.python.org/3/library/argparse.html) module.
+The [**`logging`**](https://docs.python.org/3/library/logging.html) module is Python's built-in logging framework. It replaces `print()` for anything beyond quick debugging.
+
+```python
+import logging
+
+# Basic configuration
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+
+logger = logging.getLogger(__name__)
+
+logger.info("Service check started")
+logger.warning("Disk usage at 85%%")
+logger.error("Connection to db01 failed")
+logger.critical("All backend servers unreachable")
+```
+
+### Logging to a File
+
+```python
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[
+        logging.FileHandler("/var/log/my-tool.log"),
+        logging.StreamHandler()      # Also print to console
+    ]
+)
+```
+
+!!! tip "Use `logging` instead of `print()` for operational scripts"
+    `print()` goes to stdout and has no concept of severity levels, timestamps, or output routing. The `logging` module gives you all three, plus the ability to change verbosity without modifying code (`--verbose` sets level to DEBUG, default is INFO, `--quiet` sets WARNING). For one-off scripts during development, `print()` is fine. For anything that runs in production, use `logging`.
+
+---
+
+## Command-Line Arguments
+
+### `sys.argv` for Simple Scripts
+
+```python
+import sys
+
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} <hostname>")
+    sys.exit(1)
+
+hostname = sys.argv[1]
+print(f"Checking {hostname}...")
+```
+
+### `argparse` for Production Tools
+
+The [**`argparse`**](https://docs.python.org/3/library/argparse.html) module builds CLI interfaces with help text, type validation, default values, and subcommands.
 
 ```python
 import argparse
 
-parser = argparse.ArgumentParser(description="A tool to archive logs.")
-parser.add_argument("directory", help="The directory containing logs to archive")
-parser.add_argument("--days", type=int, default=7, help="Archive logs older than X days")
-parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+parser = argparse.ArgumentParser(
+    description="Archive and compress old log files."
+)
+parser.add_argument(
+    "directory",
+    help="Directory containing logs to archive"
+)
+parser.add_argument(
+    "--days", type=int, default=7,
+    help="Archive logs older than this many days (default: 7)"
+)
+parser.add_argument(
+    "--compress", choices=["gzip", "bzip2", "none"], default="gzip",
+    help="Compression method (default: gzip)"
+)
+parser.add_argument(
+    "-v", "--verbose", action="store_true",
+    help="Enable verbose output"
+)
+parser.add_argument(
+    "-n", "--dry-run", action="store_true",
+    help="Show what would be done without making changes"
+)
 
 args = parser.parse_args()
 
-print(f"Archiving logs in {args.directory} older than {args.days} days.")
+print(f"Archiving logs in {args.directory} older than {args.days} days")
 if args.verbose:
-    print("Verbose mode enabled.")
+    print(f"Compression: {args.compress}")
+if args.dry_run:
+    print("(dry run - no changes will be made)")
+```
+
+```bash
+$ python3 archive_logs.py --help
+usage: archive_logs.py [-h] [--days DAYS] [--compress {gzip,bzip2,none}]
+                       [-v] [-n] directory
+
+Archive and compress old log files.
+
+positional arguments:
+  directory             Directory containing logs to archive
+
+options:
+  -h, --help            show this help message and exit
+  --days DAYS           Archive logs older than this many days (default: 7)
+  --compress {gzip,bzip2,none}
+                        Compression method (default: gzip)
+  -v, --verbose         Enable verbose output
+  -n, --dry-run         Show what would be done without making changes
 ```
 
 ---
 
-## Interactive Quizzes: System Automation
+## Environment Variables
 
-Test your understanding of Python's system interaction capabilities.
+Environment variables pass configuration to scripts without hardcoding values or using config files.
+
+```python
+import os
+
+# Read with defaults
+db_host = os.getenv("DB_HOST", "localhost")
+db_port = int(os.getenv("DB_PORT", "5432"))
+debug = os.getenv("DEBUG", "false").lower() == "true"
+
+# Require a variable (fail fast if missing)
+api_key = os.environ["API_KEY"]    # Raises KeyError if not set
+
+# Safer pattern
+api_key = os.getenv("API_KEY")
+if not api_key:
+    print("Error: API_KEY environment variable is required")
+    sys.exit(1)
+```
+
+---
+
+## Real-World Pattern: Service Health Checker
+
+```python
+#!/usr/bin/env python3
+"""Check the health of services and report status."""
+
+import argparse
+import logging
+import subprocess
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s"
+)
+logger = logging.getLogger("healthcheck")
+
+def check_service(name):
+    """Check if a systemd service is active."""
+    result = subprocess.run(
+        ["systemctl", "is-active", name],
+        capture_output=True, text=True
+    )
+    return result.stdout.strip() == "active"
+
+def check_port(host, port):
+    """Check if a TCP port is reachable."""
+    result = subprocess.run(
+        ["timeout", "3", "bash", "-c", f"echo > /dev/tcp/{host}/{port}"],
+        capture_output=True
+    )
+    return result.returncode == 0
+
+def main():
+    parser = argparse.ArgumentParser(description="Service health checker")
+    parser.add_argument("--services", nargs="+", default=["nginx", "postgresql"])
+    parser.add_argument("--check-ports", nargs="+", help="host:port pairs to check")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    failures = []
+
+    for service in args.services:
+        if check_service(service):
+            logger.info(f"{service}: OK")
+        else:
+            logger.error(f"{service}: DOWN")
+            failures.append(service)
+
+    if args.check_ports:
+        for pair in args.check_ports:
+            host, port = pair.split(":")
+            if check_port(host, int(port)):
+                logger.info(f"{host}:{port}: REACHABLE")
+            else:
+                logger.error(f"{host}:{port}: UNREACHABLE")
+                failures.append(pair)
+
+    if failures:
+        logger.critical(f"Failed checks: {', '.join(failures)}")
+        sys.exit(2)
+    else:
+        logger.info("All checks passed")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+```terminal
+scenario: "Build and test a system automation script"
+steps:
+  - command: "python3 -c \"import subprocess; r = subprocess.run(['uptime'], capture_output=True, text=True); print(r.stdout.strip())\""
+    output: " 14:23:01 up 42 days,  3:17,  2 users,  load average: 0.15, 0.22, 0.18"
+    narration: "subprocess.run() captures the output of any command. The capture_output=True and text=True flags give you the output as a Python string."
+  - command: "python3 -c \"import subprocess; r = subprocess.run(['systemctl', 'is-active', 'nginx'], capture_output=True, text=True); print(f'nginx: {r.stdout.strip()} (exit code {r.returncode})')\""
+    output: "nginx: active (exit code 0)"
+    narration: "Check a systemd service status. 'is-active' returns 'active' with exit code 0, or 'inactive'/'failed' with a non-zero code. This makes it easy to use in conditionals."
+  - command: "python3 -c \"import os; print(f'HOME={os.getenv(\\\"HOME\\\")}'); print(f'USER={os.getenv(\\\"USER\\\")}'); print(f'DEBUG={os.getenv(\\\"DEBUG\\\", \\\"not set\\\")}')\""
+    output: "HOME=/home/admin\nUSER=admin\nDEBUG=not set"
+    narration: "Environment variables are the standard way to pass configuration to scripts. os.getenv() returns None (or a default) if the variable isn't set, avoiding KeyError exceptions."
+  - command: "python3 -c \"from pathlib import Path; import shutil; Path('/tmp/demo-backup').mkdir(exist_ok=True); shutil.copy2('/etc/hostname', '/tmp/demo-backup/'); print('Backed up:', list(Path('/tmp/demo-backup').iterdir()))\""
+    output: "Backed up: [PosixPath('/tmp/demo-backup/hostname')]"
+    narration: "Combine pathlib for directory creation with shutil for file copying. copy2 preserves file metadata (timestamps, permissions)."
+  - command: "python3 -c \"import logging; logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s'); logging.info('Backup complete'); logging.warning('Disk at 82%%')\""
+    output: "2026-03-25 14:23:05 [INFO] Backup complete\n2026-03-25 14:23:05 [WARNING] Disk at 82%"
+    narration: "The logging module produces timestamped, leveled output. In production, route this to a file or syslog instead of the console."
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
-question: "Which module should you use if you need to recursively delete a directory tree (similar to `rm -rf`)?"
+question: "Which function should you use to recursively delete a directory tree?"
 type: multiple-choice
 options:
-  - text: "os"
-    feedback: "os.remove() deletes a single file, and os.rmdir() deletes an empty directory. Neither deletes recursively."
-  - text: "sys"
-    feedback: "The sys module is for system parameters, not file operations."
-  - text: "shutil"
+  - text: "os.remove()"
+    feedback: "os.remove() deletes a single file. It raises an error on directories."
+  - text: "os.rmdir()"
+    feedback: "os.rmdir() deletes only empty directories. It fails if the directory has contents."
+  - text: "shutil.rmtree()"
     correct: true
-    feedback: "Correct! `shutil.rmtree()` is the standard function for recursively deleting a directory and all of its contents."
-  - text: "subprocess"
-    feedback: "While you could call 'rm -rf' via subprocess, using shutil.rmtree() is more Pythonic and platform-independent."
+    feedback: "Correct! shutil.rmtree() recursively removes a directory and all its contents, like rm -rf. Use it with caution."
+  - text: "pathlib.Path.unlink()"
+    feedback: "unlink() removes a single file. For directories, use shutil.rmtree()."
 ```
 
 ```quiz
-question: "What is the recommended function for running an external command and waiting for it to complete?"
+question: "Why is `shell=True` dangerous in `subprocess.run()`?"
 type: multiple-choice
 options:
-  - text: "os.system()"
-    feedback: "os.system() is considered legacy and provides limited control over input/output."
-  - text: "subprocess.run()"
+  - text: "It makes the command run slower."
+    feedback: "There's a small overhead from spawning a shell, but the real issue is security."
+  - text: "It enables shell injection attacks when user input is part of the command."
     correct: true
-    feedback: "Correct! `subprocess.run()` (introduced in Python 3.5) is the recommended high-level function for executing commands."
-  - text: "subprocess.Popen()"
-    feedback: "Popen is for advanced scenarios where you need more control over the process lifecycle. For simple tasks, run() is preferred."
-  - text: "sys.execute()"
-    feedback: "There is no sys.execute() function in the standard library."
+    feedback: "Correct! With shell=True, metacharacters like ;, |, and $() are interpreted by the shell. User input containing '; rm -rf /' would be executed. Passing commands as a list bypasses the shell entirely."
+  - text: "It only works on Linux, not macOS."
+    feedback: "shell=True works on both platforms. The security risk exists on all operating systems."
+  - text: "It prevents output capture."
+    feedback: "You can capture output with shell=True. The issue is security, not functionality."
 ```
 
 ```quiz
-question: "How do you access the list of raw command-line arguments passed to a Python script?"
+question: "What is the main advantage of `logging` over `print()` for production scripts?"
 type: multiple-choice
 options:
-  - text: "sys.args"
-    feedback: "The name of the list is sys.argv, not sys.args."
-  - text: "os.argv"
-    feedback: "Command-line arguments are stored in the sys module, not os."
-  - text: "sys.argv"
+  - text: "logging is faster than print."
+    feedback: "Performance is similar. The advantage is in functionality."
+  - text: "logging provides severity levels, timestamps, and configurable output destinations."
     correct: true
-    feedback: "Correct! `sys.argv` is a list in Python that contains all the command-line arguments passed to the script, where `sys.argv[0]` is the script name itself."
-  - text: "argparse.list()"
-    feedback: "argparse is used for parsing arguments, but the raw arguments themselves are in sys.argv."
+    feedback: "Correct! logging supports DEBUG/INFO/WARNING/ERROR/CRITICAL levels, automatic timestamps, output to files and syslog, and runtime verbosity control. print() has none of these."
+  - text: "print() is deprecated in Python 3."
+    feedback: "print() is not deprecated and is fine for interactive use and quick scripts."
+  - text: "logging uses less memory."
+    feedback: "Memory usage is similar. The advantage is operational features."
+```
+
+---
+
+```exercise
+title: "Write a System Health Checker"
+description: "Create a command-line tool that checks disk usage, service status, and port reachability, then reports results with proper logging and exit codes."
+requirements:
+  - "Accept --services (list of systemd service names) and --disk-paths (list of filesystem paths) as arguments"
+  - "Check each service with systemctl is-active via subprocess"
+  - "Check each disk path with shutil.disk_usage, warning at 80% and critical at 90%"
+  - "Use the logging module for all output (not print)"
+  - "Support --verbose flag that enables DEBUG-level logging"
+  - "Exit with code 0 if all checks pass, 1 for warnings, 2 for critical failures"
+hints:
+  - "Use argparse with nargs='+' for arguments that accept multiple values"
+  - "subprocess.run(['systemctl', 'is-active', name], capture_output=True, text=True) returns the status"
+  - "Track the worst exit code: worst = max(worst, current_code)"
+  - "Set logger.setLevel(logging.DEBUG) when --verbose is passed"
+solution: |
+  #!/usr/bin/env python3
+  """System health checker with configurable checks."""
+
+  import argparse
+  import logging
+  import shutil
+  import subprocess
+  import sys
+
+  logging.basicConfig(
+      level=logging.INFO,
+      format="%(asctime)s [%(levelname)s] %(message)s",
+      datefmt="%Y-%m-%d %H:%M:%S"
+  )
+  logger = logging.getLogger("healthcheck")
+
+  def check_service(name):
+      result = subprocess.run(
+          ["systemctl", "is-active", name],
+          capture_output=True, text=True
+      )
+      status = result.stdout.strip()
+      if status == "active":
+          logger.info(f"Service {name}: OK")
+          return 0
+      else:
+          logger.error(f"Service {name}: {status}")
+          return 2
+
+  def check_disk(path, warn=80, crit=90):
+      try:
+          total, used, free = shutil.disk_usage(path)
+      except OSError as e:
+          logger.error(f"Disk {path}: {e}")
+          return 2
+
+      percent = (used / total) * 100
+      if percent >= crit:
+          logger.critical(f"Disk {path}: {percent:.1f}% (CRITICAL)")
+          return 2
+      elif percent >= warn:
+          logger.warning(f"Disk {path}: {percent:.1f}% (WARNING)")
+          return 1
+      else:
+          logger.info(f"Disk {path}: {percent:.1f}% (OK)")
+          return 0
+
+  def main():
+      parser = argparse.ArgumentParser(description="System health checker")
+      parser.add_argument("--services", nargs="+", default=[])
+      parser.add_argument("--disk-paths", nargs="+", default=["/"])
+      parser.add_argument("-v", "--verbose", action="store_true")
+      args = parser.parse_args()
+
+      if args.verbose:
+          logger.setLevel(logging.DEBUG)
+
+      worst = 0
+      for svc in args.services:
+          worst = max(worst, check_service(svc))
+      for path in args.disk_paths:
+          worst = max(worst, check_disk(path))
+
+      if worst == 0:
+          logger.info("All checks passed")
+      sys.exit(worst)
+
+  if __name__ == "__main__":
+      main()
 ```
 
 ---
 
 ## Further Reading
 
-- [**Python Docs: os Module**](https://docs.python.org/3/library/os.html)  
-- [**Python Docs: subprocess Module**](https://docs.python.org/3/library/subprocess.html)  
-- [**Real Python: Working with Files and Directories**](https://realpython.com/working-with-files-in-python/)  
+- [Python Docs: subprocess](https://docs.python.org/3/library/subprocess.html) - complete reference for running external commands
+- [Python Docs: pathlib](https://docs.python.org/3/library/pathlib.html) - modern object-oriented path handling
+- [Python Docs: argparse](https://docs.python.org/3/library/argparse.html) - building command-line interfaces
+- [Python Docs: logging](https://docs.python.org/3/library/logging.html) - the standard logging framework
+- [Real Python: Working with Files](https://realpython.com/working-with-files-in-python/) - practical guide to file operations
 
 ---
 

--- a/Dev Zero/Python/testing-and-tooling.md
+++ b/Dev Zero/Python/testing-and-tooling.md
@@ -1,6 +1,6 @@
 # Testing and Tooling in Python
 
-**Version:** 0.1  
+**Version:** 0.2
 **Year:** 2026
 
 ---
@@ -11,11 +11,13 @@ Copyright (c) 2025-2026 Ryan Thomas Robson / Robworks Software LLC. Licensed und
 
 ---
 
-As your automation scripts grow from simple snippets to production-grade tools, reliability and maintainability become critical. Python has a mature ecosystem for testing and dependency management that helps ensure your code behaves as expected and is easy to share.
+As your automation scripts grow from quick hacks to production tools, you need confidence that they work correctly and stay maintainable. Python has a mature ecosystem for testing, code quality, and dependency management that turns scripts into reliable software.
+
+---
 
 ## Unit Testing with `pytest`
 
-While Python includes a built-in `unittest` module, [**`pytest`**](https://docs.pytest.org/) is the industry standard due to its simpler syntax, powerful fixtures, and rich plugin ecosystem.
+While Python includes the built-in `unittest` module, [**`pytest`**](https://docs.pytest.org/) is the industry standard. Its plain `assert` statements, automatic test discovery, and powerful fixture system make tests easier to write and read.
 
 ```bash
 pip install pytest
@@ -23,131 +25,501 @@ pip install pytest
 
 ### Writing Your First Test
 
-`pytest` automatically discovers files that start with `test_` or end with `_test.py`.
+`pytest` discovers files matching `test_*.py` or `*_test.py` and runs functions that start with `test_`.
 
 ```python
-# script_to_test.py
+# server_utils.py
 def format_server_name(name):
+    """Normalize a server name to lowercase kebab-case."""
     return name.strip().lower().replace(" ", "-")
 
-# test_script.py
-from script_to_test import format_server_name
+def parse_host_port(address):
+    """Split 'host:port' into (host, port) tuple."""
+    host, port_str = address.rsplit(":", 1)
+    return host, int(port_str)
+```
 
-def test_format_server_name_strips_whitespace():
+```python
+# test_server_utils.py
+from server_utils import format_server_name, parse_host_port
+import pytest
+
+def test_format_strips_whitespace():
     assert format_server_name("  WEB01  ") == "web01"
 
-def test_format_server_name_replaces_spaces():
+def test_format_replaces_spaces():
     assert format_server_name("DB Server 01") == "db-server-01"
+
+def test_format_lowercases():
+    assert format_server_name("CacheNode") == "cachenode"
+
+def test_parse_host_port():
+    assert parse_host_port("db01:5432") == ("db01", 5432)
+
+def test_parse_host_port_invalid():
+    with pytest.raises(ValueError):
+        parse_host_port("no-port-here")
 ```
 
-To run your tests, simply execute `pytest` in the project root.
+```bash
+$ pytest -v
+test_server_utils.py::test_format_strips_whitespace PASSED
+test_server_utils.py::test_format_replaces_spaces PASSED
+test_server_utils.py::test_format_lowercases PASSED
+test_server_utils.py::test_parse_host_port PASSED
+test_server_utils.py::test_parse_host_port_invalid PASSED
+```
+
+!!! tip "pytest discovery conventions"
+    Keep test files next to the code they test, or in a `tests/` directory. Name test files `test_<module>.py` and test functions `test_<behavior>`. pytest finds them automatically - no registration or test suites needed.
+
+### Fixtures
+
+**Fixtures** provide test dependencies (data, connections, temporary files) that are set up before each test and cleaned up after. They replace the setup/teardown pattern from `unittest`.
+
+```python
+import pytest
+import json
+from pathlib import Path
+
+@pytest.fixture
+def sample_config(tmp_path):
+    """Create a temporary config file for testing."""
+    config = {"hostname": "test-server", "port": 8080, "debug": True}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(config))
+    return config_file
+
+def test_load_config(sample_config):
+    """Test that config loading works with a real file."""
+    with open(sample_config) as f:
+        data = json.load(f)
+    assert data["hostname"] == "test-server"
+    assert data["port"] == 8080
+
+def test_config_file_exists(sample_config):
+    """Test that the fixture creates a valid file."""
+    assert sample_config.exists()
+    assert sample_config.suffix == ".json"
+```
+
+`tmp_path` is a built-in pytest fixture that provides a temporary directory unique to each test. It's automatically cleaned up after the test session.
+
+### Parametrize
+
+Run the same test with multiple inputs:
+
+```python
+@pytest.mark.parametrize("input_name,expected", [
+    ("  WEB01  ", "web01"),
+    ("DB Server 01", "db-server-01"),
+    ("CacheNode", "cachenode"),
+    ("already-formatted", "already-formatted"),
+    ("UPPER CASE NAME", "upper-case-name"),
+])
+def test_format_server_name(input_name, expected):
+    assert format_server_name(input_name) == expected
+```
+
+This generates 5 separate test cases from a single test function, each with a clear pass/fail status.
 
 ---
 
-## Dependency Management
+## Mocking
 
-Managing external libraries is essential for reproducible environments.
+When your code calls external services, databases, or system commands, you don't want tests to depend on those systems being available. [**`unittest.mock`**](https://docs.python.org/3/library/unittest.mock.html) replaces real dependencies with controlled substitutes.
 
-### `pip` and `requirements.txt`
+```python
+from unittest.mock import patch, MagicMock
+import subprocess
 
-The simplest way to manage dependencies is using a `requirements.txt` file.
+def is_service_running(name):
+    """Check if a systemd service is active."""
+    result = subprocess.run(
+        ["systemctl", "is-active", name],
+        capture_output=True, text=True
+    )
+    return result.stdout.strip() == "active"
 
-```bash
-# Generate the file
-pip freeze > requirements.txt
+@patch("subprocess.run")
+def test_service_running(mock_run):
+    mock_run.return_value = MagicMock(stdout="active\n", returncode=0)
+    assert is_service_running("nginx") is True
 
-# Install from the file
-pip install -r requirements.txt
+@patch("subprocess.run")
+def test_service_not_running(mock_run):
+    mock_run.return_value = MagicMock(stdout="inactive\n", returncode=3)
+    assert is_service_running("nginx") is False
 ```
 
-### Modern Tooling: Poetry
+!!! warning "Don't over-mock"
+    Mocking is a tool, not a goal. If you mock every dependency, your tests verify your mocks, not your code. Mock at boundaries (external APIs, system commands, databases) but let internal logic run for real. A test that mocks everything and passes doesn't prove anything works.
 
-For larger projects, [**Poetry**](https://python-poetry.org/) is the preferred tool for dependency management and packaging. It replaces `requirements.txt`, `setup.py`, and `pip` with a single `pyproject.toml` file.
+### When to Mock vs When to Use Real Objects
 
-```bash
-# Initialize a new project
-poetry init
-
-# Add a dependency
-poetry add requests
-
-# Run a script within the managed environment
-poetry run python my_script.py
-```
+| Situation | Approach |
+|-----------|----------|
+| External API calls | Mock - don't hit real APIs in tests |
+| System commands (`systemctl`, `docker`) | Mock - tests shouldn't require services running |
+| File operations | Use `tmp_path` fixture with real files |
+| Pure functions (string formatting, math) | No mocking needed - test directly |
+| Database queries | Use a test database or mock the connection |
 
 ---
 
-## Code Quality and Linting
+## Test Coverage
 
-Consistent code style is enforced by linters and formatters, making your tools easier for others to read and maintain.
-
-- [**`flake8`**](https://flake8.pycqa.org/): Checks for PEP 8 compliance and common errors.
-- [**`black`**](https://black.readthedocs.io/): An "uncompromising" code formatter that automatically re-styles your code.
-- [**`isort`**](https://pycqa.github.io/isort/): Automatically sorts your imports.
+**Coverage** measures which lines of code your tests execute. It doesn't guarantee correctness, but uncovered code is definitely untested.
 
 ```bash
-# Example: Running black on your code
+pip install pytest-cov
+
+# Run tests with coverage report
+pytest --cov=server_utils --cov-report=term-missing
+
+# Output:
+# Name                Stmts   Miss  Cover   Missing
+# --------------------------------------------------
+# server_utils.py        12      2    83%   15, 22
+```
+
+The `Missing` column tells you exactly which lines need tests. Aim for 80-90% coverage on critical code. 100% coverage is rarely worth the effort for utility scripts.
+
+---
+
+## Code Quality Tools
+
+### Linting with `ruff`
+
+[**`ruff`**](https://docs.astral.sh/ruff/) is the modern Python linter - it replaces `flake8`, `isort`, `pycodestyle`, and dozens of other tools in a single fast binary.
+
+```bash
+pip install ruff
+
+# Check for issues
+ruff check .
+
+# Fix auto-fixable issues
+ruff check --fix .
+
+# Format code (replaces black)
+ruff format .
+```
+
+### Formatting with `black`
+
+[**`black`**](https://black.readthedocs.io/) is the "uncompromising" code formatter. It makes stylistic decisions for you, eliminating debates over formatting.
+
+```bash
+pip install black
+
+# Format a file
 black my_script.py
+
+# Check without modifying (useful in CI)
+black --check my_script.py
+```
+
+### Type Checking with `mypy`
+
+[**`mypy`**](https://mypy-lang.org/) checks type annotations without running your code, catching bugs like passing a string where an integer is expected.
+
+```python
+# server_utils.py (with type annotations)
+def format_server_name(name: str) -> str:
+    return name.strip().lower().replace(" ", "-")
+
+def parse_host_port(address: str) -> tuple[str, int]:
+    host, port_str = address.rsplit(":", 1)
+    return host, int(port_str)
+```
+
+```bash
+pip install mypy
+mypy server_utils.py
+```
+
+Type annotations are optional in Python, but they become valuable as your codebase grows. Start by annotating function signatures - you don't need to annotate every variable.
+
+---
+
+## Project Structure
+
+Once a script grows beyond a single file, organizing it properly makes it testable and distributable.
+
+### Minimal Project Layout
+
+```
+my-tool/
+├── my_tool/
+│   ├── __init__.py          # Makes this a Python package
+│   ├── cli.py               # Command-line interface (argparse)
+│   ├── checks.py            # Business logic (service checks, disk checks)
+│   └── utils.py             # Shared utilities
+├── tests/
+│   ├── test_checks.py
+│   └── test_utils.py
+├── pyproject.toml            # Project metadata, dependencies, tool config
+├── README.md
+└── .gitignore
+```
+
+### `pyproject.toml`
+
+[**`pyproject.toml`**](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/) is the modern standard for Python project configuration. It replaces `setup.py`, `setup.cfg`, and tool-specific config files.
+
+```toml
+[project]
+name = "my-tool"
+version = "0.1.0"
+description = "System health checker"
+requires-python = ">=3.10"
+dependencies = [
+    "requests>=2.28",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov",
+    "ruff",
+    "mypy",
+]
+
+[project.scripts]
+my-tool = "my_tool.cli:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+strict = true
+```
+
+```code-walkthrough
+title: "pyproject.toml Anatomy"
+description: "How a modern Python project defines its metadata, dependencies, and tool configuration."
+code: |
+  [project]
+  name = "my-tool"
+  version = "0.1.0"
+  description = "System health checker"
+  requires-python = ">=3.10"
+  dependencies = [
+      "requests>=2.28",
+  ]
+
+  [project.optional-dependencies]
+  dev = [
+      "pytest>=7.0",
+      "pytest-cov",
+      "ruff",
+      "mypy",
+  ]
+
+  [project.scripts]
+  my-tool = "my_tool.cli:main"
+
+  [tool.pytest.ini_options]
+  testpaths = ["tests"]
+
+  [tool.ruff]
+  line-length = 100
+annotations:
+  - line: 1
+    text: "The [project] table defines metadata that pip and other tools use. This follows PEP 621."
+  - line: 2
+    text: "Package name as it appears on PyPI. Use hyphens for names, underscores for the import directory."
+  - line: 5
+    text: "Minimum Python version. This prevents installation on older interpreters that lack features you depend on."
+  - line: 6
+    text: "Runtime dependencies. These are installed automatically when someone pip installs your package."
+  - line: 10
+    text: "Optional dependency groups. Install with pip install -e '.[dev]' to get testing and linting tools."
+  - line: 17
+    text: "Console script entry points. After installation, typing 'my-tool' on the command line runs the main() function from my_tool/cli.py."
+  - line: 20
+    text: "Tool-specific configuration. pytest, ruff, mypy, and other tools read their settings from pyproject.toml instead of separate config files."
 ```
 
 ---
 
-## Interactive Quizzes: Testing and Tooling
+## Pre-commit Hooks
 
-Verify your understanding of Python's quality assurance tools.
+[**`pre-commit`**](https://pre-commit.com/) runs checks automatically before each git commit, catching issues before they reach code review.
+
+```bash
+pip install pre-commit
+```
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+```
+
+```bash
+# Install the hooks into your git repo
+pre-commit install
+
+# Run against all files (useful for first-time setup)
+pre-commit run --all-files
+```
+
+---
+
+```terminal
+scenario: "Set up a Python project with testing and quality tools"
+steps:
+  - command: "mkdir -p my_tool tests && touch my_tool/__init__.py"
+    output: ""
+    narration: "Create the project structure. The __init__.py file makes my_tool a Python package that can be imported."
+  - command: "cat my_tool/utils.py"
+    output: "def format_server_name(name):\n    return name.strip().lower().replace(' ', '-')\n\ndef parse_host_port(address):\n    host, port_str = address.rsplit(':', 1)\n    return host, int(port_str)"
+    narration: "A utility module with two functions. These are the functions we'll test."
+  - command: "cat tests/test_utils.py"
+    output: "from my_tool.utils import format_server_name, parse_host_port\nimport pytest\n\ndef test_format_strips_whitespace():\n    assert format_server_name('  WEB01  ') == 'web01'\n\ndef test_parse_host_port():\n    assert parse_host_port('db01:5432') == ('db01', 5432)\n\ndef test_parse_invalid():\n    with pytest.raises(ValueError):\n        parse_host_port('no-port')"
+    narration: "Test file with three test functions. pytest discovers these automatically by filename and function name conventions."
+  - command: "pytest -v"
+    output: "tests/test_utils.py::test_format_strips_whitespace PASSED\ntests/test_utils.py::test_parse_host_port PASSED\ntests/test_utils.py::test_parse_invalid PASSED\n\n3 passed in 0.02s"
+    narration: "Run pytest with verbose output. All three tests pass. The -v flag shows each test name and its result."
+  - command: "pytest --cov=my_tool --cov-report=term-missing"
+    output: "tests/test_utils.py ...                                  [100%]\n\nName                  Stmts   Miss  Cover   Missing\n---------------------------------------------------\nmy_tool/__init__.py       0      0   100%\nmy_tool/utils.py          6      0   100%\n---------------------------------------------------\nTOTAL                     6      0   100%\n\n3 passed in 0.05s"
+    narration: "Run with coverage. 100% means every line in utils.py is executed by at least one test. The Missing column would show uncovered line numbers."
+  - command: "ruff check my_tool/"
+    output: "All checks passed!"
+    narration: "ruff checks for style violations, common bugs, and import ordering. A clean result means the code follows Python best practices."
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
-question: "Which command would you use to install a list of dependencies from a text file named `requirements.txt`?"
+question: "Which command installs dependencies from a requirements.txt file?"
 type: multiple-choice
 options:
   - text: "pip install requirements.txt"
-    feedback: "This would try to install a package literally named 'requirements.txt' from PyPI."
-  - text: "pip get -r requirements.txt"
-    feedback: "There is no 'get' command in pip."
+    feedback: "This tries to install a package literally named 'requirements.txt' from PyPI."
   - text: "pip install -r requirements.txt"
     correct: true
-    feedback: "Correct! The `-r` (or `--requirement`) flag tells `pip` to read the dependency list from the specified file."
-  - text: "python -m pip requirements.txt"
-    feedback: "While 'python -m pip' is a valid way to run pip, you still need the 'install -r' command and flag."
+    feedback: "Correct! The -r flag tells pip to read the dependency list from the file. Each line specifies a package and optional version constraint."
+  - text: "pip get -r requirements.txt"
+    feedback: "There is no 'get' command in pip."
+  - text: "python -m requirements install"
+    feedback: "There is no 'requirements' module. Use pip install -r."
 ```
 
 ```quiz
-question: "In `pytest`, which keyword is used to verify that a value matches your expectation?"
+question: "What does `pytest.raises(ValueError)` verify in a test?"
 type: multiple-choice
 options:
-  - text: "verify"
-    feedback: "Python doesn't have a 'verify' keyword."
-  - text: "check"
-    feedback: "Python doesn't have a 'check' keyword."
-  - text: "assert"
+  - text: "That the test function itself raises ValueError."
+    feedback: "pytest.raises is a context manager that wraps code you expect to fail, not the test function itself."
+  - text: "That the code inside the with block raises a ValueError exception."
     correct: true
-    feedback: "Correct! Python's built-in `assert` statement is the primary way to perform checks in `pytest`. If the expression following `assert` is False, the test fails."
-  - text: "expect"
-    feedback: "Some testing frameworks use 'expect', but pytest uses 'assert'."
+    feedback: "Correct! pytest.raises is used as a context manager: 'with pytest.raises(ValueError): code_that_should_fail()'. The test passes if the expected exception is raised, and fails if it isn't."
+  - text: "That ValueError is defined in the module."
+    feedback: "pytest.raises tests runtime behavior, not definitions."
+  - text: "That no ValueError occurs."
+    feedback: "It's the opposite - the test expects a ValueError to be raised."
 ```
 
 ```quiz
-question: "Which tool is used for 'uncompromising' automatic code formatting in Python?"
+question: "Why should you avoid mocking everything in your tests?"
 type: multiple-choice
 options:
-  - text: "flake8"
-    feedback: "flake8 is a linter (it checks for style and errors), not a formatter (it doesn't change your code)."
-  - text: "pylint"
-    feedback: "pylint is a static code analyzer/linter."
-  - text: "black"
+  - text: "Mocking is slower than running real code."
+    feedback: "Mocks are actually faster than real dependencies. The problem is correctness, not speed."
+  - text: "If you mock all dependencies, your tests verify the mocks, not your actual code."
     correct: true
-    feedback: "Correct! `black` is the most popular auto-formatter for Python, known for its strict, opinionated style that eliminates debates over code formatting."
-  - text: "pytest"
-    feedback: "pytest is a testing framework, not a code formatter."
+    feedback: "Correct! Over-mocking means your tests pass even when the real integration is broken. Mock at system boundaries (APIs, databases, system commands) but let internal logic run for real."
+  - text: "Python doesn't support mocking."
+    feedback: "Python has excellent mocking support via unittest.mock in the standard library."
+  - text: "Mocking makes tests harder to read."
+    feedback: "Readability can be an issue, but the real problem is that over-mocked tests don't prove your code works."
+```
+
+---
+
+```exercise
+title: "Add Tests to an Existing Function"
+description: "Write a comprehensive test suite for a disk usage checker function, including fixtures, parametrize, and mocking."
+requirements:
+  - "Write tests for a check_disk(path) function that returns ('OK', 0), ('WARNING', 1), or ('CRITICAL', 2) based on usage percentage"
+  - "Use @pytest.mark.parametrize to test multiple thresholds"
+  - "Use @patch to mock shutil.disk_usage so tests don't depend on actual disk state"
+  - "Test the error case where the path doesn't exist (should return ('ERROR', 2))"
+  - "Include at least 5 test cases covering normal, warning, critical, error, and edge cases (exactly 80%)"
+hints:
+  - "Mock shutil.disk_usage to return a named tuple: MagicMock(total=100, used=X, free=100-X)"
+  - "Use @pytest.mark.parametrize('used,expected_status,expected_code', [...]) for multiple thresholds"
+  - "For the error case, make the mock raise OSError"
+  - "Edge case: 80% exactly should trigger WARNING (test boundary conditions)"
+solution: |
+  import pytest
+  from unittest.mock import patch, MagicMock
+
+  # Function under test
+  def check_disk(path, warn=80, crit=90):
+      import shutil
+      try:
+          usage = shutil.disk_usage(path)
+      except OSError:
+          return ("ERROR", 2)
+      percent = (usage.used / usage.total) * 100
+      if percent >= crit:
+          return ("CRITICAL", 2)
+      elif percent >= warn:
+          return ("WARNING", 1)
+      return ("OK", 0)
+
+  @pytest.mark.parametrize("used,expected_status,expected_code", [
+      (50, "OK", 0),           # Normal usage
+      (79, "OK", 0),           # Just below warning
+      (80, "WARNING", 1),      # Exactly at warning threshold
+      (85, "WARNING", 1),      # In warning range
+      (90, "CRITICAL", 2),     # At critical threshold
+      (99, "CRITICAL", 2),     # Near full
+  ])
+  @patch("shutil.disk_usage")
+  def test_check_disk_thresholds(mock_usage, used, expected_status, expected_code):
+      mock_usage.return_value = MagicMock(total=100, used=used, free=100-used)
+      status, code = check_disk("/")
+      assert status == expected_status
+      assert code == expected_code
+
+  @patch("shutil.disk_usage", side_effect=OSError("No such path"))
+  def test_check_disk_missing_path(mock_usage):
+      status, code = check_disk("/nonexistent")
+      assert status == "ERROR"
+      assert code == 2
 ```
 
 ---
 
 ## Further Reading
 
-- [**Pytest Getting Started Guide**](https://docs.pytest.org/en/latest/getting-started.html)  
-- [**Poetry: Basic Usage**](https://python-poetry.org/docs/basic-usage/)  
-- [**Real Python: Effective Python Testing**](https://realpython.com/python-testing/)  
+- [pytest Documentation](https://docs.pytest.org/) - fixtures, parametrize, plugins, and configuration
+- [Real Python: Effective Testing](https://realpython.com/python-testing/) - practical testing strategies and patterns
+- [Ruff Documentation](https://docs.astral.sh/ruff/) - fast linter and formatter replacing flake8, isort, and more
+- [Python Packaging Guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/) - the official guide to pyproject.toml
+- [pre-commit Documentation](https://pre-commit.com/) - automated code quality checks on every commit
 
 ---
 

--- a/Dev Zero/Python/testing-and-tooling.md
+++ b/Dev Zero/Python/testing-and-tooling.md
@@ -339,9 +339,9 @@ annotations:
     text: "Runtime dependencies. These are installed automatically when someone pip installs your package."
   - line: 10
     text: "Optional dependency groups. Install with pip install -e '.[dev]' to get testing and linting tools."
-  - line: 17
+  - line: 18
     text: "Console script entry points. After installation, typing 'my-tool' on the command line runs the main() function from my_tool/cli.py."
-  - line: 20
+  - line: 21
     text: "Tool-specific configuration. pytest, ruff, mypy, and other tools read their settings from pyproject.toml instead of separate config files."
 ```
 
@@ -459,13 +459,14 @@ options:
 
 ```exercise
 title: "Add Tests to an Existing Function"
-description: "Write a comprehensive test suite for a disk usage checker function, including fixtures, parametrize, and mocking."
-requirements:
-  - "Write tests for a check_disk(path) function that returns ('OK', 0), ('WARNING', 1), or ('CRITICAL', 2) based on usage percentage"
-  - "Use @pytest.mark.parametrize to test multiple thresholds"
-  - "Use @patch to mock shutil.disk_usage so tests don't depend on actual disk state"
-  - "Test the error case where the path doesn't exist (should return ('ERROR', 2))"
-  - "Include at least 5 test cases covering normal, warning, critical, error, and edge cases (exactly 80%)"
+scenario: |
+  You have a `check_disk(path)` function that returns `('OK', 0)`, `('WARNING', 1)`, or `('CRITICAL', 2)` based on disk usage percentage. Write a comprehensive test suite that:
+
+  1. Uses `@pytest.mark.parametrize` to test multiple thresholds (normal, warning, critical)
+  2. Uses `@patch` to mock `shutil.disk_usage` so tests don't depend on actual disk state
+  3. Tests the error case where the path doesn't exist (should return `('ERROR', 2)`)
+  4. Includes at least 5 test cases covering normal, warning, critical, error, and edge cases (exactly 80%)
+  5. Verifies both the status string and exit code for each case
 hints:
   - "Mock shutil.disk_usage to return a named tuple: MagicMock(total=100, used=X, free=100-X)"
   - "Use @pytest.mark.parametrize('used,expected_status,expected_code', [...]) for multiple thresholds"

--- a/Docker/compose.md
+++ b/Docker/compose.md
@@ -1,128 +1,481 @@
 # Docker Compose
 
-[**Docker Compose**](https://docs.docker.com/compose/) is a tool for defining and running multi-container Docker applications. With Compose, you use a YAML file to configure your application’s services. Then, with a single command, you create and start all the services from your configuration.
-
-## Why Use Docker Compose?
-
-Managing multiple containers manually using `docker run` becomes complex very quickly. You have to remember specific network settings, volumes, and environment variables for each container. Docker Compose centralizes this configuration, allowing you to:
-
-- **Define service dependencies**: Start your database before your web application.
-- **Manage networks and volumes**: Automatically create networks for service-to-service communication.
-- **Standardize environments**: Ensure everyone on the team is running the same stack with the same configuration.
+[**Docker Compose**](https://docs.docker.com/compose/) is a tool for defining and running multi-container Docker applications. Instead of managing each container with separate `docker run` commands - each with its own flags for ports, volumes, networks, and environment variables - you declare everything in a single YAML file and bring the entire stack up or down with one command.
 
 ---
 
-## The `docker-compose.yml` File
+## Why Compose Exists
 
-The core of Docker Compose is the YAML configuration file.
+Running a web application typically means running at least three containers: the application itself, a database, and maybe a cache or message queue. Managing these by hand means remembering the exact `docker run` invocation for each one, creating networks, and starting them in the right order. Docker Compose solves this by letting you define the entire stack declaratively.
+
+The benefits go beyond convenience:
+
+- **Reproducible environments**: Every developer runs the same stack with `docker compose up`.
+- **Service discovery**: Containers on a Compose network reach each other by service name - no IP addresses to manage.
+- **Single-command lifecycle**: Start, stop, rebuild, and tear down the entire stack in one step.
+- **Environment parity**: The same `compose.yml` works in development, CI, and staging.
+
+---
+
+## The Compose File
+
+The core of Docker Compose is a YAML file named `compose.yml` (or `docker-compose.yml` for backward compatibility). It defines services, networks, and volumes.
+
+### A Production-Style Example
 
 ```yaml
-version: "3.9"
-
 services:
-  db:
-    image: postgres
-    volumes:
-      - ./data/db:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_DB=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
   web:
-    build: .
-    command: python manage.py runserver 0.0.0.0:8000
-    volumes:
-      - .:/code
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
       - "8000:8000"
     environment:
-      - POSTGRES_NAME=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      DATABASE_URL: postgres://admin:secret@db:5432/myapp
+      REDIS_URL: redis://cache:6379
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_started
+    restart: unless-stopped
+
+  db:
+    image: postgres:16
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: secret
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin -d myapp"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  cache:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+volumes:
+  pgdata:
 ```
 
-### Key Components
+!!! tip "`depends_on` does not wait for readiness"
+    By default, `depends_on` only waits for a container to *start*, not for the service inside to be ready. A PostgreSQL container can take several seconds to initialize its database after the process starts. Use `condition: service_healthy` with a `healthcheck` to ensure the database is actually accepting connections before the web service starts.
 
-- **`services`**: Defines the different containers that make up your application.
-- **`image`**: Specifies the image to start the container from.
-- **`build`**: Configuration options that are applied at build time (usually points to a directory containing a `Dockerfile`).
-- **`ports`**: Maps host ports to container ports.
-- **`volumes`**: Mounts paths on the host to paths in the container.
-- **`depends_on`**: Expresses dependency order between services.
+### Key Directives
+
+| Directive | Purpose |
+|-----------|---------|
+| `services` | Defines each container in your application stack. |
+| `image` | Use a pre-built image from a registry. |
+| `build` | Build an image from a Dockerfile in the specified context. |
+| `ports` | Map host ports to container ports (`HOST:CONTAINER`). |
+| `volumes` | Mount named volumes or bind paths into the container. |
+| `environment` | Set environment variables. Supports both mapping and list syntax. |
+| `depends_on` | Control startup order. Use with `condition` for health-based ordering. |
+| `healthcheck` | Define a command to check if the service is healthy. |
+| `restart` | Restart policy: `no`, `always`, `on-failure`, `unless-stopped`. |
+| `networks` | Attach the service to specific networks. |
+| `command` | Override the default CMD from the image. |
+| `profiles` | Assign the service to a profile so it only starts when that profile is active. |
+
+---
+
+## Environment Variables and `.env` Files
+
+Hardcoding secrets in `compose.yml` is fine for local development, but Compose supports `.env` files for separating configuration from the stack definition.
+
+### Variable Substitution
+
+Compose resolves `${VARIABLE}` references from the shell environment, a `.env` file in the same directory, or the `environment` directive.
+
+```yaml
+services:
+  db:
+    image: postgres:${POSTGRES_VERSION:-16}
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+```
+
+```bash
+# .env file (same directory as compose.yml)
+POSTGRES_VERSION=16
+DB_PASSWORD=supersecret
+```
+
+### The `env_file` Directive
+
+For services that need many environment variables, you can point to a file instead of listing them inline:
+
+```yaml
+services:
+  web:
+    build: .
+    env_file:
+      - .env
+      - .env.local
+```
+
+Files are loaded in order. Later files override earlier ones. Variables set directly in `environment` override everything.
+
+---
+
+## Volumes: Named vs Bind Mounts
+
+Compose supports two primary volume strategies, and choosing the right one matters.
+
+### Named Volumes (Production)
+
+Named volumes are managed by Docker. They persist data across container restarts and removals, and they're the right choice for databases, file uploads, and any data that must survive a `docker compose down`.
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+```
+
+### Bind Mounts (Development)
+
+Bind mounts map a host directory into the container. They're essential for development because changes to files on the host appear immediately inside the container - no rebuild needed.
+
+```yaml
+services:
+  web:
+    build: .
+    volumes:
+      - .:/app           # Source code (live reloading)
+      - /app/node_modules # Prevent host node_modules from overriding container's
+    ports:
+      - "3000:3000"
+```
+
+!!! warning "Named volumes survive `docker compose down`"
+    Running `docker compose down` removes containers and networks but keeps named volumes. If you want to delete the data too, use `docker compose down -v`. This is destructive and irreversible - the database data is gone.
+
+---
+
+## Networking
+
+Compose automatically creates a bridge network for each project. Every service can reach every other service by its service name as a hostname.
+
+```yaml
+services:
+  web:
+    build: .
+    # Can connect to "db" at hostname "db" on port 5432
+    # No port publishing needed for service-to-service communication
+  db:
+    image: postgres:16
+    # Only publish if you need direct host access (e.g., for a GUI client)
+    # ports:
+    #   - "5432:5432"
+```
+
+For more complex setups, you can define multiple networks to isolate groups of services:
+
+```yaml
+services:
+  web:
+    networks:
+      - frontend
+      - backend
+  db:
+    networks:
+      - backend
+  nginx:
+    networks:
+      - frontend
+
+networks:
+  frontend:
+  backend:
+```
+
+In this configuration, `nginx` can reach `web` but cannot reach `db` directly - the database is only accessible on the `backend` network.
 
 ---
 
 ## Common Compose Commands
 
-Docker Compose commands are run from the directory containing the `docker-compose.yml` file.
+```bash
+# Start the stack (build images if needed)
+docker compose up -d
 
-- `docker-compose up`: Create and start containers.
-- `docker-compose up -d`: Start containers in the background.
-- `docker-compose down`: Stop and remove containers, networks, and images created by `up`.
-- `docker-compose ps`: List containers managed by Compose.
-- `docker-compose logs -f`: View tailing logs from all services.
-- `docker-compose exec <service_name> <command>`: Execute a command in a running service container.
+# Rebuild images and start
+docker compose up -d --build
+
+# Stop and remove containers and networks
+docker compose down
+
+# Stop, remove containers, networks, AND volumes
+docker compose down -v
+
+# View logs from all services
+docker compose logs -f
+
+# View logs from a single service
+docker compose logs -f web
+
+# List running services
+docker compose ps
+
+# Run a one-off command in a service container
+docker compose exec db psql -U admin -d myapp
+
+# Run a command in a new container (doesn't attach to the running one)
+docker compose run --rm web python manage.py migrate
+
+# Scale a service to multiple replicas
+docker compose up -d --scale worker=3
+```
+
+```terminal
+scenario: "Bring up a three-service stack, verify connectivity, and tear it down"
+steps:
+  - command: "cat compose.yml"
+    output: "services:\n  web:\n    build: .\n    ports:\n      - \"8000:8000\"\n    depends_on:\n      db:\n        condition: service_healthy\n  db:\n    image: postgres:16\n    environment:\n      POSTGRES_PASSWORD: secret\n    healthcheck:\n      test: [\"CMD-SHELL\", \"pg_isready\"]\n      interval: 3s\n      retries: 5\n    volumes:\n      - pgdata:/var/lib/postgresql/data\n  cache:\n    image: redis:7-alpine\nvolumes:\n  pgdata:"
+    narration: "The compose file defines three services: a web app built from a local Dockerfile, a PostgreSQL database with a health check, and a Redis cache. The web service waits for the database to be healthy before starting."
+  - command: "docker compose up -d --build"
+    output: "[+] Building 8.2s\n[+] Running 4/4\n ✔ Network myproject_default  Created\n ✔ Volume myproject_pgdata    Created\n ✔ Container myproject-db-1    Healthy\n ✔ Container myproject-cache-1 Started\n ✔ Container myproject-web-1   Started"
+    narration: "Compose builds the web image, creates a bridge network and a named volume, then starts containers in dependency order. The web container waits until the db health check passes."
+  - command: "docker compose ps"
+    output: "NAME                 SERVICE   STATUS    PORTS\nmyproject-cache-1    cache     running   6379/tcp\nmyproject-db-1       db        running   5432/tcp\nmyproject-web-1      web       running   0.0.0.0:8000->8000/tcp"
+    narration: "All three services are running. Only the web service has a published port (8000). The cache and database ports are accessible to other containers on the network but not from the host."
+  - command: "docker compose exec web python -c \"import redis; r = redis.Redis(host='cache'); print(r.ping())\""
+    output: "True"
+    narration: "The web container can reach Redis using the service name 'cache' as the hostname. Compose's built-in DNS handles the resolution."
+  - command: "docker compose exec db psql -U postgres -c 'SELECT version();'"
+    output: "                                                version\n---------------------------------------------------\n PostgreSQL 16.2 on x86_64-pc-linux-gnu, compiled by gcc"
+    narration: "You can run commands directly inside the database container. This is useful for migrations, backups, and debugging."
+  - command: "docker compose logs web --tail 5"
+    output: "web-1  | INFO:     Application startup complete.\nweb-1  | INFO:     Uvicorn running on http://0.0.0.0:8000\nweb-1  | INFO:     172.20.0.1:54321 - \"GET / HTTP/1.1\" 200"
+    narration: "Logs are namespaced by service. The --tail flag limits output to the last N lines."
+  - command: "docker compose down"
+    output: "[+] Running 4/4\n ✔ Container myproject-web-1    Removed\n ✔ Container myproject-cache-1  Removed\n ✔ Container myproject-db-1     Removed\n ✔ Network myproject_default    Removed"
+    narration: "Containers and the network are removed, but the pgdata volume is preserved. Your database data is safe for the next 'docker compose up'."
+```
 
 ---
 
-## Interactive Quizzes: Docker Compose
+## Override Files and Profiles
 
-Verify your understanding of Docker Compose.
+### Override Files
+
+Compose automatically merges `compose.yml` with `compose.override.yml` if it exists. This is the standard pattern for separating production defaults from development customizations.
+
+```yaml
+# compose.yml (production defaults)
+services:
+  web:
+    image: my-app:latest
+    restart: unless-stopped
+
+# compose.override.yml (development overrides)
+services:
+  web:
+    build: .
+    volumes:
+      - .:/app
+    environment:
+      DEBUG: "true"
+```
+
+In development, `docker compose up` merges both files - building from source with a bind mount. In production, deploy with `docker compose -f compose.yml up` to skip the override.
+
+### Profiles
+
+Profiles let you include optional services that only start when explicitly requested.
+
+```yaml
+services:
+  web:
+    build: .
+  db:
+    image: postgres:16
+  adminer:
+    image: adminer
+    ports:
+      - "8080:8080"
+    profiles:
+      - debug
+```
+
+```bash
+# Normal startup (adminer is NOT started)
+docker compose up -d
+
+# Start with the debug profile (includes adminer)
+docker compose --profile debug up -d
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
-question: "Which command is used to stop and remove all resources (containers, networks) created by Docker Compose?"
+question: "Which command removes containers and networks but preserves named volumes?"
 type: multiple-choice
 options:
-  - text: "docker-compose stop"
+  - text: "docker compose stop"
     feedback: "stop only pauses the containers; it doesn't remove them or their networks."
-  - text: "docker-compose rm"
-    feedback: "rm removes stopped containers but doesn't stop them or remove networks."
-  - text: "docker-compose down"
+  - text: "docker compose down"
     correct: true
-    feedback: "Correct! `docker-compose down` stops containers and also removes them along with the networks created for the project."
-  - text: "docker-compose delete"
-    feedback: "There is no 'delete' command in Docker Compose."
+    feedback: "Correct! docker compose down removes containers and networks but keeps named volumes intact. Use docker compose down -v to also delete volumes."
+  - text: "docker compose down -v"
+    feedback: "The -v flag deletes volumes too. Without -v, volumes are preserved."
+  - text: "docker compose rm"
+    feedback: "rm removes stopped containers but doesn't handle networks. Use docker compose down for a clean teardown."
 ```
 
 ```quiz
-question: "In a `docker-compose.yml` file, what does the `depends_on` directive do?"
+question: "How do containers in a Compose stack communicate with each other?"
 type: multiple-choice
 options:
-  - text: "It links the container to an external network."
-    feedback: "Networking is handled by the 'networks' directive."
-  - text: "It ensures services are started in a specific order."
+  - text: "Through published ports on the host."
+    feedback: "Published ports are for host-to-container access. Container-to-container communication uses the internal network directly."
+  - text: "By using the service name as a hostname on the shared Compose network."
     correct: true
-    feedback: "Correct! `depends_on` defines the order in which services are started and stopped. For example, a web app might depend on a database service."
-  - text: "It copies files from one service to another."
-    feedback: "Copying files is handled by 'volumes' or 'build' context."
-  - text: "It merges two Docker images into one."
-    feedback: "Images are not merged. Each service runs its own image."
+    feedback: "Correct! Compose creates a bridge network where each service is reachable by its service name. A web service can connect to a database service at hostname 'db' without any port publishing."
+  - text: "By writing to a shared volume."
+    feedback: "Volumes share files, not network connections. Services communicate over the network using hostnames."
+  - text: "They cannot communicate unless you set up an external network."
+    feedback: "Compose automatically creates a network for the project. All services are connected to it by default."
 ```
 
 ```quiz
-question: "What is the primary format used for Docker Compose configuration files?"
+question: "What does `depends_on` with `condition: service_healthy` do?"
 type: multiple-choice
 options:
-  - text: "JSON"
-    feedback: "While Docker Compose can sometimes parse JSON, YAML is the standard format."
-  - text: "XML"
-    feedback: "XML is not used for Docker Compose configuration."
-  - text: "YAML"
+  - text: "It health-checks the dependent service."
+    feedback: "The health check is defined on the dependency (e.g., the database), not the dependent service."
+  - text: "It waits for the dependency to start, but not necessarily be ready."
+    feedback: "That's what plain depends_on does. Adding condition: service_healthy waits for the health check to pass."
+  - text: "It waits for the dependency's health check to pass before starting the dependent service."
     correct: true
-    feedback: "Correct! Docker Compose uses YAML (`.yml` or `.yaml`) for its configuration files due to its readability."
-  - text: "TOML"
-    feedback: "TOML is used by some tools (like Poetry), but not Docker Compose."
+    feedback: "Correct! Unlike plain depends_on (which only waits for the container to start), service_healthy waits until the healthcheck reports the service is actually ready to accept connections."
+  - text: "It restarts the dependency if it becomes unhealthy."
+    feedback: "Restart behavior is controlled by the restart policy, not depends_on."
+```
+
+---
+
+```exercise
+title: "Build a Three-Service Development Stack"
+description: "Create a compose.yml for a Node.js API with PostgreSQL and Redis, including health checks, proper volume strategy, and environment configuration."
+requirements:
+  - "Define a 'web' service that builds from the current directory and maps port 3000"
+  - "Define a 'db' service using postgres:16 with a named volume for data persistence"
+  - "Define a 'cache' service using redis:7-alpine"
+  - "Add a health check to the db service using pg_isready"
+  - "Make the web service wait for db to be healthy before starting"
+  - "Use a .env file for the database password instead of hardcoding it"
+  - "Add a bind mount on the web service for live code reloading in development"
+hints:
+  - "The healthcheck test for PostgreSQL is: [\"CMD-SHELL\", \"pg_isready -U postgres\"]"
+  - "Use ${DB_PASSWORD} syntax in compose.yml and define DB_PASSWORD in a .env file"
+  - "For the bind mount, use .:/app for the source code, but add /app/node_modules as an anonymous volume to prevent host modules from overriding container modules"
+  - "Named volumes are declared both under the service (as a mount) and at the top level under 'volumes:'"
+solution: |
+  # compose.yml
+  services:
+    web:
+      build: .
+      ports:
+        - "3000:3000"
+      volumes:
+        - .:/app
+        - /app/node_modules
+      environment:
+        DATABASE_URL: postgres://postgres:${DB_PASSWORD}@db:5432/myapp
+        REDIS_URL: redis://cache:6379
+      depends_on:
+        db:
+          condition: service_healthy
+        cache:
+          condition: service_started
+      restart: unless-stopped
+
+    db:
+      image: postgres:16
+      volumes:
+        - pgdata:/var/lib/postgresql/data
+      environment:
+        POSTGRES_DB: myapp
+        POSTGRES_PASSWORD: ${DB_PASSWORD}
+      healthcheck:
+        test: ["CMD-SHELL", "pg_isready -U postgres -d myapp"]
+        interval: 5s
+        timeout: 3s
+        retries: 5
+      restart: unless-stopped
+
+    cache:
+      image: redis:7-alpine
+      restart: unless-stopped
+
+  volumes:
+    pgdata:
+
+  # .env
+  # DB_PASSWORD=your-secure-password-here
+```
+
+---
+
+```command-builder
+title: "Docker Compose Command Builder"
+description: "Build docker compose commands for common stack operations."
+base: "docker compose"
+groups:
+  - name: "Action"
+    options:
+      - label: "Start stack"
+        value: "up -d"
+      - label: "Stop and remove stack"
+        value: "down"
+      - label: "View logs"
+        value: "logs -f"
+      - label: "List services"
+        value: "ps"
+      - label: "Run command in service"
+        value: "exec"
+      - label: "Rebuild and start"
+        value: "up -d --build"
+  - name: "Options"
+    required: false
+    options:
+      - label: "Remove volumes too"
+        value: "-v"
+        description: "Also delete named volumes (data loss!)"
+      - label: "Include debug profile"
+        value: "--profile debug"
+        description: "Start services tagged with the debug profile"
+      - label: "Scale workers"
+        value: "--scale worker=3"
+        description: "Run 3 replicas of the worker service"
+      - label: "Force recreate"
+        value: "--force-recreate"
+        description: "Recreate containers even if config hasn't changed"
 ```
 
 ---
 
 ## Further Reading
 
-- [**Docker Compose Documentation**](https://docs.docker.com/compose/)  
-- [**Compose File Reference**](https://docs.docker.com/compose/compose-file/)  
-- [**Docker Compose Samples**](https://docs.docker.com/compose/samples-for-compose/)  
+- [Docker Compose Documentation](https://docs.docker.com/compose/) - official getting-started guide and concepts
+- [Compose File Reference](https://docs.docker.com/compose/compose-file/) - complete specification of every directive
+- [Awesome Compose](https://github.com/docker/awesome-compose) - sample Compose files for common application stacks
+- [Docker Compose in Production](https://docs.docker.com/compose/production/) - guidelines for deploying Compose stacks beyond development
 
 ---
 

--- a/Docker/compose.md
+++ b/Docker/compose.md
@@ -371,15 +371,16 @@ options:
 
 ```exercise
 title: "Build a Three-Service Development Stack"
-description: "Create a compose.yml for a Node.js API with PostgreSQL and Redis, including health checks, proper volume strategy, and environment configuration."
-requirements:
-  - "Define a 'web' service that builds from the current directory and maps port 3000"
-  - "Define a 'db' service using postgres:16 with a named volume for data persistence"
-  - "Define a 'cache' service using redis:7-alpine"
-  - "Add a health check to the db service using pg_isready"
-  - "Make the web service wait for db to be healthy before starting"
-  - "Use a .env file for the database password instead of hardcoding it"
-  - "Add a bind mount on the web service for live code reloading in development"
+scenario: |
+  You need a development stack for a Node.js API with PostgreSQL and Redis. Create a `compose.yml` that meets these requirements:
+
+  1. Define a `web` service that builds from the current directory and maps port 3000
+  2. Define a `db` service using `postgres:16` with a named volume for data persistence
+  3. Define a `cache` service using `redis:7-alpine`
+  4. Add a health check to the `db` service using `pg_isready`
+  5. Make the `web` service wait for `db` to be healthy before starting
+  6. Use a `.env` file for the database password instead of hardcoding it
+  7. Add a bind mount on the `web` service for live code reloading in development
 hints:
   - "The healthcheck test for PostgreSQL is: [\"CMD-SHELL\", \"pg_isready -U postgres\"]"
   - "Use ${DB_PASSWORD} syntax in compose.yml and define DB_PASSWORD in a .env file"
@@ -433,39 +434,30 @@ solution: |
 ---
 
 ```command-builder
-title: "Docker Compose Command Builder"
-description: "Build docker compose commands for common stack operations."
+description: Build docker compose commands for common stack operations
 base: "docker compose"
-groups:
-  - name: "Action"
-    options:
-      - label: "Start stack"
-        value: "up -d"
-      - label: "Stop and remove stack"
-        value: "down"
-      - label: "View logs"
-        value: "logs -f"
-      - label: "List services"
-        value: "ps"
-      - label: "Run command in service"
-        value: "exec"
-      - label: "Rebuild and start"
-        value: "up -d --build"
-  - name: "Options"
-    required: false
-    options:
-      - label: "Remove volumes too"
-        value: "-v"
-        description: "Also delete named volumes (data loss!)"
-      - label: "Include debug profile"
-        value: "--profile debug"
-        description: "Start services tagged with the debug profile"
-      - label: "Scale workers"
-        value: "--scale worker=3"
-        description: "Run 3 replicas of the worker service"
-      - label: "Force recreate"
-        value: "--force-recreate"
-        description: "Recreate containers even if config hasn't changed"
+options:
+  - flag: ""
+    type: select
+    label: "Action"
+    explanation: "The primary compose operation to perform"
+    choices:
+      - ["up -d", "Start stack (detached)"]
+      - ["down", "Stop and remove stack"]
+      - ["logs -f", "View logs (follow)"]
+      - ["ps", "List services"]
+      - ["exec", "Run command in service"]
+      - ["up -d --build", "Rebuild and start"]
+  - flag: ""
+    type: select
+    label: "Additional option"
+    explanation: "Optional flags to modify the command behavior"
+    choices:
+      - ["", "(none)"]
+      - ["-v", "Remove volumes too (data loss!)"]
+      - ["--profile debug", "Include debug profile"]
+      - ["--scale worker=3", "Scale workers to 3 replicas"]
+      - ["--force-recreate", "Force recreate containers"]
 ```
 
 ---

--- a/Docker/fundamentals.md
+++ b/Docker/fundamentals.md
@@ -421,8 +421,8 @@ steps:
     output: "Dockerfile  app.py  requirements.txt"
     narration: "You have a Python application with its Dockerfile and dependency file ready."
   - command: "cat Dockerfile"
-    output: "FROM python:3.12-slim\nWORKDIR /app\nCOPY requirements.txt .\nRUN pip install --no-cache-dir -r requirements.txt\nCOPY . .\nUSER nobody\nEXPOSE 8000\nCMD [\"uvicorn\", \"app:app\", \"--host\", \"0.0.0.0\", \"--port\", \"8000\"]"
-    narration: "The Dockerfile uses a slim base image, installs dependencies first for layer caching, copies application code, drops to a non-root user, and runs the app with uvicorn."
+    output: "FROM python:3.12-slim\nWORKDIR /app\nRUN adduser --disabled-password --no-create-home appuser\nCOPY requirements.txt .\nRUN pip install --no-cache-dir -r requirements.txt\nCOPY . .\nUSER appuser\nEXPOSE 8000\nCMD [\"uvicorn\", \"app:app\", \"--host\", \"0.0.0.0\", \"--port\", \"8000\"]"
+    narration: "The Dockerfile uses a slim base image, creates a dedicated non-root user, installs dependencies first for layer caching, copies application code, switches to that user, and runs the app with uvicorn."
   - command: "docker build -t my-api:1.0 ."
     output: "[+] Building 12.3s (9/9) FINISHED\n => [1/5] FROM python:3.12-slim\n => [2/5] WORKDIR /app\n => [3/5] COPY requirements.txt .\n => [4/5] RUN pip install --no-cache-dir -r requirements.txt\n => [5/5] COPY . .\n => exporting to image\n => naming to docker.io/library/my-api:1.0"
     narration: "Docker builds the image layer by layer. Each step is cached - if you change only app.py, steps 1-4 use the cache and only step 5 runs again."
@@ -499,15 +499,16 @@ options:
 
 ```exercise
 title: "Containerize a Python Application"
-description: "Write a Dockerfile and supporting files for a Flask API, then build and run it."
-requirements:
-  - "Create a Dockerfile that uses python:3.12-slim as the base image"
-  - "Install dependencies from requirements.txt using pip with --no-cache-dir"
-  - "Copy application code after installing dependencies (for layer caching)"
-  - "Run the app as a non-root user"
-  - "Create a .dockerignore that excludes .git, __pycache__, .env, and venv/"
-  - "Build the image tagged as flask-app:1.0"
-  - "Run the container with port 5000 mapped and a 256MB memory limit"
+scenario: |
+  You have a Flask API application with `app.py` and `requirements.txt`. Your tasks:
+
+  1. Create a Dockerfile that uses `python:3.12-slim` as the base image
+  2. Install dependencies from `requirements.txt` using pip with `--no-cache-dir`
+  3. Copy application code after installing dependencies (for layer caching)
+  4. Run the app as a non-root user (create a dedicated user with `adduser`)
+  5. Create a `.dockerignore` that excludes `.git`, `__pycache__`, `.env`, and `venv/`
+  6. Build the image tagged as `flask-app:1.0`
+  7. Run the container with port 5000 mapped and a 256MB memory limit
 hints:
   - "Start with FROM, then WORKDIR, then COPY just the requirements file"
   - "Use RUN adduser --disabled-password appuser and USER appuser to drop root privileges"

--- a/Docker/fundamentals.md
+++ b/Docker/fundamentals.md
@@ -1,93 +1,454 @@
 # Docker Fundamentals
 
-Docker provides a way to package and run an application in an isolated environment called a **container**. The isolation and security allow you to run many containers simultaneously on a given host.
+Docker provides a way to package and run an application in an isolated environment called a **container**. The isolation and security allow you to run many containers simultaneously on a given host. Unlike virtual machines, containers share the host kernel and start in milliseconds rather than minutes - making them the standard unit of deployment for modern applications.
+
+---
 
 ## Understanding the Architecture
 
-Docker uses a client-server architecture. The [**Docker client**](https://docs.docker.com/engine/reference/commandline/cli/) talks to the [**Docker daemon**](https://docs.docker.com/engine/reference/commandline/dockerd/), which does the heavy lifting of building, running, and distributing your Docker containers.
+Docker uses a client-server architecture. The [**Docker client**](https://docs.docker.com/engine/reference/commandline/cli/) talks to the [**Docker daemon**](https://docs.docker.com/engine/reference/commandline/dockerd/), which does the heavy lifting of building, running, and distributing your containers.
 
-- **Docker Daemon (`dockerd`)**: Listens for Docker API requests and manages Docker objects such as images, containers, networks, and volumes.
-- **Docker Client (`docker`)**: The primary way that many Docker users interact with Docker. When you use commands such as `docker run`, the client sends these commands to `dockerd`, which carries them out.
-- **Docker Registries**: A Docker registry stores Docker images. [**Docker Hub**](https://hub.docker.com/) is a public registry that anyone can use, and Docker is configured to look for images on Docker Hub by default.
+- **Docker Daemon (`dockerd`)**: Listens for Docker API requests and manages Docker objects such as images, containers, networks, and volumes. It runs as a background service on the host.
+- **Docker Client (`docker`)**: The primary way users interact with Docker. When you run commands like `docker run`, the client sends these commands to `dockerd` via the Docker API.
+- **Docker Registries**: Stores and distributes Docker images. [**Docker Hub**](https://hub.docker.com/) is the default public registry. Organizations often run private registries using [**Harbor**](https://goharbor.io/) or cloud-provider registries (ECR, GCR, ACR).
+
+```mermaid
+graph LR
+    A[Docker Client] -->|REST API| B[Docker Daemon]
+    B --> C[Images]
+    B --> D[Containers]
+    B --> E[Networks]
+    B --> F[Volumes]
+    B -->|pull/push| G[Registry]
+```
 
 ---
 
 ## Images and Containers
 
 ### Images
-An **image** is a read-only template with instructions for creating a Docker container. Often, an image is based on another image, with some additional customization. For example, you may build an image which is based on the `ubuntu` image, but installs the Apache web server and your application, as well as the configuration details needed to make your application run.
+
+An **image** is a read-only template with instructions for creating a Docker container. Images are built in layers - each instruction in a Dockerfile creates a new layer stacked on top of the previous ones. When you change a layer, only that layer and everything above it gets rebuilt.
+
+```bash
+# List images on your system
+docker images
+
+# Pull an image from Docker Hub without running it
+docker pull nginx:1.25
+
+# Remove an image
+docker rmi nginx:1.25
+```
+
+!!! tip "Image layer caching"
+    Docker caches each layer independently. If nothing changed in a layer, Docker reuses the cached version. This is why Dockerfiles copy dependency files (like `package.json` or `requirements.txt`) before copying application code - dependencies change less frequently, so that layer stays cached across most builds.
 
 ### Containers
-A **container** is a runnable instance of an image. You can create, start, stop, move, or delete a container using the Docker API or CLI. You can connect a container to one or more networks, attach storage to it, or even create a new image based on its current state.
 
-By default, a container is relatively well isolated from other containers and its host machine.
+A **container** is a runnable instance of an image. You can create, start, stop, and delete containers using the Docker CLI. Each container gets its own filesystem, networking, and process tree - isolated from the host and from other containers.
+
+Containers are **ephemeral** by default. When you remove a container, any data written inside it is gone. This is by design - it forces you to think about persistence explicitly through volumes.
 
 ---
 
-## Basic Docker Commands
+## Container Lifecycle
 
-The `docker` CLI is the main tool for managing containers.
+A container moves through several states during its life:
 
-### Running a Container
-
-The most common command is `docker run`, which pulls an image (if it's not already present), creates a container, and starts it.
-
-```bash
-docker run -d --name my-web-server -p 8080:80 nginx
+```mermaid
+graph LR
+    A[Created] -->|start| B[Running]
+    B -->|stop| C[Stopped]
+    C -->|start| B
+    C -->|rm| D[Removed]
+    B -->|kill| C
+    B -->|rm -f| D
 ```
 
-- `-d`: Runs the container in **detached mode** (in the background).
-- `--name`: Assigns a custom name to the container.
-- `-p 8080:80`: Maps port 8080 on the host to port 80 in the container.
-- `nginx`: The name of the image to use.
+```bash
+# Create a container without starting it
+docker create --name my-app nginx
 
-### Managing Containers
+# Start a stopped or created container
+docker start my-app
 
-- `docker ps`: List running containers.
-- `docker ps -a`: List all containers (including stopped ones).
-- `docker stop <container_id>`: Stop a running container.
-- `docker rm <container_id>`: Remove a container.
-- `docker images`: List all images on the host.
-- `docker rmi <image_id>`: Remove an image.
+# Stop gracefully (sends SIGTERM, then SIGKILL after timeout)
+docker stop my-app
+
+# Kill immediately (sends SIGKILL)
+docker kill my-app
+
+# Remove a stopped container
+docker rm my-app
+
+# Force-remove a running container (stop + rm in one step)
+docker rm -f my-app
+```
+
+---
+
+## Running Containers
+
+The `docker run` command combines `create` and `start` into a single step. It pulls the image if not present, creates a container, and starts it.
+
+```bash
+# Run Nginx in the background, map port 8080 on host to 80 in container
+docker run -d --name my-web -p 8080:80 nginx
+
+# Run an interactive Ubuntu shell (removed on exit)
+docker run -it --rm ubuntu bash
+
+# Run with environment variables
+docker run -d --name my-db \
+  -e POSTGRES_USER=admin \
+  -e POSTGRES_PASSWORD=secret \
+  -p 5432:5432 \
+  postgres:16
+```
+
+- `-d`: **Detached mode** - runs in the background and prints the container ID.
+- `-it`: **Interactive terminal** - allocates a pseudo-TTY and keeps STDIN open. Use this for shells.
+- `--rm`: Automatically remove the container when it exits. Good for throwaway tasks.
+- `--name`: Assigns a human-readable name instead of Docker's random names.
+- `-p HOST:CONTAINER`: Maps a host port to a container port.
+- `-e KEY=VALUE`: Sets an environment variable inside the container.
+
+### Inspecting Running Containers
+
+```bash
+# List running containers
+docker ps
+
+# List all containers (including stopped)
+docker ps -a
+
+# View detailed container metadata (networking, mounts, config)
+docker inspect my-web
+
+# See resource usage (CPU, memory, network I/O)
+docker stats
+```
+
+---
+
+## Working Inside Containers
+
+You frequently need to run commands inside a running container for debugging, database administration, or one-off tasks.
+
+```bash
+# Open a shell in a running container
+docker exec -it my-web bash
+
+# Run a single command without an interactive shell
+docker exec my-db psql -U admin -c "SELECT version();"
+
+# View container logs (stdout/stderr)
+docker logs my-web
+
+# Follow logs in real time (like tail -f)
+docker logs -f --tail 100 my-web
+```
+
+!!! warning "Running as root inside containers"
+    By default, processes inside a container run as root. This means a container breakout vulnerability gives the attacker root access on the host. Always add a `USER` directive in your Dockerfile to run as a non-root user, and use `--read-only` to mount the container filesystem as read-only where possible.
 
 ---
 
 ## Dockerfile: Building Your Own Image
 
-To create your own image, you create a [**`Dockerfile`**](https://docs.docker.com/engine/reference/builder/) with a simple syntax for defining the steps needed to create the image and run it.
+A [**Dockerfile**](https://docs.docker.com/engine/reference/builder/) is a text file with instructions for assembling an image. Each instruction creates a layer.
+
+### Basic Dockerfile
 
 ```dockerfile
-# Use an official Node.js runtime as a parent image
-FROM node:14
+# Start from an official Python image
+FROM python:3.12-slim
 
-# Set the working directory in the container
-WORKDIR /usr/src/app
+# Set the working directory
+WORKDIR /app
 
-# Copy package.json and install dependencies
-COPY package*.json ./
-RUN npm install
+# Copy dependency file first (layer caching)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the rest of the application code
+# Copy application code
 COPY . .
 
-# Make port 8080 available to the world outside this container
-EXPOSE 8080
+# Expose the port the app runs on
+EXPOSE 8000
 
-# Define the command to run your app
-CMD [ "node", "app.js" ]
+# Run the application
+CMD ["python", "app.py"]
 ```
 
-To build an image from a Dockerfile:
+### Key Instructions
+
+| Instruction | Purpose |
+|------------|---------|
+| `FROM` | Sets the base image. Every Dockerfile starts with this. |
+| `WORKDIR` | Sets the working directory for subsequent instructions. |
+| `COPY` | Copies files from the build context into the image. |
+| `RUN` | Executes a command during the build (installing packages, compiling code). |
+| `EXPOSE` | Documents which port the container listens on. Does not actually publish it. |
+| `CMD` | Default command when the container starts. Only the last `CMD` takes effect. |
+| `ENTRYPOINT` | Like `CMD`, but arguments passed to `docker run` are appended rather than replacing it. |
+| `ENV` | Sets environment variables available during build and at runtime. |
+| `USER` | Switches to a non-root user for subsequent instructions and at runtime. |
+| `ARG` | Defines build-time variables (not available at runtime). |
+
+### The `.dockerignore` File
+
+Just like `.gitignore`, a `.dockerignore` file prevents unnecessary files from being sent to the Docker daemon during builds. This speeds up builds and prevents secrets from leaking into images.
+
+```
+.git
+node_modules
+__pycache__
+*.pyc
+.env
+.vscode
+README.md
+```
+
+### Building and Tagging
 
 ```bash
-docker build -t my-node-app .
+# Build from the current directory
+docker build -t my-app .
+
+# Build with a specific tag (version)
+docker build -t my-app:1.0.0 .
+
+# Build and specify a different Dockerfile
+docker build -f Dockerfile.prod -t my-app:prod .
 ```
 
 ---
 
-## Interactive Quizzes: Docker Basics
+## Multi-Stage Builds
 
-Test your knowledge of Docker fundamentals.
+Multi-stage builds let you use multiple `FROM` statements in a single Dockerfile. This is the standard pattern for producing small, secure production images - you compile or build in one stage, then copy only the artifacts into a minimal final stage.
+
+```dockerfile
+# Stage 1: Build
+FROM golang:1.22 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /app
+
+# Stage 2: Production
+FROM alpine:3.19
+RUN apk --no-cache add ca-certificates
+COPY --from=builder /app /app
+USER nobody
+ENTRYPOINT ["/app"]
+```
+
+The final image contains only the compiled binary and ca-certificates - no Go toolchain, no source code. A Go application image built this way is typically 10-20 MB instead of 800+ MB.
+
+```code-walkthrough
+title: "Multi-Stage Dockerfile Anatomy"
+description: "How a multi-stage build separates build tools from the production image."
+code: |
+  FROM golang:1.22 AS builder
+  WORKDIR /src
+  COPY go.mod go.sum ./
+  RUN go mod download
+  COPY . .
+  RUN CGO_ENABLED=0 go build -o /app
+
+  FROM alpine:3.19
+  RUN apk --no-cache add ca-certificates
+  COPY --from=builder /app /app
+  USER nobody
+  ENTRYPOINT ["/app"]
+annotations:
+  - line: 1
+    text: "The first FROM starts the build stage. 'AS builder' names it so later stages can reference it. This image includes the full Go toolchain (~800 MB)."
+  - line: 2
+    text: "WORKDIR creates and switches to /src. All subsequent commands run from this directory."
+  - line: 3
+    text: "Copy dependency manifests first. If go.mod and go.sum haven't changed, Docker reuses the cached layer from the next step - skipping a potentially slow download."
+  - line: 4
+    text: "Download all dependencies. This layer is cached independently, so adding new application code won't re-trigger this step."
+  - line: 5
+    text: "Now copy the full source code. This layer invalidates on every code change, but the dependency layer above stays cached."
+  - line: 6
+    text: "CGO_ENABLED=0 produces a statically linked binary with no C library dependency - required for running on minimal images like alpine or scratch."
+  - line: 8
+    text: "The second FROM starts a fresh stage from alpine (~5 MB). Nothing from the builder stage carries over unless explicitly copied."
+  - line: 9
+    text: "Install CA certificates so the binary can make HTTPS calls. The --no-cache flag avoids storing the package index in the image."
+  - line: 10
+    text: "COPY --from=builder copies the compiled binary from the first stage. This is the key to multi-stage builds - cherry-pick only what the production image needs."
+  - line: 11
+    text: "Switch to the 'nobody' user. The final image runs without root privileges, limiting the blast radius of any container escape."
+  - line: 12
+    text: "ENTRYPOINT sets the binary as the container's main process. Unlike CMD, arguments passed to 'docker run' are appended to the entrypoint rather than replacing it."
+```
+
+---
+
+## Volumes and Persistence
+
+Containers are ephemeral - when you remove one, its filesystem is gone. **Volumes** are Docker's mechanism for persistent data that outlives any individual container.
+
+### Volume Types
+
+| Type | Syntax | Use Case |
+|------|--------|----------|
+| Named volume | `-v mydata:/var/lib/data` | Production data (databases, uploads). Docker manages the storage location. |
+| Bind mount | `-v /host/path:/container/path` | Development (mount source code for live reloading). |
+| tmpfs mount | `--tmpfs /tmp` | Scratch space that should never touch disk (secrets, session data). |
+
+```bash
+# Create and use a named volume
+docker volume create pgdata
+docker run -d --name db -v pgdata:/var/lib/postgresql/data postgres:16
+
+# Bind mount for development
+docker run -d --name dev-app -v $(pwd):/app -p 3000:3000 node:20
+
+# List volumes
+docker volume ls
+
+# Remove unused volumes
+docker volume prune
+```
+
+!!! danger "Bind mounts expose the host filesystem"
+    Bind mounts give the container direct access to host directories. A misconfigured bind mount (e.g., `-v /:/host`) can expose the entire host filesystem. In production, prefer named volumes. Reserve bind mounts for development workflows where you need live code reloading.
+
+---
+
+## Networking
+
+Docker creates isolated networks so containers can communicate with each other without exposing ports to the host.
+
+### Network Types
+
+| Driver | Description |
+|--------|-------------|
+| `bridge` | Default. Containers on the same bridge network can reach each other by container name. |
+| `host` | Removes network isolation - the container shares the host's network stack. |
+| `none` | Disables networking entirely. |
+| `overlay` | Spans multiple Docker hosts. Used with Docker Swarm for multi-node clusters. |
+
+```bash
+# Create a custom bridge network
+docker network create my-net
+
+# Run containers on the same network
+docker run -d --name api --network my-net my-api-image
+docker run -d --name db --network my-net postgres:16
+
+# The api container can now reach the database at hostname "db"
+# No port publishing needed for container-to-container communication
+```
+
+Containers on the default `bridge` network cannot resolve each other by name - they can only communicate by IP address. Custom bridge networks enable DNS-based service discovery, which is why you should always create a named network for multi-container setups.
+
+---
+
+## Resource Limits
+
+Without limits, a single container can consume all available CPU and memory on the host, starving other containers and system processes.
+
+```bash
+# Limit memory to 512MB and CPU to 1.5 cores
+docker run -d --name api \
+  --memory=512m \
+  --cpus=1.5 \
+  my-api-image
+
+# Set a memory reservation (soft limit) and hard limit
+docker run -d --name worker \
+  --memory=1g \
+  --memory-reservation=512m \
+  my-worker-image
+```
+
+If a container exceeds its memory limit, Docker kills it with an out-of-memory (OOM) error. You can see this in `docker inspect`:
+
+```bash
+docker inspect my-app --format='{{.State.OOMKilled}}'
+```
+
+---
+
+## Debugging Containers
+
+When a container crashes or behaves unexpectedly, these commands help you diagnose the problem.
+
+```bash
+# Check why a container stopped
+docker inspect my-app --format='{{.State.ExitCode}} {{.State.Error}}'
+
+# View the last 200 lines of logs
+docker logs --tail 200 my-app
+
+# See what changed in the container's filesystem since it started
+docker diff my-app
+
+# Export a stopped container's filesystem for inspection
+docker export my-app | tar -tf - | head -50
+
+# Start a fresh container from the same image for comparison
+docker run -it --rm my-app-image sh
+```
+
+Common exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Clean exit |
+| `1` | Application error |
+| `137` | Killed by OOM or `docker kill` (128 + SIGKILL=9) |
+| `139` | Segmentation fault (128 + SIGSEGV=11) |
+| `143` | Graceful stop via `docker stop` (128 + SIGTERM=15) |
+
+---
+
+## Putting It All Together
+
+```terminal
+scenario: "Build and deploy a Python web application with Docker"
+steps:
+  - command: "ls"
+    output: "Dockerfile  app.py  requirements.txt"
+    narration: "You have a Python application with its Dockerfile and dependency file ready."
+  - command: "cat Dockerfile"
+    output: "FROM python:3.12-slim\nWORKDIR /app\nCOPY requirements.txt .\nRUN pip install --no-cache-dir -r requirements.txt\nCOPY . .\nUSER nobody\nEXPOSE 8000\nCMD [\"uvicorn\", \"app:app\", \"--host\", \"0.0.0.0\", \"--port\", \"8000\"]"
+    narration: "The Dockerfile uses a slim base image, installs dependencies first for layer caching, copies application code, drops to a non-root user, and runs the app with uvicorn."
+  - command: "docker build -t my-api:1.0 ."
+    output: "[+] Building 12.3s (9/9) FINISHED\n => [1/5] FROM python:3.12-slim\n => [2/5] WORKDIR /app\n => [3/5] COPY requirements.txt .\n => [4/5] RUN pip install --no-cache-dir -r requirements.txt\n => [5/5] COPY . .\n => exporting to image\n => naming to docker.io/library/my-api:1.0"
+    narration: "Docker builds the image layer by layer. Each step is cached - if you change only app.py, steps 1-4 use the cache and only step 5 runs again."
+  - command: "docker images my-api"
+    output: "REPOSITORY   TAG   IMAGE ID       CREATED          SIZE\nmy-api       1.0   a3b8f2c1d4e5   12 seconds ago   187MB"
+    narration: "The image is 187MB. Using python:3.12-slim instead of the full python:3.12 image saves about 700MB."
+  - command: "docker run -d --name api -p 8000:8000 --memory=256m my-api:1.0"
+    output: "f7a2b3c4d5e6f7a2b3c4d5e6f7a2b3c4d5e6f7a2b3c4d5e6f7a2b3c4"
+    narration: "Start the container in detached mode with a port mapping and a 256MB memory limit. Docker prints the full container ID."
+  - command: "docker ps"
+    output: "CONTAINER ID   IMAGE        COMMAND                  STATUS          PORTS                    NAMES\nf7a2b3c4d5e6   my-api:1.0   \"uvicorn app:app --h…\"   Up 3 seconds    0.0.0.0:8000->8000/tcp   api"
+    narration: "The container is running. Port 8000 on your machine now forwards to the container."
+  - command: "curl -s http://localhost:8000/health"
+    output: "{\"status\": \"ok\"}"
+    narration: "The API responds. Any HTTP client on the host can reach the container through the published port."
+  - command: "docker logs api"
+    output: "INFO:     Started server process [1]\nINFO:     Waiting for application startup.\nINFO:     Application startup complete.\nINFO:     Uvicorn running on http://0.0.0.0:8000\nINFO:     172.17.0.1:54321 - \"GET /health HTTP/1.1\" 200"
+    narration: "Container logs capture everything the process writes to stdout and stderr. You can see the startup messages and the health check request."
+  - command: "docker stop api && docker rm api"
+    output: "api\napi"
+    narration: "Stop the container gracefully (SIGTERM → SIGKILL after 10s), then remove it. The image remains for future use."
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
 question: "What is the primary difference between an image and a container?"
@@ -99,48 +460,102 @@ options:
     feedback: "An image is the template; a container is the instance."
   - text: "An image is a read-only template, while a container is its runnable instance."
     correct: true
-    feedback: "Correct! Think of an image as a blueprint (template) and a container as the actual building (instance) created from that blueprint."
+    feedback: "Correct! Think of an image as a blueprint and a container as the building created from that blueprint. You can create many containers from the same image."
   - text: "There is no difference; the terms are interchangeable."
-    feedback: "They are distinct concepts. An image is static; a container is active."
+    feedback: "They are distinct concepts. An image is static and read-only; a container is a running process with its own writable layer."
 ```
 
 ```quiz
-question: "Which Docker command is used to list all containers, including those that are stopped?"
+question: "Why does a well-written Dockerfile copy `requirements.txt` before copying the rest of the application code?"
 type: multiple-choice
 options:
-  - text: "docker ps"
-    feedback: "docker ps only shows running containers by default."
-  - text: "docker ps -a"
+  - text: "Python requires it to be copied first."
+    feedback: "This is a Docker optimization pattern, not a Python requirement."
+  - text: "To take advantage of Docker's layer caching - dependencies change less often than code."
     correct: true
-    feedback: "Correct! Adding the `-a` (or `--all`) flag includes stopped containers in the output."
-  - text: "docker list"
-    feedback: "There is no 'docker list' command; the command is 'docker container ls' or 'docker ps'."
-  - text: "docker containers --all"
-    feedback: "The correct syntax is 'docker container ls -a' or 'docker ps -a'."
+    feedback: "Correct! If requirements.txt hasn't changed, Docker reuses the cached pip install layer. This means rebuilding after a code change takes seconds instead of minutes."
+  - text: "To reduce the final image size."
+    feedback: "The copy order doesn't affect final image size - the same files end up in the image either way. It affects build speed through caching."
+  - text: "To prevent security vulnerabilities."
+    feedback: "While Dockerfile best practices improve security, this particular pattern is about build performance through layer caching."
 ```
 
 ```quiz
-question: "In the command `docker run -p 8080:80 nginx`, what does the `8080:80` part do?"
+question: "A container exits with code 137. What happened?"
 type: multiple-choice
 options:
-  - text: "Sets the container ID to 8080."
-    feedback: "Container IDs are generated hashes, not set via port flags."
-  - text: "Maps host port 80 to container port 8080."
-    feedback: "The mapping is HOST:CONTAINER, not the other way around."
-  - text: "Maps host port 8080 to container port 80."
+  - text: "The application crashed with an unhandled exception."
+    feedback: "Application exceptions typically produce exit code 1. Code 137 indicates an external signal."
+  - text: "The container ran out of memory or was killed with docker kill."
     correct: true
-    feedback: "Correct! The port mapping syntax is `HOST_PORT:CONTAINER_PORT`. Here, it forwards traffic from the host's port 8080 to the container's port 80."
-  - text: "Limits the container to 8080MB of RAM."
-    feedback: "Memory limits are set with the -m flag, not -p."
+    feedback: "Correct! Exit code 137 = 128 + 9 (SIGKILL). The two most common causes are the OOM killer terminating the process for exceeding its memory limit, or an explicit docker kill command."
+  - text: "The Dockerfile had a syntax error."
+    feedback: "Dockerfile syntax errors prevent the image from building at all. They don't produce runtime exit codes."
+  - text: "Docker could not find the specified image."
+    feedback: "Missing images produce an error before the container starts, not an exit code."
+```
+
+---
+
+```exercise
+title: "Containerize a Python Application"
+description: "Write a Dockerfile and supporting files for a Flask API, then build and run it."
+requirements:
+  - "Create a Dockerfile that uses python:3.12-slim as the base image"
+  - "Install dependencies from requirements.txt using pip with --no-cache-dir"
+  - "Copy application code after installing dependencies (for layer caching)"
+  - "Run the app as a non-root user"
+  - "Create a .dockerignore that excludes .git, __pycache__, .env, and venv/"
+  - "Build the image tagged as flask-app:1.0"
+  - "Run the container with port 5000 mapped and a 256MB memory limit"
+hints:
+  - "Start with FROM, then WORKDIR, then COPY just the requirements file"
+  - "Use RUN adduser --disabled-password appuser and USER appuser to drop root privileges"
+  - "Use EXPOSE to document the port, but -p at runtime to actually publish it"
+  - "The .dockerignore syntax is identical to .gitignore"
+solution: |
+  # Dockerfile
+  FROM python:3.12-slim
+
+  WORKDIR /app
+
+  # Create a non-root user
+  RUN adduser --disabled-password --no-create-home appuser
+
+  # Install dependencies first (layer caching)
+  COPY requirements.txt .
+  RUN pip install --no-cache-dir -r requirements.txt
+
+  # Copy application code
+  COPY . .
+
+  # Switch to non-root user
+  USER appuser
+
+  EXPOSE 5000
+  CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]
+
+  # .dockerignore
+  # .git
+  # __pycache__
+  # *.pyc
+  # .env
+  # venv/
+  # .vscode
+
+  # Build and run:
+  # docker build -t flask-app:1.0 .
+  # docker run -d -p 5000:5000 --memory=256m flask-app:1.0
 ```
 
 ---
 
 ## Further Reading
 
-- [**Docker Documentation**](https://docs.docker.com/)  
-- [**Docker Hub**](https://hub.docker.com/)  
-- [**Dockerfile Reference**](https://docs.docker.com/engine/reference/builder/)  
+- [Docker Documentation](https://docs.docker.com/) - official guides covering installation, configuration, and advanced features
+- [Dockerfile Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) - official recommendations for writing efficient, secure Dockerfiles
+- [Docker Hub](https://hub.docker.com/) - the default public registry with official and community images
+- [Dive](https://github.com/wagoodman/dive) - a tool for exploring Docker image layers and finding wasted space
 
 ---
 

--- a/Nginx/configuration.md
+++ b/Nginx/configuration.md
@@ -1,12 +1,38 @@
 # Nginx Configuration
 
-Nginx is a high-performance HTTP server, reverse proxy, and load balancer. Its event-driven architecture allows it to handle thousands of concurrent connections with minimal memory overhead, making it the industry standard for serving static content and proxying to application servers.
+[**Nginx**](https://nginx.org/) is a high-performance HTTP server, reverse proxy, and load balancer. Its event-driven architecture handles thousands of concurrent connections with minimal memory overhead, making it the industry standard for serving static content, terminating TLS, and proxying to application servers.
 
 ---
 
-## Server Blocks (Virtual Hosts)
+## Configuration Structure
 
-Nginx uses **server blocks** to host multiple domains on a single IP address. Each block defines how Nginx should respond to requests for a specific domain name or port.
+Nginx configuration is hierarchical. The main file is typically `/etc/nginx/nginx.conf`, which includes additional files for organization.
+
+```
+/etc/nginx/
+├── nginx.conf              # Main config (worker processes, global settings)
+├── conf.d/                 # General config snippets (loaded by default)
+│   └── default.conf
+├── sites-available/        # All virtual host configs (Debian/Ubuntu)
+│   ├── default
+│   └── example.com
+├── sites-enabled/          # Symlinks to active configs
+│   └── example.com -> ../sites-available/example.com
+├── snippets/               # Reusable config fragments
+│   └── ssl-params.conf
+└── mime.types              # File extension to MIME type mappings
+```
+
+The `sites-available` / `sites-enabled` pattern (common on Debian/Ubuntu) keeps all configurations in one place while controlling which ones are active via symlinks. RHEL-based distributions typically use `conf.d/` exclusively.
+
+!!! tip "Always test before reloading"
+    Run `nginx -t` before applying any configuration change. It validates syntax and catches errors like missing semicolons or duplicate `server_name` directives without touching the running server. Reload with `sudo systemctl reload nginx` - reload is graceful (existing connections finish), while restart drops them.
+
+---
+
+## Server Blocks
+
+**Server blocks** are Nginx's equivalent of Apache virtual hosts. Each block defines how Nginx handles requests for a specific domain or IP/port combination.
 
 ```nginx
 server {
@@ -22,16 +48,72 @@ server {
 }
 ```
 
-- **`listen`**: The port Nginx should monitor for incoming connections.
-- **`server_name`**: The domain names this block should respond to.
-- **`root`**: The directory on the filesystem containing the static files.
-- **`index`**: The default file to serve if a directory is requested.
+- **`listen`**: The port (and optionally IP address) to bind. `listen 80` binds to all interfaces on port 80.
+- **`server_name`**: Domain names this block handles. Nginx matches the `Host` header from the request against these values.
+- **`root`**: The filesystem directory containing the site's files.
+- **`index`**: Default files to serve when a directory is requested.
+- **`try_files`**: Attempts each path in order. Here it tries the exact URI, then the URI as a directory, then returns 404.
+
+### How Nginx Selects a Server Block
+
+When a request arrives, Nginx first matches the `listen` directive (IP + port), then matches `server_name` against the `Host` header. If no `server_name` matches, it falls back to the `default_server`:
+
+```nginx
+server {
+    listen 80 default_server;
+    server_name _;
+    return 444;  # Close connection without response
+}
+```
+
+This catch-all block drops requests for unknown domains - a basic security measure against scanners probing by IP address.
+
+---
+
+## Location Blocks and Matching
+
+Location blocks define how Nginx handles requests to specific URL paths. The matching rules have a defined precedence:
+
+| Modifier | Type | Priority | Example |
+|----------|------|----------|---------|
+| `=` | Exact match | 1 (highest) | `location = /health { ... }` |
+| `^~` | Prefix (stops search) | 2 | `location ^~ /static/ { ... }` |
+| `~` | Regex (case-sensitive) | 3 | `location ~ \.php$ { ... }` |
+| `~*` | Regex (case-insensitive) | 3 | `location ~* \.(jpg|png)$ { ... }` |
+| (none) | Prefix | 4 (lowest) | `location /api/ { ... }` |
+
+Nginx evaluates locations in this order: exact matches first, then prefix matches (longest wins), then regex matches (first match in config order wins). The `^~` modifier on a prefix match prevents regex locations from overriding it.
+
+```nginx
+# Exact match for health checks (fastest - no further searching)
+location = /health {
+    return 200 "ok";
+    add_header Content-Type text/plain;
+}
+
+# All static files - ^~ prevents regex locations from overriding
+location ^~ /static/ {
+    root /var/www;
+    expires 30d;
+    add_header Cache-Control "public, immutable";
+}
+
+# API requests proxied to the backend
+location /api/ {
+    proxy_pass http://localhost:3000;
+}
+
+# Everything else
+location / {
+    try_files $uri $uri/ /index.html;
+}
+```
 
 ---
 
 ## Reverse Proxying
 
-As a **reverse proxy**, Nginx sits between client browsers and backend application servers (like Node.js, Python/Django, or Go). It handles client connections and forwards requests to the appropriate backend.
+As a **reverse proxy**, Nginx sits between client browsers and backend application servers. It handles TLS termination, static file serving, and load distribution while your application focuses on business logic.
 
 ```nginx
 server {
@@ -44,18 +126,74 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Timeouts
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
     }
 }
 ```
 
-- **`proxy_pass`**: Specifies the backend server address.
-- **`proxy_set_header`**: Forwards original client headers (like IP and protocol) so the backend knows who the actual client is.
+- **`proxy_pass`**: The backend address. A trailing slash matters: `proxy_pass http://backend/` strips the matched location prefix from the forwarded URI; without the slash, the full URI is forwarded.
+- **`proxy_set_header`**: Passes original client information to the backend. Without these headers, the backend sees all requests as coming from 127.0.0.1.
+- **Timeouts**: `proxy_connect_timeout` limits how long Nginx waits to establish a connection. `proxy_read_timeout` limits how long it waits for a response.
+
+### WebSocket Proxying
+
+WebSocket connections require Nginx to upgrade the HTTP connection:
+
+```nginx
+location /ws/ {
+    proxy_pass http://localhost:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_read_timeout 3600s;  # Keep alive for up to 1 hour
+}
+```
+
+---
+
+## Load Balancing
+
+The `upstream` block distributes requests across multiple backend servers.
+
+```nginx
+upstream api_servers {
+    least_conn;  # Send to the server with fewest active connections
+    server 10.0.0.1:3000 weight=3;
+    server 10.0.0.2:3000;
+    server 10.0.0.3:3000 backup;  # Only used if others are down
+}
+
+server {
+    listen 80;
+    server_name api.example.com;
+
+    location / {
+        proxy_pass http://api_servers;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Load balancing algorithms:
+
+| Algorithm | Directive | Behavior |
+|-----------|-----------|----------|
+| Round robin | (default) | Distributes requests evenly in order |
+| Least connections | `least_conn` | Sends to the server with fewest active connections |
+| IP hash | `ip_hash` | Routes the same client IP to the same server (session persistence) |
+| Hash | `hash $request_uri` | Routes by a custom key (e.g., URI, cookie) |
 
 ---
 
 ## SSL/TLS Termination
 
-Handling SSL/TLS at the Nginx layer is more efficient than doing it in the application. Modern Nginx configurations should always redirect HTTP to HTTPS and use strong encryption settings.
+Handling TLS at the Nginx layer is more efficient than doing it in the application. Nginx manages certificate negotiation and encryption while forwarding plain HTTP to the backend.
 
 ```nginx
 server {
@@ -71,102 +209,399 @@ server {
     ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
 
-    # Modern SSL configuration (Mozilla Intermediate)
+    # Modern TLS configuration (Mozilla Intermediate)
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
 
+    # HSTS - tell browsers to always use HTTPS
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+
     location / {
-        root /var/www/example.com;
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
 ```
+
+The first server block redirects all HTTP traffic to HTTPS. The second handles encrypted connections with modern cipher suites.
+
+---
+
+## Security Headers
+
+A well-configured Nginx adds security headers that instruct browsers to enable protections against common attacks.
+
+```nginx
+# Add these in the server or http block
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+```
+
+| Header | Purpose |
+|--------|---------|
+| `X-Frame-Options` | Prevents clickjacking by controlling iframe embedding |
+| `X-Content-Type-Options` | Stops browsers from MIME-sniffing responses |
+| `Strict-Transport-Security` | Forces HTTPS for the specified duration |
+| `Content-Security-Policy` | Controls which sources can load scripts, styles, and other resources |
+| `Referrer-Policy` | Controls how much URL information is sent in the Referer header |
+
+!!! danger "Hide server version information"
+    By default, Nginx exposes its version in response headers (`Server: nginx/1.25.3`) and error pages. Attackers use this to find known vulnerabilities for specific versions. Add `server_tokens off;` in the `http` block to suppress the version number.
 
 ---
 
 ## Rate Limiting
 
-Rate limiting protects your application from abuse, brute-force attacks, and DDoS. Nginx uses **leaky bucket** algorithms to control the rate of incoming requests.
+Rate limiting protects your application from brute-force attacks, credential stuffing, and abusive clients. Nginx uses a **leaky bucket** algorithm to control request rates.
 
 ```nginx
-# Define the limit zone (10MB shared memory, 1 request per second)
-limit_req_zone $binary_remote_addr zone=mylimit:10m rate=1r/s;
+# Define the zone in the http block (10MB shared memory, 10 requests/second)
+limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
+
+# Stricter limit for authentication endpoints
+limit_req_zone $binary_remote_addr zone=login_limit:10m rate=1r/s;
 
 server {
     listen 80;
     server_name example.com;
 
+    location /api/ {
+        limit_req zone=api_limit burst=20 nodelay;
+        proxy_pass http://localhost:3000;
+    }
+
     location /login {
-        # Apply the limit with a burst of 5
-        limit_req zone=mylimit burst=5 nodelay;
+        limit_req zone=login_limit burst=3;
+        limit_req_status 429;
         proxy_pass http://localhost:3000;
     }
 }
 ```
 
-- **`limit_req_zone`**: Sets up the memory zone to track client IP addresses.
-- **`burst`**: Allows clients to exceed the rate for a short period.
-- **`nodelay`**: Processes burst requests immediately instead of queuing them.
+- **`limit_req_zone`**: Creates a shared memory zone that tracks request rates per key (usually client IP). 10MB stores about 160,000 IP addresses.
+- **`burst`**: Allows short bursts above the rate limit. Excess requests queue up.
+- **`nodelay`**: Processes queued burst requests immediately instead of spacing them out.
+- **`limit_req_status`**: Sets the HTTP status code for rejected requests (default 503, but 429 Too Many Requests is more correct).
 
 ---
 
-## Interactive Quizzes: Nginx Configuration
+## Logging
 
-Verify your understanding of Nginx's core configuration directives.
+Nginx produces two log types: **access logs** (one line per request) and **error logs** (server-side problems).
+
+```nginx
+# Custom log format with timing information
+log_format detailed '$remote_addr - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent" '
+                    'rt=$request_time urt=$upstream_response_time';
+
+server {
+    access_log /var/log/nginx/example.access.log detailed;
+    error_log /var/log/nginx/example.error.log warn;
+
+    # Disable logging for health checks (reduces noise)
+    location = /health {
+        access_log off;
+        return 200 "ok";
+    }
+}
+```
+
+Key timing variables:
+- `$request_time`: Total time from first client byte to last response byte (includes backend processing).
+- `$upstream_response_time`: Time the backend took to respond. If this is high but `$request_time` is similar, the bottleneck is your application, not Nginx.
+
+---
+
+## Gzip Compression
+
+Compression reduces bandwidth and speeds up page loads, especially for text-based assets.
+
+```nginx
+# In the http block
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 4;
+gzip_min_length 256;
+gzip_types
+    text/plain
+    text/css
+    text/javascript
+    application/javascript
+    application/json
+    application/xml
+    image/svg+xml;
+```
+
+- **`gzip_vary`**: Adds `Vary: Accept-Encoding` so caches store compressed and uncompressed versions separately.
+- **`gzip_comp_level`**: 1-9 (higher = smaller files, more CPU). Level 4-6 is the sweet spot for most workloads.
+- **`gzip_min_length`**: Skip compression for tiny responses where the overhead isn't worth it.
+- **`gzip_types`**: Only compress text-based formats. Images like JPEG and PNG are already compressed.
+
+---
+
+## Putting It Together: Production Configuration
+
+```code-walkthrough
+title: "Production Nginx Configuration"
+description: "A complete reverse proxy configuration with TLS, security headers, rate limiting, and logging."
+code: |
+  server_tokens off;
+
+  limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+  limit_req_zone $binary_remote_addr zone=login:10m rate=1r/s;
+
+  upstream backend {
+      least_conn;
+      server 127.0.0.1:3000;
+      server 127.0.0.1:3001;
+  }
+
+  server {
+      listen 80;
+      server_name example.com;
+      return 301 https://$host$request_uri;
+  }
+
+  server {
+      listen 443 ssl http2;
+      server_name example.com;
+
+      ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+      ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+      ssl_protocols       TLSv1.2 TLSv1.3;
+
+      add_header Strict-Transport-Security "max-age=63072000" always;
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+
+      location /api/ {
+          limit_req zone=api burst=20 nodelay;
+          proxy_pass http://backend;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+      }
+
+      location /login {
+          limit_req zone=login burst=3;
+          limit_req_status 429;
+          proxy_pass http://backend;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+      }
+
+      location /static/ {
+          root /var/www;
+          expires 30d;
+          add_header Cache-Control "public, immutable";
+      }
+
+      location = /health {
+          access_log off;
+          return 200 "ok";
+      }
+  }
+annotations:
+  - line: 1
+    text: "Hides the Nginx version from response headers and error pages. Reduces information leakage to attackers."
+  - line: 3
+    text: "Two rate limit zones: a general API limit (10 req/s) and a strict login limit (1 req/s). The 10m zone stores ~160K client IPs."
+  - line: 6
+    text: "An upstream block with two backend servers. least_conn routes each request to the server with the fewest active connections."
+  - line: 12
+    text: "HTTP server block that redirects everything to HTTPS. The 301 tells browsers to remember the redirect permanently."
+  - line: 17
+    text: "The main HTTPS server block. http2 enables HTTP/2 for better performance (multiplexing, header compression)."
+  - line: 22
+    text: "Modern TLS: only TLSv1.2 and 1.3. Older protocols (SSLv3, TLSv1.0, TLSv1.1) have known vulnerabilities."
+  - line: 24
+    text: "HSTS tells browsers to always use HTTPS for this domain. max-age is in seconds (63072000 = 2 years)."
+  - line: 28
+    text: "API routes get the general rate limit with a burst of 20. nodelay processes burst requests immediately instead of queuing."
+  - line: 36
+    text: "Login gets an aggressive rate limit (1/s, burst 3) to slow brute-force attacks. Returns 429 instead of the default 503."
+  - line: 44
+    text: "Static files served directly from disk with a 30-day cache. 'immutable' tells browsers not to revalidate during the cache period."
+  - line: 50
+    text: "Health check endpoint for load balancers. access_log off prevents it from flooding logs with noise."
+```
+
+---
+
+```terminal
+scenario: "Set up an Nginx reverse proxy for a Node.js application"
+steps:
+  - command: "sudo apt install nginx"
+    output: "Reading package lists... Done\nSetting up nginx (1.24.0-2ubuntu1) ..."
+    narration: "Install Nginx from the distribution's package repository."
+  - command: "sudo nginx -v"
+    output: "nginx version: nginx/1.24.0"
+    narration: "Verify the installation and check the installed version."
+  - command: "cat /etc/nginx/sites-available/myapp"
+    output: "server {\n    listen 80;\n    server_name myapp.example.com;\n\n    location / {\n        proxy_pass http://localhost:3000;\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n        proxy_set_header X-Forwarded-Proto $scheme;\n    }\n}"
+    narration: "Create a server block configuration for the application. Requests to myapp.example.com are proxied to the Node.js app running on port 3000."
+  - command: "sudo ln -s /etc/nginx/sites-available/myapp /etc/nginx/sites-enabled/"
+    output: ""
+    narration: "Enable the site by creating a symlink in sites-enabled. This is the Debian/Ubuntu convention for activating configurations."
+  - command: "sudo nginx -t"
+    output: "nginx: the configuration file /etc/nginx/nginx.conf syntax is ok\nnginx: configuration file /etc/nginx/nginx.conf test is successful"
+    narration: "Always test the configuration before reloading. This catches syntax errors and duplicate server_name conflicts without affecting the running server."
+  - command: "sudo systemctl reload nginx"
+    output: ""
+    narration: "Reload Nginx to apply the new configuration. Reload is graceful - existing connections are not dropped."
+  - command: "curl -I http://myapp.example.com"
+    output: "HTTP/1.1 200 OK\nServer: nginx\nContent-Type: text/html; charset=utf-8\nX-Powered-By: Express"
+    narration: "The reverse proxy is working. Nginx receives the request and forwards it to the Node.js backend. The X-Powered-By header from Express confirms the backend is responding."
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
-question: "Which directive is used to host multiple domains on a single IP address?"
+question: "Which location modifier has the highest matching priority?"
 type: multiple-choice
 options:
-  - text: "proxy_pass"
-    feedback: "proxy_pass is for reverse proxying to a backend, not for domain matching."
-  - text: "server_name"
+  - text: "~ (regex)"
+    feedback: "Regex matches have lower priority than exact and ^~ prefix matches."
+  - text: "^~ (prefix, stop search)"
+    feedback: "^~ has second-highest priority. It prevents regex from overriding a prefix match, but exact (=) still wins."
+  - text: "= (exact match)"
     correct: true
-    feedback: "Correct! The `server_name` directive tells Nginx which domain names a specific server block should handle."
-  - text: "listen"
-    feedback: "listen specifies the IP/port to monitor, but server_name distinguishes domains on that IP."
-  - text: "root"
-    feedback: "root sets the directory for static files."
+    feedback: "Correct! The = modifier matches only if the request URI is exactly equal to the specified string. It's the fastest match and has the highest priority."
+  - text: "(none) regular prefix"
+    feedback: "Plain prefix matches have the lowest priority. They can be overridden by regex matches."
 ```
 
 ```quiz
-question: "What is the purpose of the `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` directive?"
+question: "What does `proxy_pass http://backend/` (with trailing slash) do differently from `proxy_pass http://backend` (without)?"
 type: multiple-choice
 options:
-  - text: "To encrypt the request"
-    feedback: "Encryption is handled by SSL/TLS settings, not proxy headers."
-  - text: "To speed up the connection"
-    feedback: "Headers don't inherently speed up connections; they provide metadata."
-  - text: "To pass the original client's IP address to the backend"
+  - text: "Nothing - they are identical."
+    feedback: "The trailing slash changes URI handling significantly."
+  - text: "The trailing slash strips the matched location prefix from the forwarded URI."
     correct: true
-    feedback: "Correct! `X-Forwarded-For` is a standard header used by proxies to tell the backend server the IP address of the original client."
-  - text: "To set the domain name"
-    feedback: "Domain names are set using the Host header or server_name directive."
+    feedback: "Correct! With location /api/ and proxy_pass http://backend/, a request to /api/users is forwarded as /users. Without the slash, it's forwarded as /api/users. This is one of the most common sources of Nginx proxy bugs."
+  - text: "The trailing slash enables HTTPS."
+    feedback: "HTTPS is configured with ssl directives, not proxy_pass syntax."
+  - text: "The trailing slash adds a port number."
+    feedback: "Port numbers are specified explicitly in the URL, not implied by a trailing slash."
 ```
 
 ```quiz
-question: "In rate limiting, what does the `burst` parameter do?"
+question: "Why should you run `nginx -t` before `systemctl reload nginx`?"
 type: multiple-choice
 options:
-  - text: "It completely blocks the user if they exceed the limit"
-    feedback: "It allows exceeding the limit for a short burst before blocking."
-  - text: "It allows a certain number of requests to exceed the base rate"
+  - text: "It's required by Nginx to unlock the reload command."
+    feedback: "There's no locking mechanism - you can reload without testing. But testing first is a critical best practice."
+  - text: "It validates the configuration syntax without affecting the running server."
     correct: true
-    feedback: "Correct! The `burst` parameter defines how many requests beyond the rate limit a client can make before they are rejected."
-  - text: "It resets the limit every minute"
-    feedback: "Rate limits are usually tracked in seconds or milliseconds."
-  - text: "It increases the bandwidth"
-    feedback: "Rate limiting is about request counts, not bandwidth (though bandwidth limiting is a separate Nginx feature)."
+    feedback: "Correct! nginx -t checks all configuration files for syntax errors and logical issues (like conflicting server names). If the test fails, you fix the error before reloading. Without this step, a bad reload can take your sites offline."
+  - text: "It optimizes the configuration for faster reloading."
+    feedback: "nginx -t only validates - it doesn't optimize or transform the configuration."
+  - text: "It creates a backup of the current configuration."
+    feedback: "nginx -t doesn't create backups. Use version control for configuration management."
+```
+
+---
+
+```exercise
+title: "Configure Nginx for a Multi-Application Setup"
+description: "Write Nginx configurations that serve a static marketing site, proxy an API backend, and rate-limit the login endpoint."
+requirements:
+  - "Create a server block that redirects all HTTP traffic to HTTPS"
+  - "Serve static files from /var/www/marketing at the root location with 7-day cache headers"
+  - "Proxy /api/ requests to a backend running on localhost:4000"
+  - "Add rate limiting to /api/auth/ at 2 requests per second with a burst of 5"
+  - "Include security headers: X-Frame-Options, X-Content-Type-Options, and HSTS"
+  - "Add a health check endpoint at /health that returns 200 with logging disabled"
+hints:
+  - "Define the limit_req_zone in the http context (outside the server block) - you can put it in a separate conf.d/rate-limit.conf file"
+  - "Use expires 7d and add_header Cache-Control 'public' for static file caching"
+  - "Remember proxy_set_header directives to forward the real client IP to the backend"
+  - "Place the = /health location first - exact matches are evaluated before prefix and regex matches regardless of order, but putting them first improves readability"
+solution: |
+  # /etc/nginx/conf.d/rate-limit.conf
+  limit_req_zone $binary_remote_addr zone=auth:10m rate=2r/s;
+
+  # /etc/nginx/sites-available/marketing
+  server {
+      listen 80;
+      server_name example.com;
+      return 301 https://$host$request_uri;
+  }
+
+  server {
+      listen 443 ssl http2;
+      server_name example.com;
+
+      ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+      ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+      ssl_protocols       TLSv1.2 TLSv1.3;
+
+      # Security headers
+      add_header Strict-Transport-Security "max-age=63072000" always;
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+
+      # Health check (no logging)
+      location = /health {
+          access_log off;
+          return 200 "ok";
+          add_header Content-Type text/plain;
+      }
+
+      # Rate-limited auth endpoint
+      location /api/auth/ {
+          limit_req zone=auth burst=5;
+          limit_req_status 429;
+          proxy_pass http://localhost:4000;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+      }
+
+      # API proxy
+      location /api/ {
+          proxy_pass http://localhost:4000;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+      }
+
+      # Static marketing site
+      location / {
+          root /var/www/marketing;
+          index index.html;
+          try_files $uri $uri/ =404;
+          expires 7d;
+          add_header Cache-Control "public";
+      }
+  }
 ```
 
 ---
 
 ## Further Reading
 
-- [Official Nginx Documentation](https://nginx.org/en/docs/)
-- [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/)
-- [Let's Encrypt / Certbot](https://certbot.eff.org/)
+- [Nginx Documentation](https://nginx.org/en/docs/) - official reference for all directives and modules
+- [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/) - generates secure TLS configurations for Nginx, Apache, and other servers
+- [Nginx Admin's Handbook](https://github.com/trimstray/nginx-admins-handbook) - community-maintained guide covering performance tuning and security hardening
+- [Let's Encrypt / Certbot](https://certbot.eff.org/) - free TLS certificates with automated Nginx configuration
 
 ---
 
-**Next:** [Back to Index](README.md)
+[Back to Index](README.md)

--- a/Nginx/configuration.md
+++ b/Nginx/configuration.md
@@ -421,19 +421,19 @@ annotations:
     text: "An upstream block with two backend servers. least_conn routes each request to the server with the fewest active connections."
   - line: 12
     text: "HTTP server block that redirects everything to HTTPS. The 301 tells browsers to remember the redirect permanently."
-  - line: 17
+  - line: 18
     text: "The main HTTPS server block. http2 enables HTTP/2 for better performance (multiplexing, header compression)."
-  - line: 22
-    text: "Modern TLS: only TLSv1.2 and 1.3. Older protocols (SSLv3, TLSv1.0, TLSv1.1) have known vulnerabilities."
   - line: 24
+    text: "Modern TLS: only TLSv1.2 and 1.3. Older protocols (SSLv3, TLSv1.0, TLSv1.1) have known vulnerabilities."
+  - line: 26
     text: "HSTS tells browsers to always use HTTPS for this domain. max-age is in seconds (63072000 = 2 years)."
-  - line: 28
+  - line: 30
     text: "API routes get the general rate limit with a burst of 20. nodelay processes burst requests immediately instead of queuing."
-  - line: 36
+  - line: 39
     text: "Login gets an aggressive rate limit (1/s, burst 3) to slow brute-force attacks. Returns 429 instead of the default 503."
-  - line: 44
+  - line: 47
     text: "Static files served directly from disk with a 30-day cache. 'immutable' tells browsers not to revalidate during the cache period."
-  - line: 50
+  - line: 53
     text: "Health check endpoint for load balancers. access_log off prevents it from flooding logs with noise."
 ```
 
@@ -518,14 +518,15 @@ options:
 
 ```exercise
 title: "Configure Nginx for a Multi-Application Setup"
-description: "Write Nginx configurations that serve a static marketing site, proxy an API backend, and rate-limit the login endpoint."
-requirements:
-  - "Create a server block that redirects all HTTP traffic to HTTPS"
-  - "Serve static files from /var/www/marketing at the root location with 7-day cache headers"
-  - "Proxy /api/ requests to a backend running on localhost:4000"
-  - "Add rate limiting to /api/auth/ at 2 requests per second with a burst of 5"
-  - "Include security headers: X-Frame-Options, X-Content-Type-Options, and HSTS"
-  - "Add a health check endpoint at /health that returns 200 with logging disabled"
+scenario: |
+  You are configuring Nginx for a company that has a static marketing site and an API backend on the same domain. Write the Nginx configuration to:
+
+  1. Redirect all HTTP traffic to HTTPS
+  2. Serve static files from `/var/www/marketing` at the root location with 7-day cache headers
+  3. Proxy `/api/` requests to a backend running on `localhost:4000`
+  4. Add rate limiting to `/api/auth/` at 2 requests per second with a burst of 5
+  5. Include security headers: `X-Frame-Options`, `X-Content-Type-Options`, and HSTS
+  6. Add a health check endpoint at `/health` that returns 200 with logging disabled
 hints:
   - "Define the limit_req_zone in the http context (outside the server block) - you can put it in a separate conf.d/rate-limit.conf file"
   - "Use expires 7d and add_header Cache-Control 'public' for static file caching"

--- a/Security/certificate-management.md
+++ b/Security/certificate-management.md
@@ -362,13 +362,14 @@ options:
 
 ```exercise
 title: "Set Up Certificate Auto-Renewal with Monitoring"
-description: "Configure Certbot renewal with a post-deploy hook and create a monitoring script that alerts when certificates are close to expiration."
-requirements:
-  - "Create a Certbot deploy hook script that reloads Nginx after renewal"
-  - "Make the hook executable and place it in the correct directory"
-  - "Write a shell script that checks a domain's certificate expiration and warns if it's within 14 days"
-  - "The monitoring script should output the domain, days remaining, and expiration date"
-  - "Test the renewal configuration with a dry run"
+scenario: |
+  Your team manages several HTTPS services and needs automated certificate renewal with monitoring. Complete these tasks:
+
+  1. Create a Certbot deploy hook script that reloads Nginx after renewal
+  2. Make the hook executable and place it in the correct directory
+  3. Write a shell script that checks a domain's certificate expiration and warns if it's within 14 days
+  4. The monitoring script should output the domain, days remaining, and expiration date
+  5. Test the renewal configuration with a dry run
 hints:
   - "Deploy hooks go in /etc/letsencrypt/renewal-hooks/deploy/"
   - "Use openssl s_client to connect and openssl x509 to extract the expiration date"
@@ -422,28 +423,22 @@ solution: |
 ---
 
 ```command-builder
-title: "OpenSSL Certificate Commands"
-description: "Build common OpenSSL commands for certificate management."
+description: Build common OpenSSL commands for certificate management
 base: "openssl"
-groups:
-  - name: "Operation"
-    options:
-      - label: "Inspect a certificate"
-        value: "x509 -in cert.pem -text -noout"
-      - label: "Check expiration date"
-        value: "x509 -in cert.pem -enddate -noout"
-      - label: "Generate RSA private key"
-        value: "genrsa -out server.key 4096"
-      - label: "Create a CSR"
-        value: "req -new -key server.key -out server.csr"
-      - label: "Test remote server"
-        value: "s_client -connect example.com:443 -servername example.com"
-      - label: "Verify certificate chain"
-        value: "verify -CAfile ca-bundle.pem cert.pem"
-      - label: "Convert PEM to PKCS#12"
-        value: "pkcs12 -export -in cert.pem -inkey server.key -out cert.p12"
-      - label: "Check cert/key match"
-        value: "x509 -noout -modulus -in cert.pem | openssl md5"
+options:
+  - flag: ""
+    type: select
+    label: "Operation"
+    explanation: "The OpenSSL subcommand and arguments for the task"
+    choices:
+      - ["x509 -in cert.pem -text -noout", "Inspect a certificate"]
+      - ["x509 -in cert.pem -enddate -noout", "Check expiration date"]
+      - ["genrsa -out server.key 4096", "Generate RSA private key"]
+      - ["req -new -key server.key -out server.csr", "Create a CSR"]
+      - ["s_client -connect example.com:443 -servername example.com", "Test remote server"]
+      - ["verify -CAfile ca-bundle.pem cert.pem", "Verify certificate chain"]
+      - ["pkcs12 -export -in cert.pem -inkey server.key -out cert.p12", "Convert PEM to PKCS#12"]
+      - ["x509 -noout -modulus -in cert.pem | openssl md5", "Check cert/key match"]
 ```
 
 ---

--- a/Security/certificate-management.md
+++ b/Security/certificate-management.md
@@ -1,146 +1,460 @@
 # Certificate Management
 
-Modern certificate management relies heavily on automation. This guide focuses on [**Let's Encrypt**](https://letsencrypt.org/) and [**Certbot**](https://certbot.eff.org/), the tools that revolutionized how the web is secured.
-
-## Let's Encrypt and Certbot
-
-Let's Encrypt is a free, automated, and open certificate authority. To use it, you typically use a client like Certbot to automate the certificate issuance and renewal process.
-
-### Installing Certbot
-
-On most Linux distributions, you can install Certbot via `snap` or your package manager.
-
-```bash
-# Ubuntu/Debian example
-sudo apt update
-sudo apt install certbot python3-certbot-nginx
-```
+Managing TLS certificates is one of the most operationally critical tasks in systems administration. An expired or misconfigured certificate takes down your site, breaks API integrations, and erodes user trust. This guide covers the full lifecycle: obtaining certificates, automating renewal, building internal CAs, and troubleshooting the most common failures.
 
 ---
 
-## Obtaining a Certificate
+## The ACME Protocol
 
-Certbot uses **challenges** to prove you control the domain. The two most common are:
+The **Automatic Certificate Management Environment (ACME)** protocol is how clients like Certbot communicate with [**Let's Encrypt**](https://letsencrypt.org/) to automate certificate issuance and renewal. Understanding the protocol helps you debug problems when automation fails.
 
-1. **HTTP-01 Challenge**: Certbot places a file at a specific path on your web server and Let's Encrypt verifies it.
-2. **DNS-01 Challenge**: You add a TXT record to your DNS zone and Let's Encrypt verifies it.
+The flow:
 
-### Automatic Configuration (Nginx/Apache)
+1. The client generates a key pair and registers an account with the CA.
+2. The client requests a certificate for one or more domains.
+3. The CA issues **challenges** to prove the client controls the domain(s).
+4. The client completes the challenges and notifies the CA.
+5. The CA verifies the challenges and issues the certificate.
+6. The client downloads and installs the certificate.
 
-If you use Nginx or Apache, Certbot can automatically update your configuration.
+### Challenge Types
+
+| Challenge | Mechanism | Port Required | Use Case |
+|-----------|-----------|---------------|----------|
+| HTTP-01 | Place a file at `/.well-known/acme-challenge/` | 80 | Standard web servers |
+| DNS-01 | Add a TXT record to `_acme-challenge.domain` | None | Wildcards, internal servers, CDN-fronted sites |
+| TLS-ALPN-01 | Present a special self-signed cert on port 443 | 443 | When port 80 is unavailable |
+
+HTTP-01 is the simplest - [**Certbot**](https://certbot.eff.org/) places a token file on your web server and Let's Encrypt fetches it. DNS-01 is required for wildcard certificates (`*.example.com`) because it proves control over the entire DNS zone, not just a single server.
+
+---
+
+## Let's Encrypt with Certbot
+
+### Installation
 
 ```bash
-# Obtain and install certificate for Nginx
+# Ubuntu/Debian (snap is the recommended method)
+sudo snap install --classic certbot
+sudo ln -s /snap/bin/certbot /usr/bin/certbot
+
+# Alternative: pip (useful in containers or minimal environments)
+pip install certbot certbot-nginx
+```
+
+### Obtaining a Certificate
+
+```bash
+# Automatic Nginx configuration (obtains cert + modifies nginx config)
 sudo certbot --nginx -d example.com -d www.example.com
-```
 
-### Manual/Standalone Mode
+# Certificate only (does not modify server config)
+sudo certbot certonly --nginx -d example.com -d www.example.com
 
-If you don't want Certbot to touch your config files, or you are running a different service:
-
-```bash
-# Standalone mode (requires port 80 to be free)
+# Standalone mode (Certbot runs its own temporary web server on port 80)
 sudo certbot certonly --standalone -d example.com
+
+# DNS challenge for wildcard certificates
+sudo certbot certonly --manual --preferred-challenges dns -d "*.example.com" -d example.com
 ```
 
+!!! tip "`fullchain.pem` vs `cert.pem`"
+    Certbot stores files in `/etc/letsencrypt/live/example.com/`. Always use `fullchain.pem` in your server configuration, not `cert.pem`. The fullchain includes both your certificate and the intermediate CA certificate. Using just `cert.pem` causes trust errors on clients that don't have the intermediate cached.
+
+### Certificate Files
+
+After a successful issuance, Certbot creates these files:
+
+| File | Contents |
+|------|----------|
+| `privkey.pem` | Your private key. Never share this. |
+| `cert.pem` | Your certificate only (end-entity). |
+| `chain.pem` | Intermediate CA certificate(s). |
+| `fullchain.pem` | `cert.pem` + `chain.pem` combined. Use this in server configs. |
+
 ---
 
-## Renewing Certificates
+## Automated Renewal
 
-Let's Encrypt certificates are valid for **90 days**. Certbot handles renewal automatically via a cron job or systemd timer.
+Let's Encrypt certificates are valid for **90 days**. Short lifetimes reduce the window of exposure if a key is compromised and encourage automation over manual processes.
 
-- **Dry Run**: Verify that renewal works without actually issuing a new cert.
-  ```bash
-  sudo certbot renew --dry-run
-  ```
-- **Manual Renewal**:
-  ```bash
-  sudo certbot renew
-  ```
+### How Certbot Renews
 
----
-
-## Troubleshooting TLS Errors
-
-When things go wrong, these tools can help identify the issue:
-
-### Certificate Mismatch
-
-Ensure your certificate matches your private key. The modulus of both must be identical.
+Certbot installs a systemd timer (or cron job) that runs `certbot renew` twice daily. It only renews certificates within 30 days of expiration.
 
 ```bash
-openssl x509 -noout -modulus -in cert.pem | openssl md5
-openssl rsa -noout -modulus -in key.pem | openssl md5
+# Check the renewal timer status
+sudo systemctl status certbot.timer
+
+# View all managed certificates and their expiration dates
+sudo certbot certificates
+
+# Test renewal without actually renewing (dry run)
+sudo certbot renew --dry-run
+
+# Force renewal of a specific certificate
+sudo certbot renew --cert-name example.com --force-renewal
 ```
 
-### Chain Issues
+### Post-Renewal Hooks
 
-If a browser says "Connection is not private" but the certificate is valid, you might be missing the **Intermediate Certificate**.
+After renewing a certificate, you need to reload the web server so it picks up the new files. Certbot supports hooks for this:
 
-- **Fix**: Use the `fullchain.pem` provided by Certbot in your server configuration instead of just `cert.pem`.
+```bash
+# Reload Nginx after any successful renewal
+sudo certbot renew --deploy-hook "systemctl reload nginx"
+```
 
-### Protocol/Cipher Support
+For a permanent hook, create a file in `/etc/letsencrypt/renewal-hooks/deploy/`:
 
-Older servers might use insecure protocols (like SSLv3 or TLS 1.0). Use [**SSL Labs Server Test**](https://www.ssllabs.com/ssltest/) to scan your domain for vulnerabilities.
+```bash
+#!/bin/bash
+# /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
+systemctl reload nginx
+```
+
+```bash
+sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
+```
 
 ---
 
-## Interactive Quizzes: Certificate Management
+## Monitoring Certificate Expiration
 
-Test your practical knowledge.
+Automated renewal should handle everything, but monitoring catches the cases where it doesn't - DNS changes that break challenges, Certbot bugs, or servers that were never set up for automation.
+
+### Script-Based Monitoring
+
+```bash
+#!/bin/bash
+# check-cert-expiry.sh - Alert if certificate expires within 14 days
+DOMAIN="example.com"
+DAYS_WARNING=14
+
+EXPIRY=$(echo | openssl s_client -connect "$DOMAIN:443" -servername "$DOMAIN" 2>/dev/null \
+  | openssl x509 -noout -enddate | cut -d= -f2)
+
+EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s)
+NOW_EPOCH=$(date +%s)
+DAYS_LEFT=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
+
+if [ "$DAYS_LEFT" -lt "$DAYS_WARNING" ]; then
+    echo "WARNING: $DOMAIN certificate expires in $DAYS_LEFT days ($EXPIRY)"
+    # Send alert: email, Slack webhook, PagerDuty, etc.
+fi
+```
+
+### External Monitoring Services
+
+For production systems, supplement local scripts with external monitoring that checks from outside your network:
+
+- **Uptime Robot** / **Better Uptime**: Monitor HTTPS endpoints and alert on certificate errors.
+- **SSL Labs**: Periodic deep scans of your TLS configuration.
+- **Certbot `certificates` command**: Quick local check of managed certificate status.
+
+!!! danger "Never expose or commit private keys"
+    Private keys (`privkey.pem`, `.key` files) must never appear in version control, log files, error messages, or backup archives without encryption. If a private key is compromised, you must revoke the certificate immediately (`certbot revoke --cert-path /etc/letsencrypt/live/example.com/cert.pem`) and obtain a new one.
+
+---
+
+## Building an Internal CA
+
+For internal services (microservices, development environments, VPN authentication), running your own CA avoids paying for commercial certificates and lets you issue certificates for internal hostnames that aren't publicly resolvable.
+
+### Create a Root CA
+
+```bash
+# Generate the CA private key (keep this offline/secure after setup)
+openssl genrsa -aes256 -out ca.key 4096
+
+# Create the self-signed root certificate (valid 10 years)
+openssl req -new -x509 -key ca.key -sha256 -days 3650 \
+  -out ca.crt -subj "/CN=Internal Root CA/O=My Company"
+```
+
+### Sign a Server Certificate
+
+```bash
+# Generate the server's private key
+openssl genrsa -out server.key 2048
+
+# Create a CSR with SANs
+openssl req -new -key server.key -out server.csr \
+  -subj "/CN=api.internal" \
+  -addext "subjectAltName=DNS:api.internal,DNS:api.staging.internal"
+
+# Sign it with your CA (valid 1 year)
+openssl x509 -req -in server.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -out server.crt -days 365 -sha256 \
+  -copy_extensions copyall
+```
+
+### Distributing the CA Certificate
+
+For clients to trust certificates signed by your internal CA, they need your `ca.crt` installed as a trusted root:
+
+```bash
+# Ubuntu/Debian
+sudo cp ca.crt /usr/local/share/ca-certificates/internal-ca.crt
+sudo update-ca-certificates
+
+# RHEL/CentOS
+sudo cp ca.crt /etc/pki/ca-trust/source/anchors/internal-ca.crt
+sudo update-ca-trust
+
+# macOS
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ca.crt
+```
+
+---
+
+## Format Conversion
+
+Different platforms require different certificate formats. These conversions come up frequently.
+
+```bash
+# PEM to PKCS#12 (for Windows/Java - bundles cert + key + chain)
+openssl pkcs12 -export \
+  -in server.crt -inkey server.key -certfile ca.crt \
+  -out server.p12
+
+# PKCS#12 to PEM (extract from Windows/Java format)
+openssl pkcs12 -in server.p12 -out server.pem -nodes
+
+# PEM to DER (binary format)
+openssl x509 -in server.crt -outform DER -out server.der
+
+# DER to PEM
+openssl x509 -in server.der -inform DER -out server.pem
+
+# Import PKCS#12 into a Java keystore
+keytool -importkeystore \
+  -srckeystore server.p12 -srcstoretype pkcs12 \
+  -destkeystore server.jks -deststoretype jks
+```
+
+---
+
+## Troubleshooting
+
+### Certificate/Key Mismatch
+
+The modulus of the certificate and key must match. If they don't, the server will fail to start TLS.
+
+```bash
+# These two hashes must be identical
+openssl x509 -noout -modulus -in cert.pem | openssl md5
+openssl rsa -noout -modulus -in server.key | openssl md5
+```
+
+**Common cause**: Renewed the certificate but forgot to update the key path in the server config, or mixed up files from different domains.
+
+### Incomplete Certificate Chain
+
+Symptom: Desktop browsers work (they cache intermediates), but mobile devices, API clients, or `curl` report trust errors.
+
+```bash
+# Test the chain
+openssl s_client -connect example.com:443 -servername example.com
+
+# Look for this in the output:
+# Verify return code: 21 (unable to verify the first certificate)
+# This means the intermediate certificate is missing.
+```
+
+**Fix**: Use `fullchain.pem` instead of `cert.pem` in your server configuration.
+
+### Expired Certificate
+
+```bash
+# Check from the command line
+echo | openssl s_client -connect example.com:443 2>/dev/null \
+  | openssl x509 -noout -dates
+```
+
+**Common cause**: Certbot renewal failed silently. Check `sudo certbot certificates` and `/var/log/letsencrypt/letsencrypt.log`.
+
+### SNI Issues
+
+If the wrong certificate is served, the server may not support Server Name Indication (SNI) or the `server_name` directive doesn't match.
+
+```bash
+# Explicitly test with SNI
+openssl s_client -connect 1.2.3.4:443 -servername example.com
+```
+
+---
+
+```terminal
+scenario: "Obtain and configure a Let's Encrypt certificate with Certbot"
+steps:
+  - command: "sudo certbot certonly --nginx -d mysite.example.com --dry-run"
+    output: "Saving debug log to /var/log/letsencrypt/letsencrypt.log\nSimulating renewal of an existing certificate for mysite.example.com\n\nThe dry run was successful."
+    narration: "Always do a dry run first. This validates that Certbot can reach Let's Encrypt, your DNS resolves correctly, and your web server configuration is compatible - all without consuming a rate-limited certificate issuance."
+  - command: "sudo certbot certonly --nginx -d mysite.example.com"
+    output: "Saving debug log to /var/log/letsencrypt/letsencrypt.log\nRequesting a certificate for mysite.example.com\n\nSuccessfully received certificate.\nCertificate is saved at: /etc/letsencrypt/live/mysite.example.com/fullchain.pem\nKey is saved at:         /etc/letsencrypt/live/mysite.example.com/privkey.pem"
+    narration: "Issue the real certificate. Certbot uses the HTTP-01 challenge through your existing Nginx server. The certificate and key are stored under /etc/letsencrypt/live/."
+  - command: "sudo certbot certificates"
+    output: "Certificate Name: mysite.example.com\n  Domains: mysite.example.com\n  Expiry Date: 2026-06-23 (VALID: 89 days)\n  Certificate Path: /etc/letsencrypt/live/mysite.example.com/fullchain.pem\n  Private Key Path: /etc/letsencrypt/live/mysite.example.com/privkey.pem"
+    narration: "List all managed certificates. This shows the domain, expiration, and file paths. The certificate is valid for 90 days."
+  - command: "openssl x509 -in /etc/letsencrypt/live/mysite.example.com/fullchain.pem -noout -subject -issuer -dates"
+    output: "subject=CN = mysite.example.com\nissuer=C = US, O = Let's Encrypt, CN = R11\nnotBefore=Mar 25 12:00:00 2026 GMT\nnotAfter=Jun 23 12:00:00 2026 GMT"
+    narration: "Verify the certificate details with OpenSSL. The issuer is Let's Encrypt's intermediate CA (R11), and the validity period confirms the 90-day window."
+  - command: "sudo certbot renew --dry-run"
+    output: "Processing /etc/letsencrypt/renewal/mysite.example.com.conf\nSimulating renewal of an existing certificate for mysite.example.com\nThe dry run was successful."
+    narration: "Test the renewal process. This confirms that when the systemd timer triggers certbot renew in the future, it will work correctly."
+  - command: "sudo systemctl status certbot.timer"
+    output: "● certbot.timer - Run certbot twice daily\n   Loaded: loaded (/lib/systemd/system/certbot.timer; enabled)\n   Active: active (waiting)\n  Trigger: Tue 2026-03-25 18:23:00 UTC; 5h left"
+    narration: "The certbot timer is active and will automatically attempt renewal twice daily. It only actually renews when certificates are within 30 days of expiration."
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
 question: "How long are Let's Encrypt certificates valid for before they must be renewed?"
 type: multiple-choice
 options:
   - text: "30 days"
-    feedback: "30 days is too short; the actual validity is 90 days."
+    feedback: "30 days is the renewal window (Certbot renews within 30 days of expiration), but the certificate itself is valid for 90 days."
   - text: "90 days"
     correct: true
-    feedback: "Correct! Let's Encrypt certificates are short-lived (90 days) to encourage automation and minimize the damage if a key is compromised."
+    feedback: "Correct! Let's Encrypt certificates are short-lived (90 days) to encourage automation and minimize the damage window if a key is compromised. Certbot's automatic renewal handles this transparently."
   - text: "1 year"
-    feedback: "Commercial certificates often last 1 year, but Let's Encrypt uses 90 days."
+    feedback: "Commercial certificates often last 1 year, but Let's Encrypt uses 90 days by design."
   - text: "10 years"
-    feedback: "Root certificates can last 10 years, but end-entity certificates are much shorter."
+    feedback: "Root CA certificates can last 10-20 years, but end-entity certificates are much shorter."
 ```
 
 ```quiz
-question: "If your server configuration uses `cert.pem` and clients are seeing 'Untrusted Authority' errors, what should you likely use instead?"
+question: "If clients report 'Untrusted Authority' errors but the certificate is valid, what is the most likely cause?"
 type: multiple-choice
 options:
-  - text: "privkey.pem"
-    feedback: "privkey.pem is your secret private key, not for public distribution."
-  - text: "csr.pem"
-    feedback: "csr.pem is a Certificate Signing Request, used only during issuance."
-  - text: "fullchain.pem"
+  - text: "The private key has expired."
+    feedback: "Private keys don't expire. The certificate has an expiration date, not the key."
+  - text: "The server is using cert.pem instead of fullchain.pem, missing the intermediate CA certificate."
     correct: true
-    feedback: "Correct! Most servers need the certificate *plus* the intermediate certificates to establish a path to a trusted root. `fullchain.pem` contains both."
-  - text: "root.pem"
-    feedback: "Root certificates are already in the browser's trust store. You need the intermediate chain."
+    feedback: "Correct! Without the intermediate certificate, clients cannot build the trust chain from your certificate to a trusted root CA. Desktop browsers may work because they cache intermediates, but mobile clients, curl, and API clients will fail."
+  - text: "The client's clock is wrong."
+    feedback: "Clock skew can cause certificate validation failures, but the error message would mention date/time, not 'Untrusted Authority'."
+  - text: "Let's Encrypt is not a trusted CA."
+    feedback: "Let's Encrypt is trusted by all major browsers and operating systems since 2016."
 ```
 
 ```quiz
-question: "Which Certbot challenge is best if you need to issue a wildcard certificate (e.g., `*.example.com`)?"
+question: "Which ACME challenge type is required for wildcard certificates?"
 type: multiple-choice
 options:
   - text: "HTTP-01"
-    feedback: "HTTP-01 cannot be used for wildcard certificates with Let's Encrypt."
+    feedback: "HTTP-01 proves control of a single server. It cannot verify control of an entire domain zone, which is required for wildcards."
   - text: "DNS-01"
     correct: true
-    feedback: "Correct! Let's Encrypt requires the DNS-01 challenge for wildcard certificates, as it proves control over the entire DNS zone."
+    feedback: "Correct! DNS-01 requires adding a TXT record to the domain's DNS zone, proving control over the entire zone. This is necessary for wildcards because *.example.com covers all subdomains, not just one specific server."
   - text: "TLS-ALPN-01"
-    feedback: "TLS-ALPN-01 is for specific port 443 challenges, not for wildcards."
-  - text: "Wildcard-01"
-    feedback: "There is no 'Wildcard-01' challenge; it's just a DNS-01 challenge for a wildcard name."
+    feedback: "TLS-ALPN-01 is an alternative to HTTP-01 for single-domain certificates when port 80 is unavailable."
+  - text: "Any challenge type works for wildcards."
+    feedback: "Only DNS-01 can be used for wildcard certificates. This is a Let's Encrypt policy based on the need to prove zone-level control."
+```
+
+---
+
+```exercise
+title: "Set Up Certificate Auto-Renewal with Monitoring"
+description: "Configure Certbot renewal with a post-deploy hook and create a monitoring script that alerts when certificates are close to expiration."
+requirements:
+  - "Create a Certbot deploy hook script that reloads Nginx after renewal"
+  - "Make the hook executable and place it in the correct directory"
+  - "Write a shell script that checks a domain's certificate expiration and warns if it's within 14 days"
+  - "The monitoring script should output the domain, days remaining, and expiration date"
+  - "Test the renewal configuration with a dry run"
+hints:
+  - "Deploy hooks go in /etc/letsencrypt/renewal-hooks/deploy/"
+  - "Use openssl s_client to connect and openssl x509 to extract the expiration date"
+  - "The date command can convert dates to epoch seconds for arithmetic"
+  - "Don't forget to chmod +x your scripts"
+solution: |
+  # Step 1: Create the deploy hook
+  # /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
+  #!/bin/bash
+  systemctl reload nginx
+  logger "Certbot: Nginx reloaded after certificate renewal"
+
+  # Make it executable
+  # sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
+
+  # Step 2: Create the monitoring script
+  # /usr/local/bin/check-cert-expiry.sh
+  #!/bin/bash
+  DOMAIN="${1:?Usage: $0 <domain>}"
+  WARN_DAYS=14
+
+  EXPIRY=$(echo | openssl s_client -connect "$DOMAIN:443" \
+    -servername "$DOMAIN" 2>/dev/null \
+    | openssl x509 -noout -enddate | cut -d= -f2)
+
+  if [ -z "$EXPIRY" ]; then
+      echo "ERROR: Could not connect to $DOMAIN:443"
+      exit 2
+  fi
+
+  EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s 2>/dev/null || date -j -f "%b %d %T %Y %Z" "$EXPIRY" +%s)
+  NOW_EPOCH=$(date +%s)
+  DAYS_LEFT=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
+
+  echo "$DOMAIN: $DAYS_LEFT days remaining (expires $EXPIRY)"
+
+  if [ "$DAYS_LEFT" -lt "$WARN_DAYS" ]; then
+      echo "WARNING: Certificate expires in less than $WARN_DAYS days!"
+      exit 1
+  fi
+
+  # sudo chmod +x /usr/local/bin/check-cert-expiry.sh
+
+  # Step 3: Test renewal
+  # sudo certbot renew --dry-run
+
+  # Step 4: Add to cron for daily monitoring
+  # 0 9 * * * /usr/local/bin/check-cert-expiry.sh example.com | mail -s "Cert Check" admin@example.com
+```
+
+---
+
+```command-builder
+title: "OpenSSL Certificate Commands"
+description: "Build common OpenSSL commands for certificate management."
+base: "openssl"
+groups:
+  - name: "Operation"
+    options:
+      - label: "Inspect a certificate"
+        value: "x509 -in cert.pem -text -noout"
+      - label: "Check expiration date"
+        value: "x509 -in cert.pem -enddate -noout"
+      - label: "Generate RSA private key"
+        value: "genrsa -out server.key 4096"
+      - label: "Create a CSR"
+        value: "req -new -key server.key -out server.csr"
+      - label: "Test remote server"
+        value: "s_client -connect example.com:443 -servername example.com"
+      - label: "Verify certificate chain"
+        value: "verify -CAfile ca-bundle.pem cert.pem"
+      - label: "Convert PEM to PKCS#12"
+        value: "pkcs12 -export -in cert.pem -inkey server.key -out cert.p12"
+      - label: "Check cert/key match"
+        value: "x509 -noout -modulus -in cert.pem | openssl md5"
 ```
 
 ---
 
 ## Further Reading
 
-- [**Let's Encrypt Documentation**](https://letsencrypt.org/docs/)  
-- [**Certbot Instructions**](https://certbot.eff.org/instructions)  
-- [**Electronic Frontier Foundation (EFF)**](https://www.eff.org/)  
+- [Let's Encrypt Documentation](https://letsencrypt.org/docs/) - how the CA works, rate limits, and best practices
+- [Certbot Instructions](https://certbot.eff.org/instructions) - installation and usage guides for every server/OS combination
+- [SSL Labs Server Test](https://www.ssllabs.com/ssltest/) - free online scanner that grades your TLS configuration
+- [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/) - generates recommended server configurations
+- [ACME Protocol (RFC 8555)](https://datatracker.ietf.org/doc/html/rfc8555) - the specification behind Let's Encrypt's automation
 
 ---
 

--- a/Security/tls-ssl-fundamentals.md
+++ b/Security/tls-ssl-fundamentals.md
@@ -239,7 +239,7 @@ steps:
     output: "CONNECTED(00000003)\n---\nCertificate chain\n 0 s:C = US, ST = California, L = San Francisco, O = GitHub, Inc., CN = github.com\n   i:C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\n 1 s:C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\n   i:C = US, O = DigiCert Inc, OU = www.digicert.com, CN = DigiCert Global Root CA\n---"
     narration: "Connect to GitHub's server and display the certificate chain. You can see two certificates: the end-entity cert for github.com (signed by DigiCert's intermediate CA) and the intermediate CA cert (signed by DigiCert's root CA)."
   - command: "echo | openssl s_client -connect github.com:443 2>/dev/null | openssl x509 -noout -subject -issuer -dates"
-    output: "subject=C = US, ST = California, L = San Francisco, O = GitHub, Inc., CN = github.com\nissuer=C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\nnotBefore=Mar 15 00:00:00 2024 GMT\nnotAfter=Mar 15 23:59:59 2025 GMT"
+    output: "subject=C = US, ST = California, L = San Francisco, O = GitHub, Inc., CN = github.com\nissuer=C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\nnotBefore=Mar 15 00:00:00 2026 GMT\nnotAfter=Mar 15 23:59:59 2027 GMT"
     narration: "Extract the subject (who the certificate is for), issuer (who signed it), and validity dates. This certificate is valid for one year."
   - command: "echo | openssl s_client -connect github.com:443 2>/dev/null | openssl x509 -noout -text | grep -A 3 'Subject Alternative Name'"
     output: "            X509v3 Subject Alternative Name:\n                DNS:github.com, DNS:www.github.com"
@@ -308,14 +308,15 @@ options:
 
 ```exercise
 title: "Generate and Verify a Self-Signed Certificate"
-description: "Create a self-signed certificate with Subject Alternative Names, inspect it, and verify it works with a local HTTPS server."
-requirements:
-  - "Generate a 4096-bit RSA private key"
-  - "Create a self-signed certificate valid for 365 days with CN=localhost"
-  - "Include SANs for both DNS:localhost and IP:127.0.0.1"
-  - "Verify the certificate details: subject, issuer (should match subject for self-signed), dates, and SANs"
-  - "Confirm the certificate and key match by comparing their modulus hashes"
-  - "Test the certificate by starting a local HTTPS server with openssl s_server"
+scenario: |
+  You need a self-signed certificate for local development and testing. Complete these steps:
+
+  1. Generate a 4096-bit RSA private key
+  2. Create a self-signed certificate valid for 365 days with CN=localhost
+  3. Include SANs for both DNS:localhost and IP:127.0.0.1
+  4. Verify the certificate details: subject, issuer (should match subject for self-signed), dates, and SANs
+  5. Confirm the certificate and key match by comparing their modulus hashes
+  6. Test the certificate by starting a local HTTPS server with `openssl s_server`
 hints:
   - "Use openssl req -new -x509 to combine key generation and certificate creation in one step, or generate the key first with openssl genrsa"
   - "SANs are added with -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'"

--- a/Security/tls-ssl-fundamentals.md
+++ b/Security/tls-ssl-fundamentals.md
@@ -1,116 +1,364 @@
 # TLS/SSL Fundamentals
 
-Understanding the basics of Transport Layer Security (TLS) is critical for any systems administrator. This guide covers Public Key Infrastructure (PKI), the handshake process, and common certificate formats.
+Understanding Transport Layer Security (TLS) is critical for any systems administrator. TLS encrypts communication between clients and servers, preventing eavesdropping, tampering, and impersonation. Every HTTPS connection, email relay, database connection, and API call you secure depends on these fundamentals.
+
+SSL (Secure Sockets Layer) is the predecessor to TLS. The protocol was renamed to TLS starting with version 1.0, but "SSL" persists in common usage, tool names (`openssl`), and certificate product names. In practice, when someone says "SSL certificate," they mean a certificate used with TLS.
+
+---
+
+## Cryptographic Foundations
+
+TLS relies on two types of cryptography working together.
+
+### Symmetric Encryption
+
+Both sides share the same secret key. Fast, efficient, and used for the actual data transfer once a connection is established. Common algorithms include **AES-128** and **AES-256** (Advanced Encryption Standard with 128-bit or 256-bit keys).
+
+The problem: how do two parties agree on a shared secret over an untrusted network?
+
+### Asymmetric Encryption
+
+Uses a mathematically linked key pair: a **public key** (shared openly) and a **private key** (kept secret). Data encrypted with the public key can only be decrypted with the private key, and vice versa. Common algorithms include **RSA** (2048+ bit keys) and **ECDSA** (256+ bit keys, faster and smaller).
+
+Asymmetric encryption is slower than symmetric, so TLS uses it only during the handshake to securely exchange a symmetric key. After that, all data flows using the faster symmetric cipher.
+
+---
 
 ## Public Key Infrastructure (PKI)
 
-PKI is a system of processes, technologies, and policies that allow for the secure transfer of information. It relies on **Asymmetric Cryptography**, which uses two different but mathematically related keys:
+**PKI** is the trust framework that makes TLS work at scale. Without it, you would have to manually verify every server's public key before connecting - impractical for billions of websites.
 
-- **Public Key**: Can be shared with anyone. It is used to encrypt data.
-- **Private Key**: Must be kept secret. It is used to decrypt data that was encrypted with the matching public key.
+### How Trust Works
 
-### Certificate Chains
+A **Certificate Authority (CA)** is an organization trusted by browsers and operating systems to vouch for the identity of certificate holders. When a CA signs a certificate, it's saying "we verified that this entity controls this domain."
 
-A digital certificate is not just a public key; it is signed by a **Certificate Authority (CA)** to prove its authenticity. Most certificates are part of a chain:
+Trust flows through a chain:
 
-1. **Root CA**: The anchor of trust, pre-installed in browsers and OSs.
-2. **Intermediate CA**: Signed by the Root CA, used to sign end-entity certificates (for better security).
-3. **End-Entity Certificate**: The certificate used by your server (e.g., `example.com`).
+```mermaid
+graph TD
+    A[Root CA] -->|signs| B[Intermediate CA]
+    B -->|signs| C[End-Entity Certificate]
+    C -->|installed on| D[Your Server]
+```
+
+- **Root CA**: The anchor of trust. Root certificates are pre-installed in browsers and operating systems. Root CAs sign intermediate CA certificates but rarely sign end-entity certificates directly - keeping the root key offline and secure.
+- **Intermediate CA**: Signed by the root, used to sign end-entity certificates. If an intermediate CA is compromised, the root can revoke it without replacing every certificate it ever issued.
+- **End-Entity Certificate**: The certificate installed on your server, containing your public key and domain name.
+
+!!! tip "Why intermediate certificates matter"
+    Your server must send both its end-entity certificate and the intermediate certificate(s) that chain back to the root. If you only send the end-entity certificate, clients cannot build the trust chain and will show a "connection not trusted" error. This is the single most common TLS misconfiguration.
+
+---
+
+## The TLS Handshake
+
+Every TLS connection begins with a handshake that authenticates the server, negotiates encryption parameters, and establishes a shared secret. TLS 1.3 simplified this from a two-round-trip process (TLS 1.2) to a single round trip.
+
+### TLS 1.3 Handshake
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+    Client->>Server: ClientHello (supported ciphers, key share)
+    Server->>Client: ServerHello (chosen cipher, key share, certificate, finished)
+    Note over Client,Server: Both sides derive the session key
+    Client->>Server: Finished (encrypted)
+    Note over Client,Server: Application data flows encrypted
+```
+
+1. **ClientHello**: The client sends its supported TLS versions, cipher suites, and a key share (Diffie-Hellman parameters).
+2. **ServerHello**: The server chooses a cipher suite, sends its own key share, its certificate, and a "finished" message - all in one flight.
+3. **Key Derivation**: Both sides independently compute the same session key from the exchanged key shares.
+4. **Encrypted Communication**: All subsequent data is encrypted with the symmetric session key.
+
+### TLS 1.2 vs 1.3
+
+| Feature | TLS 1.2 | TLS 1.3 |
+|---------|---------|---------|
+| Handshake round trips | 2 | 1 |
+| Cipher suites | Many (including weak ones) | 5 strong suites only |
+| Forward secrecy | Optional | Mandatory |
+| RSA key exchange | Supported | Removed |
+| 0-RTT resumption | No | Yes (with caveats) |
+
+**Forward secrecy** means that even if the server's private key is compromised in the future, past recorded traffic cannot be decrypted. TLS 1.3 enforces this by removing RSA key exchange (where the session key is encrypted with the server's long-term key) and requiring ephemeral Diffie-Hellman key exchange.
+
+---
+
+## Cipher Suites
+
+A **cipher suite** is a combination of algorithms used during a TLS connection. The name encodes each algorithm's role:
+
+```
+TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+│    │     │        │    │   │    │
+│    │     │        │    │   │    └─ Hash for PRF
+│    │     │        │    │   └────── Mode (authenticated)
+│    │     │        │    └────────── Key size
+│    │     │        └─────────────── Symmetric cipher
+│    │     └──────────────────────── Authentication
+│    └────────────────────────────── Key exchange
+└─────────────────────────────────── Protocol
+```
+
+TLS 1.3 simplified this naming. Instead of encoding every algorithm, suites are named like `TLS_AES_256_GCM_SHA384` because key exchange is always ephemeral Diffie-Hellman and authentication is determined by the certificate type.
+
+### Recommended Configuration
+
+Use the [**Mozilla SSL Configuration Generator**](https://ssl-config.mozilla.org/) to generate cipher suite configurations for your server software. The "Intermediate" profile balances security with compatibility:
+
+```
+# TLS 1.2 + 1.3 (Mozilla Intermediate)
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+ssl_prefer_server_ciphers off;
+```
 
 ---
 
 ## Working with OpenSSL
 
-[**OpenSSL**](https://www.openssl.org/) is the industry-standard tool for managing certificates and keys.
+[**OpenSSL**](https://www.openssl.org/) is the industry-standard command-line toolkit for managing certificates and keys.
 
-### Generating a Private Key and CSR
-
-To apply for a certificate, you first need a private key and a Certificate Signing Request (CSR).
+### Generating a Private Key
 
 ```bash
-# Generate a 2048-bit RSA private key
-openssl genrsa -out example.key 2048
+# RSA key (2048-bit minimum, 4096-bit for higher security)
+openssl genrsa -out server.key 4096
 
-# Create a CSR using the private key
-openssl req -new -key example.key -out example.csr
+# ECDSA key (faster, smaller - preferred for new deployments)
+openssl ecparam -genkey -name prime256v1 -out server.key
 ```
+
+### Creating a Certificate Signing Request (CSR)
+
+A CSR contains your public key and identity information. You send it to a CA to get a signed certificate.
+
+```bash
+# Interactive (prompts for country, organization, common name, etc.)
+openssl req -new -key server.key -out server.csr
+
+# Non-interactive with Subject Alternative Names (modern standard)
+openssl req -new -key server.key -out server.csr \
+  -subj "/CN=example.com" \
+  -addext "subjectAltName=DNS:example.com,DNS:www.example.com"
+```
+
+!!! warning "Always use Subject Alternative Names"
+    The Common Name (CN) field is deprecated for domain validation. Modern browsers require the domain to appear in the Subject Alternative Name (SAN) extension. A certificate with only a CN and no SANs will trigger browser warnings.
 
 ### Inspecting Certificates
 
-You often need to verify the contents of a certificate or check its expiration date.
-
 ```bash
-# View the details of a certificate
+# View full certificate details
 openssl x509 -in cert.pem -text -noout
 
-# Check the expiration date only
+# Check expiration date
 openssl x509 -in cert.pem -enddate -noout
+
+# Verify a certificate against a CA bundle
+openssl verify -CAfile ca-bundle.pem cert.pem
+
+# Check if a certificate matches a private key (modulus hash must match)
+openssl x509 -noout -modulus -in cert.pem | openssl md5
+openssl rsa -noout -modulus -in server.key | openssl md5
+```
+
+### Testing a Remote Server
+
+```bash
+# Connect to a server and display its certificate chain
+openssl s_client -connect example.com:443 -servername example.com
+
+# Check specific TLS version support
+openssl s_client -connect example.com:443 -tls1_2
+openssl s_client -connect example.com:443 -tls1_3
+
+# Show only the certificate dates
+echo | openssl s_client -connect example.com:443 2>/dev/null | openssl x509 -noout -dates
 ```
 
 ### Common Certificate Formats
 
-- **PEM (`.pem`, `.crt`, `.key`)**: Base64 encoded ASCII. Most common on Linux/Nginx/Apache.
-- **DER (`.der`, `.cer`)**: Binary format. Common in Java and Windows environments.
-- **PKCS#12 (`.p12`, `.pfx`)**: A password-protected container that can hold both the certificate and its private key.
+| Format | Extensions | Encoding | Common Use |
+|--------|-----------|----------|------------|
+| PEM | `.pem`, `.crt`, `.key` | Base64 ASCII | Linux, Nginx, Apache |
+| DER | `.der`, `.cer` | Binary | Java, Windows |
+| PKCS#12 | `.p12`, `.pfx` | Binary container | Windows, Java keystores |
+
+```bash
+# Convert PEM to DER
+openssl x509 -in cert.pem -outform DER -out cert.der
+
+# Convert PEM to PKCS#12 (bundles cert + key into one file)
+openssl pkcs12 -export -in cert.pem -inkey server.key -out cert.p12
+
+# Extract from PKCS#12 back to PEM
+openssl pkcs12 -in cert.p12 -out cert.pem -nodes
+```
 
 ---
 
-## Interactive Quizzes: TLS Fundamentals
+## Server Name Indication (SNI)
 
-Test your knowledge of TLS and OpenSSL.
+**SNI** is a TLS extension that allows a client to specify which hostname it's connecting to during the handshake. Without SNI, a server with multiple TLS certificates on one IP address wouldn't know which certificate to present.
+
+SNI is supported by all modern clients. The only environments where it causes issues are very old systems (Android 2.x, IE on Windows XP) and certain IoT devices.
+
+---
+
+## Certificate Transparency
+
+**Certificate Transparency (CT)** is a public logging system that records every certificate issued by participating CAs. It allows domain owners to detect misissued certificates - for example, if a compromised CA issues a certificate for your domain to an attacker.
+
+All major CAs now submit certificates to CT logs as a requirement for browser trust. You can search CT logs for certificates issued for your domain using tools like [**crt.sh**](https://crt.sh/).
+
+---
+
+## Historical Vulnerabilities
+
+Understanding past TLS vulnerabilities explains why modern configurations disable older protocols:
+
+| Vulnerability | Year | Affected | Impact |
+|--------------|------|----------|--------|
+| BEAST | 2011 | TLS 1.0 CBC ciphers | Could decrypt HTTPS cookies |
+| CRIME | 2012 | TLS compression | Could recover secret tokens |
+| Heartbleed | 2014 | OpenSSL 1.0.1-1.0.1f | Leaked server memory (keys, passwords) |
+| POODLE | 2014 | SSLv3 | Could decrypt SSLv3 traffic |
+| DROWN | 2016 | SSLv2 (even if only enabled alongside TLS) | Could decrypt TLS sessions |
+
+The response to each vulnerability was to disable the affected protocol version or feature. This is why modern configurations use only TLS 1.2 and 1.3 with no compression and no CBC-mode ciphers.
+
+---
+
+```terminal
+scenario: "Inspect a live TLS certificate chain"
+steps:
+  - command: "echo | openssl s_client -connect github.com:443 -servername github.com 2>/dev/null | head -20"
+    output: "CONNECTED(00000003)\n---\nCertificate chain\n 0 s:C = US, ST = California, L = San Francisco, O = GitHub, Inc., CN = github.com\n   i:C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\n 1 s:C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\n   i:C = US, O = DigiCert Inc, OU = www.digicert.com, CN = DigiCert Global Root CA\n---"
+    narration: "Connect to GitHub's server and display the certificate chain. You can see two certificates: the end-entity cert for github.com (signed by DigiCert's intermediate CA) and the intermediate CA cert (signed by DigiCert's root CA)."
+  - command: "echo | openssl s_client -connect github.com:443 2>/dev/null | openssl x509 -noout -subject -issuer -dates"
+    output: "subject=C = US, ST = California, L = San Francisco, O = GitHub, Inc., CN = github.com\nissuer=C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\nnotBefore=Mar 15 00:00:00 2024 GMT\nnotAfter=Mar 15 23:59:59 2025 GMT"
+    narration: "Extract the subject (who the certificate is for), issuer (who signed it), and validity dates. This certificate is valid for one year."
+  - command: "echo | openssl s_client -connect github.com:443 2>/dev/null | openssl x509 -noout -text | grep -A 3 'Subject Alternative Name'"
+    output: "            X509v3 Subject Alternative Name:\n                DNS:github.com, DNS:www.github.com"
+    narration: "Check the Subject Alternative Names. These are the domains the certificate is valid for. Modern browsers validate against SANs, not the Common Name field."
+  - command: "openssl s_client -connect github.com:443 -tls1_3 < /dev/null 2>&1 | grep 'Protocol\\|Cipher'"
+    output: "    Protocol  : TLSv1.3\n    Cipher    : TLS_AES_128_GCM_SHA256"
+    narration: "Verify that the server supports TLS 1.3. The negotiated cipher suite is TLS_AES_128_GCM_SHA256 - AES-128 in GCM mode with SHA-256."
+  - command: "openssl genrsa -out test.key 2048 2>/dev/null && openssl req -new -x509 -key test.key -out test.crt -days 365 -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'"
+    output: ""
+    narration: "Generate a self-signed certificate for local testing. The -x509 flag skips the CSR step and produces a certificate directly. This cert includes SANs for both 'localhost' and 127.0.0.1."
+  - command: "openssl x509 -in test.crt -noout -text | grep -A 2 'Subject Alternative'"
+    output: "            X509v3 Subject Alternative Name:\n                DNS:localhost, IP Address:127.0.0.1"
+    narration: "Verify the self-signed certificate has the correct SANs. IP addresses in SANs use the IP: prefix, not DNS:."
+```
+
+---
+
+## Interactive Quizzes
 
 ```quiz
-question: "What is the purpose of an Intermediate Certificate in a certificate chain?"
+question: "Why does TLS use both asymmetric and symmetric encryption instead of just one?"
 type: multiple-choice
 options:
-  - text: "It replaces the Root Certificate for better performance."
-    feedback: "Root certificates are still necessary to anchor the trust chain."
-  - text: "It acts as a buffer to avoid using the Root CA's private key for every signature."
+  - text: "Symmetric encryption is not secure enough on its own."
+    feedback: "AES-256 symmetric encryption is extremely secure. The problem is securely sharing the key, not the algorithm's strength."
+  - text: "Asymmetric encryption is used for the initial key exchange because it solves the key distribution problem, then symmetric encryption takes over because it's much faster."
     correct: true
-    feedback: "Correct! Intermediate CAs allow Root CAs to remain offline and highly secure, as they only sign a few intermediate certificates rather than every end-user certificate."
-  - text: "It encrypts the private key on the server."
-    feedback: "Encryption of private keys is handled by password protection (e.g., in PKCS#12)."
-  - text: "It is used for internal network traffic only."
-    feedback: "Intermediate certificates are used for both public and private traffic."
+    feedback: "Correct! Asymmetric encryption solves the chicken-and-egg problem of sharing a secret over an untrusted network. Once both sides have the shared secret, they switch to symmetric encryption, which is orders of magnitude faster for bulk data transfer."
+  - text: "Asymmetric encryption doesn't work with HTTP."
+    feedback: "There is no such limitation. The choice is purely about performance and key distribution."
+  - text: "TLS 1.3 removed symmetric encryption."
+    feedback: "TLS 1.3 still uses symmetric encryption (AES-GCM or ChaCha20) for all application data."
 ```
 
 ```quiz
-question: "Which OpenSSL command is used to view the human-readable details of a PEM-encoded certificate?"
+question: "What is forward secrecy and why does TLS 1.3 mandate it?"
 type: multiple-choice
 options:
-  - text: "openssl req -in cert.pem"
-    feedback: "The req command is for Certificate Signing Requests (CSRs)."
-  - text: "openssl rsa -in cert.pem"
-    feedback: "The rsa command is for managing RSA private keys."
-  - text: "openssl x509 -in cert.pem -text -noout"
+  - text: "It means encrypting data before sending it forward to the server."
+    feedback: "Forward secrecy is about protecting past sessions, not the direction of data flow."
+  - text: "It ensures that compromising the server's private key cannot decrypt previously recorded traffic."
     correct: true
-    feedback: "Correct! The `x509` command is for certificate management. `-text` displays the readable version, and `-noout` prevents printing the encoded certificate itself."
-  - text: "openssl verify cert.pem"
-    feedback: "The verify command checks if a certificate is valid against a trust store, but doesn't show its details."
+    feedback: "Correct! With forward secrecy, each session uses unique ephemeral keys that are discarded after the session ends. Even if an attacker steals the server's private key, they cannot decrypt past sessions because the session keys no longer exist."
+  - text: "It encrypts the server's private key for future use."
+    feedback: "Forward secrecy protects past communications, not future key storage."
+  - text: "It prevents man-in-the-middle attacks."
+    feedback: "Certificate validation prevents MITM attacks. Forward secrecy specifically protects past sessions from future key compromise."
 ```
 
 ```quiz
-question: "If you have a `.key` file and a `.crt` file, which certificate format are you likely using?"
+question: "Which OpenSSL command tests whether a certificate matches its private key?"
 type: multiple-choice
 options:
-  - text: "DER"
-    feedback: "DER is a binary format and doesn't usually use .key or .crt extensions."
-  - text: "PEM"
+  - text: "openssl verify -match cert.pem key.pem"
+    feedback: "There is no -match flag. Matching requires comparing the modulus of both files."
+  - text: "Compare the modulus hash of both: openssl x509 -noout -modulus -in cert.pem | openssl md5 and openssl rsa -noout -modulus -in key.pem | openssl md5"
     correct: true
-    feedback: "Correct! PEM is a text-based format (Base64 ASCII) typically stored in files with extensions like `.pem`, `.crt`, `.cer`, or `.key`."
-  - text: "PKCS#12"
-    feedback: "PKCS#12 usually combines the key and cert into a single .p12 or .pfx file."
-  - text: "PFX"
-    feedback: "PFX is another name for PKCS#12, which stores keys and certs in one file."
+    feedback: "Correct! If the MD5 hashes of the modulus from the certificate and the private key are identical, they are a matching pair. The modulus is the shared mathematical component of both the public and private key."
+  - text: "openssl s_client -cert cert.pem -key key.pem"
+    feedback: "s_client connects to a remote server. It doesn't verify local cert/key pairing."
+  - text: "openssl x509 -check cert.pem key.pem"
+    feedback: "There is no -check flag that takes both files. You need to compare the modulus of each separately."
+```
+
+---
+
+```exercise
+title: "Generate and Verify a Self-Signed Certificate"
+description: "Create a self-signed certificate with Subject Alternative Names, inspect it, and verify it works with a local HTTPS server."
+requirements:
+  - "Generate a 4096-bit RSA private key"
+  - "Create a self-signed certificate valid for 365 days with CN=localhost"
+  - "Include SANs for both DNS:localhost and IP:127.0.0.1"
+  - "Verify the certificate details: subject, issuer (should match subject for self-signed), dates, and SANs"
+  - "Confirm the certificate and key match by comparing their modulus hashes"
+  - "Test the certificate by starting a local HTTPS server with openssl s_server"
+hints:
+  - "Use openssl req -new -x509 to combine key generation and certificate creation in one step, or generate the key first with openssl genrsa"
+  - "SANs are added with -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'"
+  - "For a self-signed cert, the subject and issuer fields will be identical"
+  - "openssl s_server -cert cert.pem -key key.pem -accept 4443 starts a test HTTPS server"
+solution: |
+  # Step 1: Generate private key
+  openssl genrsa -out server.key 4096
+
+  # Step 2: Create self-signed certificate with SANs
+  openssl req -new -x509 \
+    -key server.key \
+    -out server.crt \
+    -days 365 \
+    -subj "/CN=localhost" \
+    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+  # Step 3: Verify certificate details
+  openssl x509 -in server.crt -noout -text | grep -A 2 "Subject:"
+  openssl x509 -in server.crt -noout -text | grep -A 2 "Issuer:"
+  openssl x509 -in server.crt -noout -dates
+  openssl x509 -in server.crt -noout -text | grep -A 2 "Subject Alternative"
+
+  # Step 4: Verify cert/key match
+  openssl x509 -noout -modulus -in server.crt | openssl md5
+  openssl rsa -noout -modulus -in server.key | openssl md5
+  # Both MD5 hashes should be identical
+
+  # Step 5: Start a test HTTPS server
+  openssl s_server -cert server.crt -key server.key -accept 4443
+  # In another terminal: curl -k https://localhost:4443
+  # The -k flag skips CA verification (needed for self-signed certs)
 ```
 
 ---
 
 ## Further Reading
 
-- [**OpenSSL Official Documentation**](https://www.openssl.org/docs/)  
-- [**Mozilla SSL Configuration Generator**](https://ssl-config.mozilla.org/)  
-- [**SSL Labs: Best Practices**](https://www.ssllabs.com/projects/best-practices/)  
+- [OpenSSL Official Documentation](https://www.openssl.org/docs/) - reference for all commands and configuration options
+- [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/) - generates recommended TLS configurations for Nginx, Apache, HAProxy, and more
+- [SSL Labs Server Test](https://www.ssllabs.com/ssltest/) - free online tool that grades your server's TLS configuration
+- [Certificate Transparency Search (crt.sh)](https://crt.sh/) - search public CT logs for certificates issued for any domain
+- [Cloudflare Learning Center: What is TLS?](https://www.cloudflare.com/learning/ssl/transport-layer-security-tls/) - accessible explanation of TLS concepts
 
 ---
 


### PR DESCRIPTION
## Summary

- Expands 10 guides from ~100-200 line stubs to 365-607 line comprehensive lessons, matching the quality standard established by the original hand-crafted guides
- Adds interactive components (terminal simulations, exercises, code walkthroughs, command builders) to every expanded guide alongside existing quizzes
- Incorporates Junie's uncommitted interactive component additions to mongodb.md and sql-essentials.md

### Guides expanded

| Guide | Before | After | New Components |
|-------|--------|-------|----------------|
| Docker/fundamentals.md | 148 | 562 | terminal, exercise, code-walkthrough, 3 admonitions |
| Docker/compose.md | 130 | 482 | terminal, exercise, command-builder, 2 admonitions |
| Nginx/configuration.md | 173 | 607 | terminal, exercise, code-walkthrough, 3 admonitions |
| Security/tls-ssl-fundamentals.md | 118 | 365 | terminal, exercise, 2 mermaid diagrams, 2 admonitions |
| Security/certificate-management.md | 148 | 461 | terminal, exercise, command-builder, 2 admonitions |
| Python/introduction | 157 | 428 | terminal, exercise, code-walkthrough, 2 admonitions |
| Python/data-structures | 193 | 511 | terminal, exercise, 2 admonitions |
| Python/files-and-apis | 178 | 462 | terminal, exercise, 2 admonitions |
| Python/system-automation | 185 | 604 | terminal, exercise, 2 admonitions |
| Python/testing-and-tooling | 155 | 526 | terminal, exercise, code-walkthrough, 2 admonitions |

**Total**: ~1,585 lines of stubs expanded to ~5,008 lines of comprehensive content (+4,132 / -626 net).

## Test plan

- [x] `python -m pytest tests/` - 25/25 passed (interactive component YAML parsing)
- [x] `npx vitest run` - 53/53 passed (JS component tests)
- [x] `mkdocs build --strict` - successful (no broken links or missing files)
- [ ] Visual review of rendered guides on the MkDocs site