### PR TITLE
Fix topic card links returning 404

### DIFF
--- a/DNS Administration/README.md
+++ b/DNS Administration/README.md
@@ -9,7 +9,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 ## Guides
 
 <div class="topic-progression">
-<a class="topic-card" href="dns-fundamentals.md" data-guide="dns-fundamentals" data-topic="DNS Administration">
+<a class="topic-card" href="dns-fundamentals/" data-guide="dns-fundamentals" data-topic="DNS Administration">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">
@@ -22,7 +22,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="zone-files-and-records.md" data-guide="zone-files-and-records" data-topic="DNS Administration">
+<a class="topic-card" href="zone-files-and-records/" data-guide="zone-files-and-records" data-topic="DNS Administration">
 <span class="topic-card__number">2</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Zone Files and Records</div>
@@ -34,7 +34,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="dns-tools.md" data-guide="dns-tools" data-topic="DNS Administration">
+<a class="topic-card" href="dns-tools/" data-guide="dns-tools" data-topic="DNS Administration">
 <span class="topic-card__number">3</span>
 <div class="topic-card__body">
 <div class="topic-card__title">DNS Tools and Troubleshooting</div>
@@ -46,7 +46,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="bind.md" data-guide="bind" data-topic="DNS Administration">
+<a class="topic-card" href="bind/" data-guide="bind" data-topic="DNS Administration">
 <span class="topic-card__number">4</span>
 <div class="topic-card__body">
 <div class="topic-card__title">BIND</div>
@@ -58,7 +58,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="nsd-and-unbound.md" data-guide="nsd-and-unbound" data-topic="DNS Administration">
+<a class="topic-card" href="nsd-and-unbound/" data-guide="nsd-and-unbound" data-topic="DNS Administration">
 <span class="topic-card__number">5</span>
 <div class="topic-card__body">
 <div class="topic-card__title">NSD and Unbound</div>
@@ -70,7 +70,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="powerdns.md" data-guide="powerdns" data-topic="DNS Administration">
+<a class="topic-card" href="powerdns/" data-guide="powerdns" data-topic="DNS Administration">
 <span class="topic-card__number">6</span>
 <div class="topic-card__body">
 <div class="topic-card__title">PowerDNS</div>
@@ -82,7 +82,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="dnssec.md" data-guide="dnssec" data-topic="DNS Administration">
+<a class="topic-card" href="dnssec/" data-guide="dnssec" data-topic="DNS Administration">
 <span class="topic-card__number">7</span>
 <div class="topic-card__body">
 <div class="topic-card__title">DNSSEC</div>
@@ -94,7 +94,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="dns-architecture.md" data-guide="dns-architecture" data-topic="DNS Administration">
+<a class="topic-card" href="dns-architecture/" data-guide="dns-architecture" data-topic="DNS Administration">
 <span class="topic-card__number">8</span>
 <div class="topic-card__body">
 <div class="topic-card__title">DNS Architecture and Operations</div>

--- a/Databases/README.md
+++ b/Databases/README.md
@@ -10,7 +10,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 
 <div class="topic-progression">
 <h3>Foundations</h3>
-<a class="topic-card" href="database-fundamentals.md" data-guide="database-fundamentals" data-topic="Databases">
+<a class="topic-card" href="database-fundamentals/" data-guide="database-fundamentals" data-topic="Databases">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">
@@ -23,7 +23,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="sql-essentials.md" data-guide="sql-essentials" data-topic="Databases">
+<a class="topic-card" href="sql-essentials/" data-guide="sql-essentials" data-topic="Databases">
 <span class="topic-card__number">2</span>
 <div class="topic-card__body">
 <div class="topic-card__title">SQL Essentials</div>
@@ -35,7 +35,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="database-design.md" data-guide="database-design" data-topic="Databases">
+<a class="topic-card" href="database-design/" data-guide="database-design" data-topic="Databases">
 <span class="topic-card__number">3</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Database Design &amp; Modeling</div>
@@ -48,7 +48,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
 <h3>MySQL &amp; MariaDB</h3>
