### PR TITLE
docs(dns): factual fixes across the DNS topic

### DIFF
--- a/DNS Administration/bind.md
+++ b/DNS Administration/bind.md
@@ -189,7 +189,7 @@ steps:
     narration: "Reload applies the new configuration without dropping existing connections. Use reload after config changes; reserve restart for major changes like listen-address modifications."
   - command: "sudo rndc status"
     output: |
-      version: BIND 9.16.23-RH
+      version: BIND 9.18.27-RH
       running on linux: Linux 5.14.0-362.el9.x86_64
       boot time: Fri, 21 Feb 2026 10:00:00 GMT
       server is up and running

--- a/DNS Administration/dns-fundamentals.md
+++ b/DNS Administration/dns-fundamentals.md
@@ -516,7 +516,7 @@ The AUTHORITY section says "these are the nameservers." The ADDITIONAL section s
 
 DNS traditionally uses **UDP on port 53** for queries under 512 bytes and **TCP on port 53** for larger responses and zone transfers. The 512-byte UDP limit was a practical constraint from the 1980s when network reliability was poor and UDP was faster.
 
-The **Extension Mechanisms for DNS ([EDNS0](https://datatracker.ietf.org/doc/html/rfc6891))** specification raised the effective UDP message size. Modern resolvers advertise a buffer size of 1232-4096 bytes, allowing larger responses (like DNSSEC-signed answers) to travel over UDP.
+The **Extension Mechanisms for DNS ([EDNS0](https://datatracker.ietf.org/doc/html/rfc6891))** specification raised the effective UDP message size. Modern resolvers advertise a buffer size of 1232 bytes (the DNS Flag Day 2020 recommendation, chosen to fit the smallest common path MTU after IPv6 and tunneling overhead), with older defaults reaching up to 4096 bytes. The larger window lets DNSSEC-signed answers travel over UDP.
 
 Newer transport protocols are emerging for privacy:
 

--- a/DNS Administration/dns-tools.md
+++ b/DNS Administration/dns-tools.md
@@ -270,7 +270,7 @@ drill -S example.com
 example.com. (A)
 |---example.com. (DNSKEY keytag: 31406 alg: 13 flags: 256)
     |---example.com. (DS keytag: 31406 digest type: 2)
-        |---com. (DNSKEY keytag: 19718 alg: 13 flags: 256)
+        |---com. (DNSKEY keytag: 19718 alg: 8 flags: 256)
             |---com. (DS keytag: 19718 digest type: 2)
                 |---. (DNSKEY keytag: 20326 alg: 8 flags: 257)
 ;; Chase successful

--- a/DNS Administration/dnssec.md
+++ b/DNS Administration/dnssec.md
@@ -28,7 +28,7 @@ DNS was designed in 1983 with no authentication whatsoever. When a resolver rece
 
 DNS cache poisoning attacks had been known for years, but in 2008, security researcher Dan Kaminsky discovered a technique that made them devastatingly practical. The attack exploited the way resolvers handle referrals to flood a resolver with forged responses, each trying a different transaction ID. Because the transaction ID was only 16 bits (65,536 possibilities), a high-speed attacker could guess the right ID within seconds and inject a poisoned cache entry.
 
-Kaminsky recognized the severity and did something unusual - instead of publishing immediately, he coordinated a massive multi-vendor patching effort through the Department of Homeland Security's US-CERT. DNS software vendors quietly developed and deployed source port randomization patches (adding ~16 bits of entropy) before the vulnerability was publicly disclosed. Kaminsky presented the full details at Black Hat 2008, famously wearing rollerskates on stage.
+Kaminsky recognized the severity and did something unusual - instead of publishing immediately, he coordinated a massive multi-vendor patching effort through CERT/CC at Carnegie Mellon. DNS software vendors quietly developed and deployed source port randomization patches (adding ~16 bits of entropy) before the vulnerability was publicly disclosed. Kaminsky presented the full details at Black Hat 2008, famously wearing rollerskates on stage.
 
 The Kaminsky attack was mitigated but not eliminated by source port randomization. DNSSEC is the real fix - it makes forged responses cryptographically detectable, regardless of how clever the spoofing technique is.
 
@@ -54,7 +54,7 @@ DNSSEC works by creating a chain of cryptographic trust from the root zone down 
 
 The root zone was fully signed with DNSSEC on **July 15, 2010**. The signing ceremony was (and continues to be) one of the most carefully controlled processes in internet governance.
 
-The ICANN **root KSK ceremony** requires approximately 12-14 people from around the world to physically assemble at one of two secure facilities (in Culver City, California or El Segundo, Virginia). Trusted Community Representatives unlock safe deposit boxes containing smart cards. Multiple HSMs (Hardware Security Modules) are involved. The ceremony follows a rigid script, is livestreamed, and typically takes 3-8 hours. A complete audit trail is published. The entire point is that no single person or organization can sign the root zone alone.
+The ICANN **root KSK ceremony** requires approximately 12-14 people from around the world to physically assemble at one of two secure facilities (in El Segundo, California or Culpeper, Virginia). Trusted Community Representatives unlock safe deposit boxes containing smart cards. Multiple HSMs (Hardware Security Modules) are involved. The ceremony follows a rigid script, is livestreamed, and typically takes 3-8 hours. A complete audit trail is published. The entire point is that no single person or organization can sign the root zone alone.
 
 ### How the Chain Works
 
@@ -175,7 +175,7 @@ example.com.    86400   IN  RRSIG   A 13 2 86400 20250215000000 20250201000000 3
 
 The RRSIG fields include the algorithm (13 = ECDSAP256SHA256), the number of labels (2), the original TTL, signature expiration and inception timestamps, the key tag (identifying which DNSKEY made the signature), and the signature itself.
 
-**RRSIG signatures have expiration dates.** If signatures expire and aren't refreshed, DNSSEC validation fails and the domain stops resolving for validating resolvers. This is the most common DNSSEC operational failure. In October 2023, Cloudflare experienced a 3-hour outage for some domains due to expired DNSSEC signatures that went undetected.
+**RRSIG signatures have expiration dates.** If signatures expire and aren't refreshed, DNSSEC validation fails and the domain stops resolving for validating resolvers. This is the most common DNSSEC operational failure. Notable real-world examples include the 2010 NASA.gov expiry and Slack's 2021 DNSSEC outage, both of which broke resolution for validating clients until signatures were refreshed.
 
 ### DS
 
@@ -186,7 +186,7 @@ dig DS example.com +short
 ```
 
 ```
-31406 13 2 abc123def456789...
+31406 13 2 abc123def456789012345678901234567890123456789012345678901234
 ```
 
 The fields are: key tag, algorithm, digest type (2 = SHA-256), and the digest.

--- a/DNS Administration/nsd-and-unbound.md
+++ b/DNS Administration/nsd-and-unbound.md
@@ -342,7 +342,7 @@ solution: |
   zone:
       name: "example.com"
       zonefile: "example.com.zone"
-      request-xfr: AXFR 192.168.1.10 transfer-key
+      request-xfr: 192.168.1.10 transfer-key
       allow-notify: 192.168.1.10 NOKEY
   ```
 

--- a/DNS Administration/powerdns.md
+++ b/DNS Administration/powerdns.md
@@ -115,9 +115,8 @@ gmysql-dnssec=yes
 local-address=0.0.0.0, ::
 local-port=53
 
-# General
-daemon=yes
-guardian=yes
+# General (run in foreground under systemd; `daemon=yes` and `guardian=yes`
+# were removed in PowerDNS Authoritative 4.5+ and break under modern systemd units)
 setuid=pdns
 setgid=pdns
 ```
@@ -232,7 +231,7 @@ steps:
     output: "New rrset:\nexample.com. 3600 IN MX 10 mail.example.com."
     narration: "Add an MX record. The content includes the priority (10) and mail server. Note the trailing dot on the hostname."
   - command: "pdnsutil check-zone example.com"
-    output: "Checked 4 records of 'example.com', 0 errors, 0 warnings."
+    output: "Checked 5 records of 'example.com', 0 errors, 0 warnings."
     narration: "Always check your zone after changes. This validates record syntax, CNAME conflicts, missing glue records, and other common mistakes."
 ```
 

--- a/DNS Administration/zone-files-and-records.md
+++ b/DNS Administration/zone-files-and-records.md
@@ -303,7 +303,9 @@ NS records at the zone apex tell resolvers where to find authoritative data. NS 
 dev         IN  NS  ns1.dev.example.com.
 dev         IN  NS  ns2.dev.example.com.
 
-; Glue records (needed because the NS names are within the delegated zone)
+; In-bailiwick glue: A records for the delegated nameservers must
+; appear in this parent zone because resolvers cannot look up
+; ns1.dev.example.com without first knowing where dev.example.com lives.
 ns1.dev     IN  A   203.0.113.10
 ns2.dev     IN  A   203.0.113.11
 ```
@@ -537,7 +539,7 @@ annotations:
   - line: 17
     text: "A record at @ points the bare domain (example.com) to an IP. This is the record browsers use when you visit example.com without www."
   - line: 18
-    text: "Glue records: ns1 and ns2 need A records here because they're within the zone they serve. Without these, there's a chicken-and-egg problem."
+    text: "In-zone A records for the authoritative nameservers. (True 'glue' records sit in the parent zone for in-bailiwick names; the records here keep the zone self-consistent.)"
   - line: 21
     text: "CNAME for www pointing to @ (the zone apex). This means www.example.com resolves to wherever example.com points."
 ```


### PR DESCRIPTION
## Summary

Triaged top-3-to-5 findings from a content-reviewer agent pass over each of the 8 DNS guides and fixed the high-confidence factual issues. See the commit body for the full list. Highlights:

- BIND 9.16 (EOL March 2024) bumped to 9.18 in the rndc demo.
- Root KSK ceremony sites corrected (El Segundo CA / Culpeper VA).
- Unverified "Oct 2023 Cloudflare" DNSSEC outage replaced with documented incidents.
- `.com` DNSKEY algorithm corrected from 13 to 8 in the drill -S trust tree.
- `daemon=yes` / `guardian=yes` removed from PowerDNS example (broken on 4.5+ under systemd).
- "Glue records" terminology tightened in zone-files-and-records.

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `pytest tests/` green (43 passed)