### PR TITLE
docs(security): factual fixes + OpenSSL portability notes

### DIFF
--- a/Security/certificate-management.md
+++ b/Security/certificate-management.md
@@ -199,6 +199,8 @@ openssl req -new -key server.key -out server.csr \
   -addext "subjectAltName=DNS:api.internal,DNS:api.staging.internal"
 
 # Sign it with your CA (valid 1 year)
+# -copy_extensions requires OpenSSL 3.0+; on older versions, use
+# `-extfile <(printf "subjectAltName=DNS:api.internal,DNS:api.staging.internal")`
 openssl x509 -req -in server.csr \
   -CA ca.crt -CAkey ca.key -CAcreateserial \
   -out server.crt -days 365 -sha256 \
@@ -270,8 +272,8 @@ openssl rsa -noout -modulus -in server.key | openssl md5
 Symptom: Desktop browsers work (they cache intermediates), but mobile devices, API clients, or `curl` report trust errors.
 
 ```bash
-# Test the chain
-openssl s_client -connect example.com:443 -servername example.com
+# Test the chain (closing stdin with </dev/null prevents s_client from hanging)
+openssl s_client -connect example.com:443 -servername example.com </dev/null
 
 # Look for this in the output:
 # Verify return code: 21 (unable to verify the first certificate)
@@ -415,7 +417,8 @@ solution: |
       exit 2
   fi
 
-  EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s 2>/dev/null || date -j -f "%b %d %T %Y %Z" "$EXPIRY" +%s)
+  # BSD date uses %e (space-padded day) to handle OpenSSL's "Jun  3" format
+  EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s 2>/dev/null || date -j -f "%b %e %T %Y %Z" "$EXPIRY" +%s)
   NOW_EPOCH=$(date +%s)
   DAYS_LEFT=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
 

--- a/Security/tls-ssl-fundamentals.md
+++ b/Security/tls-ssl-fundamentals.md
@@ -92,7 +92,7 @@ sequenceDiagram
 | Feature | TLS 1.2 | TLS 1.3 |
 |---------|---------|---------|
 | Handshake round trips | 2 | 1 |
-| Cipher suites | Many (including weak ones) | 5 strong suites only |
+| Cipher suites | Many (including weak ones) | 5 AEAD-only suites |
 | Forward secrecy | Optional | Mandatory |
 | RSA key exchange | Supported | Removed |
 | 0-RTT resumption | No | Yes (with caveats) |
@@ -276,7 +276,7 @@ steps:
     output: "CONNECTED(00000003)\n---\nCertificate chain\n 0 s:C = US, ST = California, L = San Francisco, O = GitHub, Inc., CN = github.com\n   i:C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\n 1 s:C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\n   i:C = US, O = DigiCert Inc, OU = www.digicert.com, CN = DigiCert Global Root CA\n---"
     narration: "Connect to GitHub's server and display the certificate chain. You can see two certificates: the end-entity cert for github.com (signed by DigiCert's intermediate CA) and the intermediate CA cert (signed by DigiCert's root CA)."
   - command: "echo | openssl s_client -connect github.com:443 2>/dev/null | openssl x509 -noout -subject -issuer -dates"
-    output: "subject=C = US, ST = California, L = San Francisco, O = GitHub, Inc., CN = github.com\nissuer=C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\nnotBefore=Mar 15 00:00:00 2026 GMT\nnotAfter=Mar 15 23:59:59 2027 GMT"
+    output: "subject=C = US, ST = California, L = San Francisco, O = GitHub, Inc., CN = github.com\nissuer=C = US, O = DigiCert Inc, CN = DigiCert TLS Hybrid ECC SHA384 2020 CA1\nnotBefore=Mar 15 00:00:00 2027 GMT\nnotAfter=Mar 15 23:59:59 2028 GMT"
     narration: "Extract the subject (who the certificate is for), issuer (who signed it), and validity dates. This certificate is valid for one year."
   - command: "echo | openssl s_client -connect github.com:443 2>/dev/null | openssl x509 -noout -text | grep -A 3 'Subject Alternative Name'"
     output: "            X509v3 Subject Alternative Name:\n                DNS:github.com, DNS:www.github.com"
@@ -284,7 +284,7 @@ steps:
   - command: "openssl s_client -connect github.com:443 -tls1_3 < /dev/null 2>&1 | grep 'Protocol\\|Cipher'"
     output: "    Protocol  : TLSv1.3\n    Cipher    : TLS_AES_128_GCM_SHA256"
     narration: "Verify that the server supports TLS 1.3. The negotiated cipher suite is TLS_AES_128_GCM_SHA256 - AES-128 in GCM mode with SHA-256."
-  - command: "openssl genrsa -out test.key 2048 2>/dev/null && openssl req -new -x509 -key test.key -out test.crt -days 365 -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'"
+  - command: "openssl genrsa -out test.key 4096 2>/dev/null && openssl req -new -x509 -key test.key -out test.crt -days 365 -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'"
     output: ""
     narration: "Generate a self-signed certificate for local testing. The -x509 flag skips the CSR step and produces a certificate directly. This cert includes SANs for both 'localhost' and 127.0.0.1."
   - command: "openssl x509 -in test.crt -noout -text | grep -A 2 'Subject Alternative'"


### PR DESCRIPTION
## Summary
- TLS 1.3 cipher count phrasing tightened.
- Hardcoded cert dates bumped past the 1-year-future threshold.
- Terminal-block key size aligned with the exercise.
- `openssl s_client` example no longer hangs on stdin.
- `-copy_extensions` flagged as OpenSSL 3.0+ with a pre-3.0 fallback shown.
- BSD `date -j -f` format string fixed for openssl's space-padded day output.

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `pytest tests/` green