-<a class="topic-card" href="mysql-installation-and-configuration.md" data-guide="mysql-installation-and-configuration" data-topic="Databases">
+<a class="topic-card" href="mysql-installation-and-configuration/" data-guide="mysql-installation-and-configuration" data-topic="Databases">
 <span class="topic-card__number">4</span>
 <div class="topic-card__body">
 <div class="topic-card__title">MySQL Installation &amp; Configuration</div>
@@ -60,7 +60,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="mysql-administration.md" data-guide="mysql-administration" data-topic="Databases">
+<a class="topic-card" href="mysql-administration/" data-guide="mysql-administration" data-topic="Databases">
 <span class="topic-card__number">5</span>
 <div class="topic-card__body">
 <div class="topic-card__title">MySQL Administration</div>
@@ -72,7 +72,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="mysql-performance.md" data-guide="mysql-performance" data-topic="Databases">
+<a class="topic-card" href="mysql-performance/" data-guide="mysql-performance" data-topic="Databases">
 <span class="topic-card__number">6</span>
 <div class="topic-card__body">
 <div class="topic-card__title">MySQL Performance &amp; Optimization</div>
@@ -84,7 +84,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="mysql-replication.md" data-guide="mysql-replication" data-topic="Databases">
+<a class="topic-card" href="mysql-replication/" data-guide="mysql-replication" data-topic="Databases">
 <span class="topic-card__number">7</span>
 <div class="topic-card__body">
 <div class="topic-card__title">MySQL Replication &amp; High Availability</div>
@@ -97,7 +97,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
 <h3>PostgreSQL</h3>
-<a class="topic-card" href="postgresql-fundamentals.md" data-guide="postgresql-fundamentals" data-topic="Databases">
+<a class="topic-card" href="postgresql-fundamentals/" data-guide="postgresql-fundamentals" data-topic="Databases">
 <span class="topic-card__number">8</span>
 <div class="topic-card__body">
 <div class="topic-card__title">PostgreSQL Fundamentals</div>
@@ -109,7 +109,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="postgresql-administration.md" data-guide="postgresql-administration" data-topic="Databases">
+<a class="topic-card" href="postgresql-administration/" data-guide="postgresql-administration" data-topic="Databases">
 <span class="topic-card__number">9</span>
 <div class="topic-card__body">
 <div class="topic-card__title">PostgreSQL Administration</div>
@@ -121,7 +121,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="postgresql-advanced.md" data-guide="postgresql-advanced" data-topic="Databases">
+<a class="topic-card" href="postgresql-advanced/" data-guide="postgresql-advanced" data-topic="Databases">
 <span class="topic-card__number">10</span>
 <div class="topic-card__body">
 <div class="topic-card__title">PostgreSQL Advanced Features</div>
@@ -134,7 +134,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
 <h3>NoSQL</h3>
-<a class="topic-card" href="nosql-concepts.md" data-guide="nosql-concepts" data-topic="Databases">
+<a class="topic-card" href="nosql-concepts/" data-guide="nosql-concepts" data-topic="Databases">
 <span class="topic-card__number">11</span>
 <div class="topic-card__body">
 <div class="topic-card__title">NoSQL Concepts &amp; Architecture</div>
@@ -146,7 +146,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="mongodb.md" data-guide="mongodb" data-topic="Databases">
+<a class="topic-card" href="mongodb/" data-guide="mongodb" data-topic="Databases">
 <span class="topic-card__number">12</span>
 <div class="topic-card__body">
 <div class="topic-card__title">MongoDB</div>
@@ -158,7 +158,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="redis.md" data-guide="redis" data-topic="Databases">
+<a class="topic-card" href="redis/" data-guide="redis" data-topic="Databases">
 <span class="topic-card__number">13</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Redis</div>
@@ -171,7 +171,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
 <h3>Operations</h3>
-<a class="topic-card" href="backup-and-recovery.md" data-guide="backup-and-recovery" data-topic="Databases">
+<a class="topic-card" href="backup-and-recovery/" data-guide="backup-and-recovery" data-topic="Databases">
 <span class="topic-card__number">14</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Backup &amp; Recovery Strategies</div>
@@ -183,7 +183,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="database-security.md" data-guide="database-security" data-topic="Databases">
+<a class="topic-card" href="database-security/" data-guide="database-security" data-topic="Databases">
 <span class="topic-card__number">15</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Database Security</div>
