### PR TITLE
docs(python): factual fixes across the Dev Zero / Python topic

### DIFF
--- a/Dev Zero/Python/data-structures-and-logic.md
+++ b/Dev Zero/Python/data-structures-and-logic.md
@@ -118,7 +118,7 @@ all_servers = [s for group in groups for s in group]
 
 ## Dictionaries
 
-A [**dictionary**](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) maps keys to values. Keys must be unique and immutable (strings, numbers, tuples). Dictionaries are Python's answer to hash maps, associative arrays, and lookup tables.
+A [**dictionary**](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) maps keys to values. Keys must be unique and hashable (strings, numbers, tuples of hashable values). Dictionaries are Python's answer to hash maps, associative arrays, and lookup tables.
 
 ```python
 # Server configuration
@@ -274,7 +274,7 @@ steps:
     narration: "Counter takes any iterable and tallies occurrences. most_common(n) returns the top n elements as (value, count) tuples, sorted by frequency."
   - command: "python3 -c \"allowed = {'10.0.0.1', '10.0.0.2', '10.0.0.3'}; active = {'10.0.0.2', '10.0.0.4', '10.0.0.5'}; print('Authorized:', allowed & active); print('Unauthorized:', active - allowed)\""
     output: "Authorized: {'10.0.0.2'}\nUnauthorized: {'10.0.0.4', '10.0.0.5'}"
-    narration: "Set intersection (&) finds IPs that appear in both sets. Set difference (-) finds IPs in active that are not in allowed. These operations run in O(min(len(a), len(b))) time."
+    narration: "Set intersection (&) finds IPs that appear in both sets and runs in O(min(len(a), len(b))). Set difference (-) finds IPs in active that are not in allowed and runs in O(len(a)). Both rely on average O(1) hash lookups."
   - command: "python3 -c \"config = {'hostname': 'app01', 'port': 8080}; print(config.get('port')); print(config.get('timeout', 30)); print(config.get('debug'))\""
     output: "8080\n30\nNone"
     narration: "dict.get() returns the value for a key if it exists. With a second argument, it returns that default instead of None. This avoids KeyError exceptions when accessing optional configuration keys."

--- a/Dev Zero/Python/files-and-apis.md
+++ b/Dev Zero/Python/files-and-apis.md
@@ -230,7 +230,7 @@ response = requests.post(
     json=alert                      # Automatically serializes and sets Content-Type
 )
 
-if response.ok:                     # True for any 2xx status
+if response.ok:                     # True for any status code below 400
     print("Alert sent successfully.")
 ```
 

--- a/Dev Zero/Python/functions-and-modules.md
+++ b/Dev Zero/Python/functions-and-modules.md
@@ -538,7 +538,7 @@ The first entry is typically the directory containing the script being run (or a
 
 ### Circular Imports
 
-A circular import happens when module A imports module B, and module B imports module A. Python does not raise an error immediately - it returns the partially initialized module from `sys.modules` - but you may get `ImportError` or `AttributeError` if you try to use a name that has not been defined yet.
+A circular import happens when module A imports module B, and module B imports module A. Python keeps the partially initialized module in `sys.modules`, so a plain `import X` inside the cycle succeeds with a half-built module object. The trouble shows up with `from X import name`: if `name` has not yet been bound, Python raises `ImportError`. Attribute access on the partial module later in execution can also raise `AttributeError`.
 
 ```python
 # models.py

--- a/Dev Zero/Python/object-oriented-programming.md
+++ b/Dev Zero/Python/object-oriented-programming.md
@@ -903,7 +903,7 @@ hints:
     - "Frozen dataclasses raise FrozenInstanceError on attribute assignment - use this to verify immutability."
 solution: |
     import os
-    from dataclasses import dataclass
+    from dataclasses import dataclass, FrozenInstanceError
     from typing import Protocol
 
 
@@ -955,7 +955,7 @@ solution: |
 
     try:
         settings.port = 9999
-    except AttributeError as e:
+    except FrozenInstanceError as e:
         print(f"Immutable: {e}")
 ```
 

--- a/Dev Zero/Python/system-automation.md
+++ b/Dev Zero/Python/system-automation.md
@@ -395,13 +395,14 @@ def check_service(name):
     )
     return result.stdout.strip() == "active"
 
-def check_port(host, port):
+def check_port(host, port, timeout=3):
     """Check if a TCP port is reachable."""
-    result = subprocess.run(
-        ["timeout", "3", "bash", "-c", f"echo > /dev/tcp/{host}/{port}"],
-        capture_output=True
-    )
-    return result.returncode == 0
+    import socket
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
 
 def main():
     parser = argparse.ArgumentParser(description="Service health checker")

--- a/Dev Zero/Python/testing-and-tooling.md
+++ b/Dev Zero/Python/testing-and-tooling.md
@@ -481,7 +481,7 @@ scenario: |
   4. Includes at least 5 test cases covering normal, warning, critical, error, and edge cases (exactly 80%)
   5. Verifies both the status string and exit code for each case
 hints:
-  - "Mock shutil.disk_usage to return a named tuple: MagicMock(total=100, used=X, free=100-X)"
+  - "Mock shutil.disk_usage with a MagicMock(total=100, used=X, free=100-X). The real function returns a named tuple, but a MagicMock with matching attributes is enough for attribute-access call sites."
   - "Use @pytest.mark.parametrize('used,expected_status,expected_code', [...]) for multiple thresholds"
   - "For the error case, make the mock raise OSError"
   - "Edge case: 80% exactly should trigger WARNING (test boundary conditions)"


### PR DESCRIPTION
## Summary

Triaged top-3 findings from a content-reviewer pass over the 7 Python guides and fixed the high-confidence factual issues. See commit body for the full list. Highlights:

- Dict-key requirement corrected to "hashable" (was "immutable").
- Set-difference complexity corrected: O(len(a)), not O(min(...)).
- Circular-import explanation split into the `import X` vs `from X import name` cases.
- FrozenInstanceError (not AttributeError) caught in the dataclass exercise solution.
- response.ok corrected to "< 400" (was "2xx").
- Bash-only `/dev/tcp` port check replaced with `socket.create_connection()`.

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `pytest tests/` green