### PR TITLE
docs(databases): factual fixes across the Databases topic

### DIFF
--- a/Databases/backup-and-recovery.md
+++ b/Databases/backup-and-recovery.md
@@ -469,11 +469,13 @@ chown -R postgres:postgres /var/lib/postgresql/16/main
 systemctl start postgresql
 ```
 
-PostgreSQL replays archived WAL segments using `restore_command` until it reaches `recovery_target_time`, then pauses. You verify the data and promote to normal operation:
+PostgreSQL replays archived WAL segments using `restore_command` until it reaches `recovery_target_time`, then pauses (because `recovery_target_action = pause` is the default). After verifying the data, promote the cluster out of recovery into normal read-write operation:
 
 ```sql
-SELECT pg_wal_replay_resume();
+SELECT pg_promote();
 ```
+
+`pg_wal_replay_resume()` only un-pauses replay during recovery; it does not exit recovery. Use it if you set an earlier target than intended and want to resume replaying through more WAL before promoting.
 
 ```terminal
 title: Point-in-Time Recovery with MySQL Binary Logs

--- a/Databases/database-security.md
+++ b/Databases/database-security.md
@@ -681,7 +681,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 ```
 
 !!! tip "ALTER DEFAULT PRIVILEGES matters"
-    `GRANT SELECT ON ALL TABLES` only applies to tables that exist right now. When new tables are created later, the role will not have access. `ALTER DEFAULT PRIVILEGES` sets the permissions that future tables inherit automatically.
+    `GRANT SELECT ON ALL TABLES` only applies to tables that exist right now. When new tables are created later, the role will not have access. `ALTER DEFAULT PRIVILEGES` sets the permissions that future tables inherit automatically. The defaults only apply to tables created by the role that ran the `ALTER` statement; if migrations run as a different role, add `FOR ROLE migrator` (or include each creator role explicitly) so all future tables are covered.
 
 ### Avoiding GRANT ALL
 

--- a/Databases/innodb-recovery-pdrt.md
+++ b/Databases/innodb-recovery-pdrt.md
@@ -39,7 +39,7 @@ The **system tablespace** (`ibdata1`) is InnoDB's central file. It always exists
 - The **data dictionary** - metadata about every InnoDB table, index, and column
 - The **doublewrite buffer** - a crash-recovery mechanism that prevents partial page writes
 - The **change buffer** - cached changes to secondary indexes
-- **Undo logs** - records needed to roll back uncommitted transactions
+- **Undo logs** - records needed to roll back uncommitted transactions (these moved to separate `undo_NNN` undo tablespaces by default in MySQL 8.0; older MySQL versions kept them inside `ibdata1`)
 
 When `innodb_file_per_table` is disabled (the pre-MySQL 5.6 default), `ibdata1` also stores all table data and indexes. This makes it the single target for recovery - but also means it grows indefinitely and cannot be shrunk without rebuilding.
 
@@ -54,7 +54,7 @@ This per-table layout simplifies some recovery scenarios because each table's da
 
 ### InnoDB Log Files: `ib_logfile*`
 
-The **redo logs** (`ib_logfile0`, `ib_logfile1`) record every change before it reaches the data files. InnoDB replays these logs after a crash to bring the data files up to date. Deleting these files without understanding the server's state can cause permanent data loss if uncommitted transactions needed for recovery are still in the logs.
+The **redo logs** (historically `ib_logfile0`, `ib_logfile1`; redesigned in MySQL 8.0.30 to live under `#innodb_redo/` with a dynamically managed pool of files sized by `innodb_redo_log_capacity`) record every change before it reaches the data files. InnoDB replays these logs after a crash to bring the data files up to date. Deleting these files without understanding the server's state can cause permanent data loss if uncommitted transactions needed for recovery are still in the logs.
 
 ```quiz
 question: "What is the relationship between ibdata1 and .ibd files in InnoDB?"
@@ -82,14 +82,13 @@ PDRT includes three core utilities. If you are in an active data-loss scenario, 
 The primary recovery tool. It scans raw InnoDB data files (either `ibdata1` or individual `.ibd` files) and extracts rows that match a defined table structure.
 
 ```bash