@@ -195,7 +195,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="scaling-and-architecture.md" data-guide="scaling-and-architecture" data-topic="Databases">
+<a class="topic-card" href="scaling-and-architecture/" data-guide="scaling-and-architecture" data-topic="Databases">
 <span class="topic-card__number">16</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Scaling &amp; Architecture Patterns</div>
@@ -207,7 +207,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="innodb-recovery-pdrt.md" data-guide="innodb-recovery-pdrt" data-topic="Databases">
+<a class="topic-card" href="innodb-recovery-pdrt/" data-guide="innodb-recovery-pdrt" data-topic="Databases">
 <span class="topic-card__number">17</span>
 <div class="topic-card__body">
 <div class="topic-card__title">InnoDB Recovery with PDRT</div>

--- a/Dev Zero/Perl/README.md
+++ b/Dev Zero/Perl/README.md
@@ -7,7 +7,7 @@ A comprehensive course that takes you from Unix foundations through professional
 ## Guides
 
 <div class="topic-progression">
-<a class="topic-card" href="perl_dev0_introduction.md" data-guide="perl_dev0_introduction" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="perl_dev0_introduction/" data-guide="perl_dev0_introduction" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">
@@ -20,7 +20,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="scalars-strings-numbers.md" data-guide="scalars-strings-numbers" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="scalars-strings-numbers/" data-guide="scalars-strings-numbers" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">2</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Scalars, Strings, and Numbers</div>
@@ -32,7 +32,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="arrays-hashes-lists.md" data-guide="arrays-hashes-lists" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="arrays-hashes-lists/" data-guide="arrays-hashes-lists" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">3</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Arrays, Hashes, and Lists</div>
@@ -44,7 +44,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="control-flow.md" data-guide="control-flow" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="control-flow/" data-guide="control-flow" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">4</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Control Flow</div>
@@ -56,7 +56,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="regular-expressions.md" data-guide="regular-expressions" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="regular-expressions/" data-guide="regular-expressions" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">5</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Regular Expressions</div>
@@ -68,7 +68,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="subroutines-references.md" data-guide="subroutines-references" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="subroutines-references/" data-guide="subroutines-references" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">6</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Subroutines and References</div>
@@ -80,7 +80,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="file-io-and-system.md" data-guide="file-io-and-system" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="file-io-and-system/" data-guide="file-io-and-system" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">7</span>
 <div class="topic-card__body">
 <div class="topic-card__title">File I/O and System Interaction</div>
@@ -92,7 +92,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="modules-and-cpan.md" data-guide="modules-and-cpan" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="modules-and-cpan/" data-guide="modules-and-cpan" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">8</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Modules and CPAN</div>
@@ -104,7 +104,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="object-oriented-perl.md" data-guide="object-oriented-perl" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="object-oriented-perl/" data-guide="object-oriented-perl" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">9</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Object-Oriented Perl</div>
@@ -116,7 +116,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="error-handling-debugging.md" data-guide="error-handling-debugging" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="error-handling-debugging/" data-guide="error-handling-debugging" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">10</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Error Handling and Debugging</div>
@@ -128,7 +128,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="testing.md" data-guide="testing" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="testing/" data-guide="testing" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">11</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Testing</div>
@@ -140,7 +140,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="text-processing-oneliners.md" data-guide="text-processing-oneliners" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="text-processing-oneliners/" data-guide="text-processing-oneliners" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">12</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Text Processing and One-Liners</div>
@@ -152,7 +152,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="networking-daemons.md" data-guide="networking-daemons" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="networking-daemons/" data-guide="networking-daemons" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">13</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Networking and Daemons</div>
@@ -164,7 +164,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="web-frameworks-apis.md" data-guide="web-frameworks-apis" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="web-frameworks-apis/" data-guide="web-frameworks-apis" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">14</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Web Frameworks and APIs</div>
@@ -176,7 +176,7 @@ A comprehensive course that takes you from Unix foundations through professional
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="perl_developer_roadmap.md" data-guide="perl_developer_roadmap" data-topic="Dev Zero/Perl">
+<a class="topic-card" href="perl_developer_roadmap/" data-guide="perl_developer_roadmap" data-topic="Dev Zero/Perl">
 <span class="topic-card__number">15</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Developer Roadmap</div>

