### PR TITLE
docs(git): factual fixes across the Git topic

### DIFF
--- a/Git/object-model.md
+++ b/Git/object-model.md
@@ -155,7 +155,7 @@ All objects are stored in `.git/objects/`. Git uses the first two characters of 
 
 Individual objects are called **loose objects**. As a repository grows, Git periodically packs loose objects into **packfiles** (`.pack` with an `.idx` index) for efficiency. Packfiles use delta compression - storing only the differences between similar objects. The [Refs, the Reflog, and the DAG](refs-reflog-dag.md) guide covers packfiles in depth.
 
-Each loose object is stored as: `type size\0content`, compressed with zlib.
+Each loose object is stored as: `<type> <size>\0<content>` (a type word, a single space, the content size in bytes, a NUL byte, then the raw content), compressed with zlib.
 
 ---
 

--- a/Git/rewriting-history.md
+++ b/Git/rewriting-history.md
@@ -224,8 +224,11 @@ git cherry-pick a1b2c3d
 # Cherry-pick without committing (stage the changes instead)
 git cherry-pick --no-commit a1b2c3d
 
-# Cherry-pick a range of commits
+# Cherry-pick a range of commits (start is exclusive)
 git cherry-pick a1b2c3d..d4e5f6a
+
+# Same range, but include a1b2c3d itself
+git cherry-pick a1b2c3d^..d4e5f6a
 ```
 
 Cherry-pick is useful when you need a specific fix from another branch but don't want to merge the entire branch. But use it sparingly - duplicated commits (same changes, different hashes) can cause confusion when the branches are eventually merged.
@@ -493,7 +496,7 @@ solution: |
   echo "auth v1" > auth.py && git add auth.py && git commit -m "WIP: start auth module"
   echo "login" > auth.py && git add auth.py && git commit -m "Add login endpoint"
   echo "logn" > auth.py && git add auth.py && git commit -m "fix typo"
-  echo "login\nlogout" > auth.py && git add auth.py && git commit -m "Add logout endpoint"
+  printf 'login\nlogout\n' > auth.py && git add auth.py && git commit -m "Add logout endpoint"
   echo "test" > test_auth.py && git add test_auth.py && git commit -m "forgot to add test file"
   echo "tests complete" > test_auth.py && git add test_auth.py && git commit -m "Add auth tests"
 

--- a/Git/security.md
+++ b/Git/security.md
@@ -333,13 +333,13 @@ repos:
 brew install gitleaks  # macOS
 
 # Scan the current repo
-gitleaks detect
+gitleaks git
 
 # Scan with verbose output
-gitleaks detect -v
+gitleaks git -v
 
 # Scan specific commits
-gitleaks detect --log-opts="HEAD~10..HEAD"
+gitleaks git --log-opts="HEAD~10..HEAD"
 ```
 
 [**TruffleHog**](https://github.com/trufflesecurity/trufflehog) performs deep scanning including entropy analysis:


### PR DESCRIPTION
## Summary
- object-model: spell out the loose-object header byte layout (the previous `type size\0content` reads as if type and size run together).
- rewriting-history: note cherry-pick range exclusivity; switch the `echo "login\nlogout"` exercise step to `printf` so it actually writes two lines.
- security: switch gitleaks `detect` to `git` (the canonical command in Gitleaks 8.19+).

Found a pre-existing systemic issue while reviewing: several `command-builder` blocks across the repo (Git/transfer-protocols, Git/monorepos-and-scaling, Databases/sql-essentials, Databases/mysql-administration) use a `groups:` schema the JS renderer ignores. Out of scope for this PR; flagging for a separate cross-topic fix.

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `pytest tests/` green