### PR TITLE
docs(docker): factual fixes across the Docker topic

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -46,7 +46,7 @@ Docker is a platform for developing, shipping, and running applications in isola
 
 ## Introduction
 
-Containers allow you to package an application with all of its dependencies — libraries, configuration files, and runtime — into a single unit. Unlike Virtual Machines (VMs), containers share the host's OS kernel, making them lightweight, fast to start, and efficient in resource usage.
+Containers allow you to package an application with all of its dependencies (libraries, configuration files, and runtime) into a single unit. Unlike Virtual Machines (VMs), containers share the host's OS kernel, making them lightweight, fast to start, and efficient in resource usage.
 
 ### Key Concepts
 

--- a/Docker/compose.md
+++ b/Docker/compose.md
@@ -34,7 +34,7 @@ The benefits go beyond convenience:
 
 ## The Compose File
 
-The core of Docker Compose is a YAML file named `compose.yml` (or `docker-compose.yml` for backward compatibility). It defines services, networks, and volumes.
+The core of Docker Compose is a YAML file. Compose v2 looks for `compose.yaml` (the canonical name), `compose.yml`, `docker-compose.yaml`, or `docker-compose.yml` in that order. It defines services, networks, and volumes.
 
 ### A Production-Style Example
 
@@ -264,7 +264,7 @@ steps:
     output: "[+] Building 8.2s\n[+] Running 4/4\n ✔ Network myproject_default  Created\n ✔ Volume myproject_pgdata    Created\n ✔ Container myproject-db-1    Healthy\n ✔ Container myproject-cache-1 Started\n ✔ Container myproject-web-1   Started"
     narration: "Compose builds the web image, creates a bridge network and a named volume, then starts containers in dependency order. The web container waits until the db health check passes."
   - command: "docker compose ps"
-    output: "NAME                 SERVICE   STATUS    PORTS\nmyproject-cache-1    cache     running   6379/tcp\nmyproject-db-1       db        running   5432/tcp\nmyproject-web-1      web       running   0.0.0.0:8000->8000/tcp"
+    output: "NAME                 SERVICE   STATUS              PORTS\nmyproject-cache-1    cache     Up 8 seconds        6379/tcp\nmyproject-db-1       db        Up 9 seconds (healthy)  5432/tcp\nmyproject-web-1      web       Up 7 seconds        0.0.0.0:8000->8000/tcp"
     narration: "All three services are running. Only the web service has a published port (8000). The cache and database ports are accessible to other containers on the network but not from the host."
   - command: "docker compose exec web python -c \"import redis; r = redis.Redis(host='cache'); print(r.ping())\""
     output: "True"
@@ -397,7 +397,7 @@ scenario: |
   6. Use a `.env` file for the database password instead of hardcoding it
   7. Add a bind mount on the `web` service for live code reloading in development
 hints:
-  - "The healthcheck test for PostgreSQL is: [\"CMD-SHELL\", \"pg_isready -U postgres\"]"
+  - "The healthcheck test for PostgreSQL is: [\"CMD-SHELL\", \"pg_isready -U postgres -d myapp\"]"
   - "Use ${DB_PASSWORD} syntax in compose.yml and define DB_PASSWORD in a .env file"
   - "For the bind mount, use .:/app for the source code, but add /app/node_modules as an anonymous volume to prevent host modules from overriding container modules"
   - "Named volumes are declared both under the service (as a mount) and at the top level under 'volumes:'"

--- a/Docker/dockerfile-best-practices.md
+++ b/Docker/dockerfile-best-practices.md
@@ -195,8 +195,10 @@ COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 RUN cargo build --release
 COPY . .
-RUN cargo build --release
+RUN rm -f target/release/deps/myapp* && cargo build --release
 ```
+
+The `rm` step is required: without it Cargo sees the dummy artifact in `target/` and may skip rebuilding even after the real source is copied. Replace `myapp` with your crate name.
 
 **Java (Gradle):**
 
@@ -371,7 +373,7 @@ COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 RUN cargo build --release
 COPY src ./src
-RUN touch src/main.rs && cargo build --release
+RUN rm -f target/release/deps/myapp* && cargo build --release
 
 FROM debian:bookworm-slim
 COPY --from=build /app/target/release/myapp /usr/local/bin/
@@ -470,7 +472,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 ```
 
-The `--no-install-recommends` flag skips suggested and recommended packages, which often include documentation, man pages, and utilities you do not need.
+The `--no-install-recommends` flag skips packages marked as Recommends, which often include documentation, man pages, and utilities you do not need. APT does not install Suggests by default, so they are already excluded.
 
 **apk (Alpine):**
 
@@ -768,7 +770,7 @@ The `HEALTHCHECK` directive tells Docker how to verify a container is functionin
 
 ```dockerfile
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD ["curl", "-f", "http://localhost:3000/health" ]
+    CMD ["curl", "-f", "http://localhost:3000/health"]
 ```
 
 Without a health check, Docker considers a container "healthy" as long as the process is running - even if it is deadlocked, out of memory, or returning errors. Orchestrators like Kubernetes and Docker Swarm use health checks to restart failing containers automatically.

--- a/Docker/fundamentals.md
+++ b/Docker/fundamentals.md
@@ -345,7 +345,7 @@ Docker creates isolated networks so containers can communicate with each other w
 
 | Driver | Description |
 |--------|-------------|
-| `bridge` | Default. Containers on the same bridge network can reach each other by container name. |
+| `bridge` | Default driver. On user-defined bridge networks, containers reach each other by container name; the built-in `bridge` network does not provide name resolution. |
 | `host` | Removes network isolation - the container shares the host's network stack. |
 | `none` | Disables networking entirely. |
 | `overlay` | Spans multiple Docker hosts. Used with Docker Swarm for multi-node clusters. |


### PR DESCRIPTION
## Summary
- README: replace em-dashes with parens in the Containers paragraph.
- fundamentals: fix the network-driver table so it stops contradicting the prose two paragraphs later (default bridge has no name resolution).
- compose: list the four supported file names in lookup order; correct the `docker compose ps` STATUS column in the terminal block; sync exercise hint with the solution.
- dockerfile-best-practices: tighten `--no-install-recommends` description, fix HEALTHCHECK exec-form spacing, add the missing `rm` step to the Rust dummy-build caching pattern (without it cargo can skip rebuilding the real source).

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `pytest tests/` green