--- a/Dev Zero/Python/README.md
+++ b/Dev Zero/Python/README.md
@@ -9,7 +9,7 @@ Python is the "second best language for everything." While it may not be the fas
 ## Guides
 
 <div class="topic-progression">
-<a class="topic-card" href="python_dev0_introduction.md" data-guide="python_dev0_introduction" data-topic="Dev Zero/Python">
+<a class="topic-card" href="python_dev0_introduction/" data-guide="python_dev0_introduction" data-topic="Dev Zero/Python">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">
@@ -22,7 +22,7 @@ Python is the "second best language for everything." While it may not be the fas
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="data-structures-and-logic.md" data-guide="data-structures-and-logic" data-topic="Dev Zero/Python">
+<a class="topic-card" href="data-structures-and-logic/" data-guide="data-structures-and-logic" data-topic="Dev Zero/Python">
 <span class="topic-card__number">2</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Data Structures and Logic</div>
@@ -34,7 +34,7 @@ Python is the "second best language for everything." While it may not be the fas
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="files-and-apis.md" data-guide="files-and-apis" data-topic="Dev Zero/Python">
+<a class="topic-card" href="files-and-apis/" data-guide="files-and-apis" data-topic="Dev Zero/Python">
 <span class="topic-card__number">3</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Working with Files and APIs</div>
@@ -46,7 +46,7 @@ Python is the "second best language for everything." While it may not be the fas
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="system-automation.md" data-guide="system-automation" data-topic="Dev Zero/Python">
+<a class="topic-card" href="system-automation/" data-guide="system-automation" data-topic="Dev Zero/Python">
 <span class="topic-card__number">4</span>
 <div class="topic-card__body">
 <div class="topic-card__title">System Automation</div>
@@ -58,7 +58,7 @@ Python is the "second best language for everything." While it may not be the fas
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="testing-and-tooling.md" data-guide="testing-and-tooling" data-topic="Dev Zero/Python">
+<a class="topic-card" href="testing-and-tooling/" data-guide="testing-and-tooling" data-topic="Dev Zero/Python">
 <span class="topic-card__number">5</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Testing and Tooling</div>

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -5,7 +5,7 @@ Docker is a platform for developing, shipping, and running applications in isola
 ## Guides
 
 <div class="topic-progression">
-<a class="topic-card" href="fundamentals.md" data-guide="fundamentals" data-topic="Docker">
+<a class="topic-card" href="fundamentals/" data-guide="fundamentals" data-topic="Docker">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">
@@ -18,7 +18,7 @@ Docker is a platform for developing, shipping, and running applications in isola
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="compose.md" data-guide="compose" data-topic="Docker">
+<a class="topic-card" href="compose/" data-guide="compose" data-topic="Docker">
 <span class="topic-card__number">2</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Docker Compose</div>

--- a/Git/README.md
+++ b/Git/README.md
@@ -10,7 +10,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 
 <div class="topic-progression">
 <h3>Foundations</h3>
-<a class="topic-card" href="introduction.md" data-guide="introduction" data-topic="Git">
+<a class="topic-card" href="introduction/" data-guide="introduction" data-topic="Git">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">
@@ -23,7 +23,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="three-trees.md" data-guide="three-trees" data-topic="Git">
+<a class="topic-card" href="three-trees/" data-guide="three-trees" data-topic="Git">
 <span class="topic-card__number">2</span>
 <div class="topic-card__body">
 <div class="topic-card__title">The Three Trees: Working Directory, Index, and Repository</div>
@@ -35,7 +35,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="commits-and-history.md" data-guide="commits-and-history" data-topic="Git">
+<a class="topic-card" href="commits-and-history/" data-guide="commits-and-history" data-topic="Git">
 <span class="topic-card__number">3</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Commits and History</div>
@@ -47,7 +47,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="branches-and-merging.md" data-guide="branches-and-merging" data-topic="Git">
+<a class="topic-card" href="branches-and-merging/" data-guide="branches-and-merging" data-topic="Git">
 <span class="topic-card__number">4</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Branches and Merging</div>
@@ -60,7 +60,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
 <h3>Core Workflows</h3>