-constraints_parser -4|-5|-6 [-dDV] -f <InnoDB page or dir> [-T N:M] [-b <external pages dir>]
+constraints_parser -4|-5 [-dDV] -f <InnoDB page or dir> [-T N:M] [-b <external pages dir>]
 ```
 
 | Flag | Purpose |
 |------|---------|
 | `-4` | REDUNDANT row format (MySQL 4.x) |
-| `-5` | COMPACT row format (MySQL 5.0+) |
-| `-6` | MySQL 5.6+ format |
+| `-5` | COMPACT row format (MySQL 5.0+, including 5.6/5.7/8.0 tables created with `ROW_FORMAT=COMPACT`) |
 | `-f` | Path to the InnoDB data file or directory of pages |
 | `-d` | Process only pages that may contain deleted records |
 | `-D` | Recover deleted rows only |
@@ -252,8 +251,9 @@ mysql -V
 | Version | Format Flag |
 |---------|-------------|
 | MySQL 4.x (REDUNDANT format) | `-4` |
-| MySQL 5.0 - 5.5 (COMPACT format) | `-5` |
-| MySQL 5.6+ / MariaDB 10.x+ | `-6` |
+| MySQL 5.0+ (COMPACT format) | `-5` |
+
+PDRT predates the BARRACUDA / DYNAMIC / COMPRESSED row formats introduced in MySQL 5.6. Tables created with `ROW_FORMAT=DYNAMIC` (the default since 5.7.9) cannot be recovered with PDRT directly; the table must have been created with `ROW_FORMAT=COMPACT` for `-5` to work, or you must migrate the data through a different recovery path.
 
 ---
 

--- a/Databases/mysql-replication.md
+++ b/Databases/mysql-replication.md
@@ -117,7 +117,7 @@ CHANGE REPLICATION SOURCE TO
 START REPLICA;
 ```
 
-The `SOURCE_LOG_FILE` and `SOURCE_LOG_POS` values come from `SHOW MASTER STATUS` on the source (or from a backup's metadata). Getting these wrong means the replica starts reading from the wrong position - it will either skip transactions or try to replay events that have already been applied.
+The `SOURCE_LOG_FILE` and `SOURCE_LOG_POS` values come from `SHOW BINARY LOG STATUS` on the source (also available as the deprecated alias `SHOW MASTER STATUS`, which was removed in MySQL 8.4) or from a backup's metadata. Getting these wrong means the replica starts reading from the wrong position - it will either skip transactions or try to replay events that have already been applied.
 
 !!! warning "File-and-position pitfalls"
     Binary log file names and positions are fragile. They change after log rotation, are specific to a single source, and make it difficult to re-point a replica to a new source after failover. GTID replication (covered next) eliminates these problems.
@@ -377,8 +377,9 @@ enforce-gtid-consistency           = ON
 log-bin                            = mysql-bin
 log-replica-updates                = ON
 binlog-checksum                    = NONE
-relay-log-info-repository          = TABLE
-transaction-write-set-extraction   = XXHASH64
+# relay-log-info-repository and transaction-write-set-extraction were
+# the historical defaults but were deprecated in 8.0.23/8.0.26 and
+# removed in 8.3 - omit them on modern MySQL.
 
 # Group Replication settings
 plugin-load-add                    = group_replication.so

--- a/Databases/postgresql-administration.md
+++ b/Databases/postgresql-administration.md
@@ -497,10 +497,15 @@ Unused indexes waste disk space and slow down writes (every INSERT, UPDATE, and 
 The **background writer** and **checkpointer** flush dirty buffers to disk. This view shows how that work is distributed:
 
 ```sql
+-- PostgreSQL 16 and earlier: all columns live on pg_stat_bgwriter.
+-- PostgreSQL 17+: checkpoint columns moved to pg_stat_checkpointer.
 SELECT
     checkpoints_timed,
     checkpoints_req,
-    buffers_checkpoint,
+    buffers_checkpoint
+FROM pg_stat_checkpointer;  -- on PG 17+; use pg_stat_bgwriter on <=16
+
+SELECT
     buffers_clean,
     buffers_backend,
     buffers_alloc


### PR DESCRIPTION
## Summary
- innodb-recovery-pdrt: drop the non-existent `-6` flag, note PDRT's row-format limitation, and update undo / redo storage claims for MySQL 8.0+.
- mysql-replication: replace deprecated SHOW MASTER STATUS / config options that were removed in MySQL 8.3-8.4.
- postgresql-administration: split pg_stat_bgwriter / pg_stat_checkpointer for PG 17+.
- database-security: ALTER DEFAULT PRIVILEGES caveat about creator-role scope.
- backup-and-recovery: pg_promote() vs pg_wal_replay_resume() (the former exits recovery, the latter just resumes paused replay).

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `pytest tests/` green