### PR TITLE
docs(linux): factual fixes across the Linux Essentials topic

### DIFF
--- a/Linux Essentials/file-permissions.md
+++ b/Linux Essentials/file-permissions.md
@@ -207,7 +207,7 @@ chgrp -R developers dir/         # recursive
 
 Only root can change a file's owner. Regular users can change the group to any group they belong to.
 
-The reason only root can change file ownership is to prevent two abuses. First, **quota bypass**: if users could give their files to other users, they could evade disk quotas by assigning large files to someone else's account. Second, **setuid abuse**: if a user could create a program, set the setuid bit, then change ownership to root, they'd have a root-owned setuid binary - an instant privilege escalation. Restricting `chown` to root prevents both scenarios.
+The reason only root can change file ownership is to prevent two abuses. First, **quota bypass**: if users could give their files to other users, they could evade disk quotas by assigning large files to someone else's account. Second, **accountability and audit integrity**: if any user could hand a file off to another user, file ownership would no longer be a reliable signal in audit logs or forensic investigations. (The kernel separately strips setuid/setgid bits on `chown`, so chown-to-root is not itself a privilege-escalation path.) Restricting `chown` to root preserves both guarantees.
 
 ```quiz
 question: "Why can't regular users use chown to change a file's owner?"

--- a/Linux Essentials/ssh-configuration.md
+++ b/Linux Essentials/ssh-configuration.md
@@ -91,9 +91,9 @@ type: multiple-choice
 options:
   - text: "RSA with 4096 bits - Ed25519 may not be supported on older systems"
     correct: true
-    feedback: "Correct. RHEL 7 ships with OpenSSH 7.4, which supports Ed25519, but some organizations run even older patch levels or have FIPS mode enabled (which disables Ed25519). RSA 4096 is the safest bet for broad compatibility."
+    feedback: "Correct. RHEL 7 ships with OpenSSH 7.4, which supports Ed25519, but legacy infrastructure may still hand you a system running an even older OpenSSH where Ed25519 isn't recognized. RSA 4096 is the safest bet for broad compatibility. (Ed25519 was added to FIPS 186-5 in 2023 and is permitted by FIPS-validated OpenSSH on RHEL 9+, so the older 'FIPS disables Ed25519' rationale is no longer accurate.)"
   - text: "Ed25519 - it's always the right choice"
-    feedback: "Ed25519 is the best default, but older systems or FIPS-mode environments may not support it. RSA 4096 is the safe fallback."
+    feedback: "Ed25519 is the best default, but older OpenSSH versions on legacy systems may not recognize it. RSA 4096 is the safe fallback when targeting unknown legacy infrastructure."
   - text: "DSA - it's the most widely supported"
     feedback: "DSA keys are limited to 1024 bits and are considered insecure. OpenSSH 7.0+ disabled DSA by default."
   - text: "ECDSA 521 - larger key means more security"
@@ -402,8 +402,9 @@ ClientAliveCountMax 2
 MaxSessions 10
 X11Forwarding no
 
-# Security
-Protocol 2
+# Security (the legacy `Protocol 2` directive was removed in OpenSSH 7.6;
+# SSHv1 is gone, so the directive is no longer needed and modern sshd
+# emits a warning if it appears.)
 PermitUserEnvironment no
 Banner /etc/ssh/banner
 ```
@@ -411,7 +412,10 @@ Banner /etc/ssh/banner
 After editing, validate the config and restart:
 
 ```bash
-# Check for syntax errors without restarting
+# Check the config for syntax errors (does not start the daemon)
+sudo sshd -t
+
+# Or print the effective configuration after parsing
 sudo sshd -T
 
 # Restart sshd to apply changes

--- a/Linux Essentials/system-services.md
+++ b/Linux Essentials/system-services.md
@@ -719,7 +719,7 @@ scenario: |
 hints:
   - "Service units go in /etc/systemd/system/ with a .service extension"
   - "Use Type=oneshot for scripts that run and exit rather than long-running daemons"
-  - "After=network-online.target ensures the network is fully up, not just that the network stack loaded"
+  - "After=network-online.target orders the unit relative to the target, but does not pull it in. Add Wants=network-online.target so systemd actually starts the target before this service."
   - "Timer files must have the same base name as the service they trigger"
   - "Use systemctl list-timers to verify your timer is scheduled"
 solution: |


### PR DESCRIPTION
## Summary
- ssh-configuration: drop the obsolete `Protocol 2` directive, fix the `sshd -t` vs `-T` flag explanation, and update the FIPS/Ed25519 rationale (FIPS 186-5 added Ed25519 in 2023).
- file-permissions: replace the incorrect "chown-to-root setuid escalation" reasoning with the real reason (accountability/audit integrity); the kernel already strips setuid/setgid on `chown`.
- system-services: clarify that `After=network-online.target` orders without activating; the corresponding hint now mentions `Wants=`.

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `pytest tests/` green