-<a class="topic-card" href="remote-repositories.md" data-guide="remote-repositories" data-topic="Git">
+<a class="topic-card" href="remote-repositories/" data-guide="remote-repositories" data-topic="Git">
 <span class="topic-card__number">5</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Remote Repositories</div>
@@ -72,7 +72,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="rewriting-history.md" data-guide="rewriting-history" data-topic="Git">
+<a class="topic-card" href="rewriting-history/" data-guide="rewriting-history" data-topic="Git">
 <span class="topic-card__number">6</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Rewriting History</div>
@@ -84,7 +84,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="stashing-and-worktree.md" data-guide="stashing-and-worktree" data-topic="Git">
+<a class="topic-card" href="stashing-and-worktree/" data-guide="stashing-and-worktree" data-topic="Git">
 <span class="topic-card__number">7</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Stashing and the Worktree</div>
@@ -96,7 +96,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="configuring-git.md" data-guide="configuring-git" data-topic="Git">
+<a class="topic-card" href="configuring-git/" data-guide="configuring-git" data-topic="Git">
 <span class="topic-card__number">8</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Configuring Git</div>
@@ -109,7 +109,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
 <h3>Git Internals</h3>
-<a class="topic-card" href="object-model.md" data-guide="object-model" data-topic="Git">
+<a class="topic-card" href="object-model/" data-guide="object-model" data-topic="Git">
 <span class="topic-card__number">9</span>
 <div class="topic-card__body">
 <div class="topic-card__title">The Object Model</div>
@@ -121,7 +121,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="refs-reflog-dag.md" data-guide="refs-reflog-dag" data-topic="Git">
+<a class="topic-card" href="refs-reflog-dag/" data-guide="refs-reflog-dag" data-topic="Git">
 <span class="topic-card__number">10</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Refs, the Reflog, and the DAG</div>
@@ -133,7 +133,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="transfer-protocols.md" data-guide="transfer-protocols" data-topic="Git">
+<a class="topic-card" href="transfer-protocols/" data-guide="transfer-protocols" data-topic="Git">
 <span class="topic-card__number">11</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Transfer Protocols and Plumbing</div>
@@ -146,7 +146,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
 <h3>Platform Collaboration</h3>
-<a class="topic-card" href="collaboration-workflows.md" data-guide="collaboration-workflows" data-topic="Git">
+<a class="topic-card" href="collaboration-workflows/" data-guide="collaboration-workflows" data-topic="Git">
 <span class="topic-card__number">12</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Collaboration Workflows</div>
@@ -158,7 +158,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="platforms.md" data-guide="platforms" data-topic="Git">
+<a class="topic-card" href="platforms/" data-guide="platforms" data-topic="Git">
 <span class="topic-card__number">13</span>
 <div class="topic-card__body">
 <div class="topic-card__title">GitHub, GitLab, and Bitbucket</div>
@@ -171,7 +171,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
 <h3>Advanced Operations</h3>
-<a class="topic-card" href="hooks-and-automation.md" data-guide="hooks-and-automation" data-topic="Git">
+<a class="topic-card" href="hooks-and-automation/" data-guide="hooks-and-automation" data-topic="Git">
 <span class="topic-card__number">14</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Git Hooks and Automation</div>
@@ -183,7 +183,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="security.md" data-guide="security" data-topic="Git">
+<a class="topic-card" href="security/" data-guide="security" data-topic="Git">
 <span class="topic-card__number">15</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Git Security</div>
@@ -195,7 +195,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="monorepos-and-scaling.md" data-guide="monorepos-and-scaling" data-topic="Git">
+<a class="topic-card" href="monorepos-and-scaling/" data-guide="monorepos-and-scaling" data-topic="Git">
 <span class="topic-card__number">16</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Monorepos and Scaling Git</div>
@@ -207,7 +207,7 @@ Each guide is self-contained, but the order below follows a natural learning pat
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="troubleshooting-and-recovery.md" data-guide="troubleshooting-and-recovery" data-topic="Git">
+<a class="topic-card" href="troubleshooting-and-recovery/" data-guide="troubleshooting-and-recovery" data-topic="Git">
 <span class="topic-card__number">17</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Troubleshooting and Recovery</div>

--- a/Linux Essentials/README.md
+++ b/Linux Essentials/README.md
@@ -13,7 +13,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 ## Guides
 
 <div class="topic-progression">
-<a class="topic-card" href="shell-basics.md" data-guide="shell-basics" data-topic="Linux Essentials">
+<a class="topic-card" href="shell-basics/" data-guide="shell-basics" data-topic="Linux Essentials">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">
@@ -26,7 +26,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="streams-and-redirection.md" data-guide="streams-and-redirection" data-topic="Linux Essentials">
+<a class="topic-card" href="streams-and-redirection/" data-guide="streams-and-redirection" data-topic="Linux Essentials">
 <span class="topic-card__number">2</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Streams and Redirection</div>
@@ -38,7 +38,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="text-processing.md" data-guide="text-processing" data-topic="Linux Essentials">
+<a class="topic-card" href="text-processing/" data-guide="text-processing" data-topic="Linux Essentials">
 <span class="topic-card__number">3</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Text Processing</div>
@@ -50,7 +50,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="regular-expressions.md" data-guide="regular-expressions" data-topic="Linux Essentials">
+<a class="topic-card" href="regular-expressions/" data-guide="regular-expressions" data-topic="Linux Essentials">
 <span class="topic-card__number">4</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Regular Expressions</div>
@@ -62,7 +62,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="finding-files.md" data-guide="finding-files" data-topic="Linux Essentials">
+<a class="topic-card" href="finding-files/" data-guide="finding-files" data-topic="Linux Essentials">
 <span class="topic-card__number">5</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Finding Files</div>
@@ -74,7 +74,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="file-permissions.md" data-guide="file-permissions" data-topic="Linux Essentials">
+<a class="topic-card" href="file-permissions/" data-guide="file-permissions" data-topic="Linux Essentials">
 <span class="topic-card__number">6</span>
 <div class="topic-card__body">
 <div class="topic-card__title">File Permissions</div>
@@ -86,7 +86,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="job-control.md" data-guide="job-control" data-topic="Linux Essentials">
+<a class="topic-card" href="job-control/" data-guide="job-control" data-topic="Linux Essentials">
 <span class="topic-card__number">7</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Job Control</div>
@@ -98,7 +98,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="scripting-fundamentals.md" data-guide="scripting-fundamentals" data-topic="Linux Essentials">
+<a class="topic-card" href="scripting-fundamentals/" data-guide="scripting-fundamentals" data-topic="Linux Essentials">
 <span class="topic-card__number">8</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Scripting Fundamentals</div>
@@ -110,7 +110,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="disk-and-filesystem.md" data-guide="disk-and-filesystem" data-topic="Linux Essentials">
+<a class="topic-card" href="disk-and-filesystem/" data-guide="disk-and-filesystem" data-topic="Linux Essentials">
 <span class="topic-card__number">9</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Disk and Filesystem</div>
@@ -122,7 +122,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="package-management.md" data-guide="package-management" data-topic="Linux Essentials">
+<a class="topic-card" href="package-management/" data-guide="package-management" data-topic="Linux Essentials">
 <span class="topic-card__number">10</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Package Management</div>
@@ -134,7 +134,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="system-services.md" data-guide="system-services" data-topic="Linux Essentials">
+<a class="topic-card" href="system-services/" data-guide="system-services" data-topic="Linux Essentials">
 <span class="topic-card__number">11</span>
 <div class="topic-card__body">
 <div class="topic-card__title">System Services</div>
@@ -146,7 +146,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="user-and-group-management.md" data-guide="user-and-group-management" data-topic="Linux Essentials">
+<a class="topic-card" href="user-and-group-management/" data-guide="user-and-group-management" data-topic="Linux Essentials">
 <span class="topic-card__number">12</span>
 <div class="topic-card__body">
 <div class="topic-card__title">User and Group Management</div>
@@ -158,7 +158,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="ssh-configuration.md" data-guide="ssh-configuration" data-topic="Linux Essentials">
+<a class="topic-card" href="ssh-configuration/" data-guide="ssh-configuration" data-topic="Linux Essentials">
 <span class="topic-card__number">13</span>
 <div class="topic-card__body">
 <div class="topic-card__title">SSH Configuration</div>
@@ -170,7 +170,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="log-management.md" data-guide="log-management" data-topic="Linux Essentials">
+<a class="topic-card" href="log-management/" data-guide="log-management" data-topic="Linux Essentials">
 <span class="topic-card__number">14</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Log Management</div>
@@ -182,7 +182,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="networking.md" data-guide="networking" data-topic="Linux Essentials">
+<a class="topic-card" href="networking/" data-guide="networking" data-topic="Linux Essentials">
 <span class="topic-card__number">15</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Networking</div>
@@ -194,7 +194,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="system-information.md" data-guide="system-information" data-topic="Linux Essentials">
+<a class="topic-card" href="system-information/" data-guide="system-information" data-topic="Linux Essentials">
 <span class="topic-card__number">16</span>
 <div class="topic-card__body">
 <div class="topic-card__title">System Information</div>
@@ -206,7 +206,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="archiving-and-compression.md" data-guide="archiving-and-compression" data-topic="Linux Essentials">
+<a class="topic-card" href="archiving-and-compression/" data-guide="archiving-and-compression" data-topic="Linux Essentials">
 <span class="topic-card__number">17</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Archiving and Compression</div>
@@ -218,7 +218,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="best-practices.md" data-guide="best-practices" data-topic="Linux Essentials">
+<a class="topic-card" href="best-practices/" data-guide="best-practices" data-topic="Linux Essentials">
 <span class="topic-card__number">18</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Best Practices</div>
@@ -230,7 +230,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="cron-and-scheduled-tasks.md" data-guide="cron-and-scheduled-tasks" data-topic="Linux Essentials">
+<a class="topic-card" href="cron-and-scheduled-tasks/" data-guide="cron-and-scheduled-tasks" data-topic="Linux Essentials">
 <span class="topic-card__number">19</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Cron and Scheduled Tasks</div>
@@ -242,7 +242,7 @@ Each topic is covered in its own guide. Start anywhere - they're self-contained,
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="firewall-fundamentals.md" data-guide="firewall-fundamentals" data-topic="Linux Essentials">
+<a class="topic-card" href="firewall-fundamentals/" data-guide="firewall-fundamentals" data-topic="Linux Essentials">
 <span class="topic-card__number">20</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Firewall and Networking Security</div>

--- a/Nginx/README.md
+++ b/Nginx/README.md
@@ -9,7 +9,7 @@ Each topic is covered in its own guide. Start with the configuration fundamental
 ## Guides
 
 <div class="topic-progression">
-<a class="topic-card" href="configuration.md" data-guide="configuration" data-topic="Nginx">
+<a class="topic-card" href="configuration/" data-guide="configuration" data-topic="Nginx">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">

--- a/Security/README.md
+++ b/Security/README.md
@@ -5,7 +5,7 @@ This section covers essential security practices for system administrators, focu
 ## Guides
 
 <div class="topic-progression">
-<a class="topic-card" href="tls-ssl-fundamentals.md" data-guide="tls-ssl-fundamentals" data-topic="Security">
+<a class="topic-card" href="tls-ssl-fundamentals/" data-guide="tls-ssl-fundamentals" data-topic="Security">
 <span class="topic-card__number">1</span>
 <span class="topic-card__badge">Start Here</span>
 <div class="topic-card__body">
@@ -18,7 +18,7 @@ This section covers essential security practices for system administrators, focu
 </div>
 <span class="topic-card__check" aria-hidden="true">&#10003;</span>
 </a>
-<a class="topic-card" href="certificate-management.md" data-guide="certificate-management" data-topic="Security">
+<a class="topic-card" href="certificate-management/" data-guide="certificate-management" data-topic="Security">
 <span class="topic-card__number">2</span>
 <div class="topic-card__body">
 <div class="topic-card__title">Certificate Management</div>


### PR DESCRIPTION
## Summary
- Fixed 87 topic card `href` attributes across all 9 topic README files
- Changed `.md` extensions to `/` suffixes (e.g., `href="shell-basics.md"` → `href="shell-basics/"`)
- MkDocs uses directory URLs but does not resolve `.md` in raw HTML `href` attributes, causing every topic card click to 404

## Test plan
- [ ] `mkdocs build --strict` passes
- [ ] Click topic cards on Linux Essentials, Git, Databases, DNS, Perl, Python, Docker, Nginx, Security index pages — all navigate correctly
- [ ] Existing Python and JS test suites pass