### PR TITLE
docs: convert command-builder blocks to the supported flat options schema

### DIFF
--- a/Databases/mysql-administration.md
+++ b/Databases/mysql-administration.md
@@ -101,55 +101,32 @@ nopager
     `pager less -S` combined with `\G` output gives you a scrollable, searchable view of wide result sets. This is the fastest way to browse `SHOW ENGINE INNODB STATUS` output.
 
 ```command-builder
-title: MySQL CLI Connection Builder
-base: "mysql"
-groups:
-  - name: "Connection"
-    flags:
-      - flag: "-u"
-        description: "Username"
-        options:
-          - value: "root"
-            label: "root"
-          - value: "app_user"
-            label: "Application user"
-      - flag: "-h"
-        description: "Host"
-        options:
-          - value: "localhost"
-            label: "Local"
-          - value: "db.example.com"
-            label: "Remote"
-      - flag: "-P"
-        description: "Port"
-        options:
-          - value: "3306"
-            label: "Default (3306)"
-          - value: "3307"
-            label: "Custom (3307)"
-  - name: "Authentication"
-    flags:
-      - flag: "-p"
-        description: "Prompt for password"
-        options:
-          - value: ""
-            label: "Prompt at connect"
-  - name: "Target"
-    flags:
-      - flag: "-D"
-        description: "Database"
-        options:
-          - value: "myapp"
-            label: "myapp"
-          - value: "mysql"
-            label: "mysql (system)"
-      - flag: "-e"
-        description: "Execute query and exit"
-        options:
-          - value: "\"SHOW DATABASES\""
-            label: "List databases"
-          - value: "\"SHOW PROCESSLIST\""
-            label: "Show connections"
+base: mysql
+options:
+- flag: ''
+  type: select
+  label: Connection
+  choices:
+  - - -u
+    - Username
+  - - -h
+    - Host
+  - - -P
+    - Port
+- flag: ''
+  type: select
+  label: Authentication
+  choices:
+  - - -p
+    - Prompt for password
+- flag: ''
+  type: select
+  label: Target
+  choices:
+  - - -D
+    - Database
+  - - -e
+    - Execute query and exit
 ```
 
 ```quiz

--- a/Databases/postgresql-administration.md
+++ b/Databases/postgresql-administration.md
@@ -696,38 +696,43 @@ SELECT * FROM products WHERE name ILIKE '%postgres%';
     Use `pg_trgm` for fuzzy matching on short strings (names, titles) and PostgreSQL's built-in full-text search (`tsvector`/`tsquery`) for document-length content. They complement each other well - trigrams catch typos and abbreviations that full-text search misses.
 
 ```command-builder
-title: "PostgreSQL Admin Command Builder"
-description: "Build common psql administration commands for database maintenance and monitoring."
-base: "psql"
-groups:
-  - name: "Connection"
-    options:
-      - flag: "-U postgres"
-        description: "Connect as the postgres superuser"
-      - flag: "-d myapp"
-        description: "Connect to the myapp database"
-      - flag: "-h localhost"
-        description: "Connect to localhost (TCP instead of socket)"
-      - flag: "-p 5432"
-        description: "Specify the port number"
-  - name: "Execution Mode"
-    options:
-      - flag: "-c \"VACUUM VERBOSE tablename;\""
-        description: "Run VACUUM with verbose output on a table"
-      - flag: "-c \"ANALYZE tablename;\""
-        description: "Update planner statistics for a table"
-      - flag: "-c \"SELECT * FROM pg_stat_activity WHERE state != 'idle';\""
-        description: "Show active queries"
-      - flag: "-c \"SELECT * FROM pg_stat_user_tables ORDER BY n_dead_tup DESC LIMIT 10;\""
-        description: "Show tables with most dead tuples"
-  - name: "Output Format"
-    options:
-      - flag: "-x"
-        description: "Expanded (vertical) output for wide rows"
-      - flag: "--csv"
-        description: "CSV output for scripting"
-      - flag: "-t"
-        description: "Tuples only (no headers or footers)"
+base: psql
+description: Build common psql administration commands for database maintenance and monitoring.
+options:
+- flag: ''
+  type: select
+  label: Connection
+  choices:
+  - - -U postgres
+    - Connect as the postgres superuser
+  - - -d myapp
+    - Connect to the myapp database
+  - - -h localhost
+    - Connect to localhost (TCP instead of socket)
+  - - -p 5432
+    - Specify the port number
+- flag: ''
+  type: select
+  label: Execution Mode
+  choices:
+  - - -c "VACUUM VERBOSE tablename;"
+    - Run VACUUM with verbose output on a table
+  - - -c "ANALYZE tablename;"
+    - Update planner statistics for a table
+  - - -c "SELECT * FROM pg_stat_activity WHERE state != 'idle';"
+    - Show active queries
+  - - -c "SELECT * FROM pg_stat_user_tables ORDER BY n_dead_tup DESC LIMIT 10;"
+    - Show tables with most dead tuples
+- flag: ''
+  type: select
+  label: Output Format
+  choices:
+  - - -x
+    - Expanded (vertical) output for wide rows
+  - - --csv
+    - CSV output for scripting
+  - - -t
+    - Tuples only (no headers or footers)
 ```
 
 ---

--- a/Databases/redis.md
+++ b/Databases/redis.md
@@ -742,48 +742,53 @@ SLOWLOG GET 10
     `KEYS` blocks the server while it iterates every key in the database. On a production instance with millions of keys, this can freeze Redis for seconds. Always use `SCAN` with a cursor instead - it returns results incrementally without blocking.
 
 ```command-builder
-title: "redis-cli Command Builder"
-description: "Build a redis-cli command for connecting and running diagnostics."
-base: "redis-cli"
-groups:
-  - name: "Connection"
-    options:
-      - flag: "-h <hostname>"
-        description: "Server hostname (default: 127.0.0.1)"
-      - flag: "-p <port>"
-        description: "Server port (default: 6379)"
-      - flag: "-a <password>"
-        description: "Authentication password"
-      - flag: "-n <db>"
-        description: "Database number (0-15)"
-      - flag: "-c"
-        description: "Cluster mode (follow MOVED/ASK redirects)"
-      - flag: "--tls"
-        description: "Enable TLS/SSL connection"
-  - name: "Diagnostics"
-    options:
-      - flag: "--stat"
-        description: "Live stats: ops/sec, memory, connected clients"
-      - flag: "--latency"
-        description: "Continuous latency measurement"
-      - flag: "--latency-history"
-        description: "Latency samples over time (default 15s intervals)"
-      - flag: "--bigkeys"
-        description: "Scan for largest keys by type"
-      - flag: "--memkeys"
-        description: "Scan for keys using the most memory"
-  - name: "Commands"
-    options:
-      - flag: "INFO"
-        description: "Server information and statistics"
-      - flag: "INFO memory"
-        description: "Memory usage breakdown"
-      - flag: "MONITOR"
-        description: "Real-time stream of all commands processed"
-      - flag: "SLOWLOG GET 10"
-        description: "Show 10 slowest recent queries"
-      - flag: "DBSIZE"
-        description: "Count of keys in the current database"
+base: redis-cli
+description: Build a redis-cli command for connecting and running diagnostics.
+options:
+- flag: ''
+  type: select
+  label: Connection
+  choices:
+  - - -h <hostname>
+    - 'Server hostname (default: 127.0.0.1)'
+  - - -p <port>
+    - 'Server port (default: 6379)'
+  - - -a <password>
+    - Authentication password
+  - - -n <db>
+    - Database number (0-15)
+  - - -c
+    - Cluster mode (follow MOVED/ASK redirects)
+  - - --tls
+    - Enable TLS/SSL connection
+- flag: ''
+  type: select
+  label: Diagnostics
+  choices:
+  - - --stat
+    - 'Live stats: ops/sec, memory, connected clients'
+  - - --latency
+    - Continuous latency measurement
+  - - --latency-history
+    - Latency samples over time (default 15s intervals)
+  - - --bigkeys
+    - Scan for largest keys by type
+  - - --memkeys
+    - Scan for keys using the most memory
+- flag: ''
+  type: select
+  label: Commands
+  choices:
+  - - INFO
+    - Server information and statistics
+  - - INFO memory
+    - Memory usage breakdown
+  - - MONITOR
+    - Real-time stream of all commands processed
+  - - SLOWLOG GET 10
+    - Show 10 slowest recent queries
+  - - DBSIZE
+    - Count of keys in the current database
 ```
 
 ---

--- a/Databases/sql-essentials.md
+++ b/Databases/sql-essentials.md
@@ -848,56 +848,67 @@ SELECT * FROM employees WHERE manager_id IS NULL;
 Build a `SELECT` statement by combining clauses. Each group represents a part of the query you can customize.
 
 ```command-builder
-title: "SELECT Statement Builder"
-description: "Construct a SELECT query by choosing columns, filtering, grouping, and sorting options."
-base: "SELECT"
-groups:
-  - name: "Columns"
-    flags:
-      - flag: " *"
-        description: "All columns"
-      - flag: " id, name, price"
-        description: "Specific columns"
-      - flag: " department, COUNT(*) AS count"
-        description: "Aggregation with alias"
-      - flag: " DISTINCT category"
-        description: "Unique values only"
-  - name: "Source"
-    flags:
-      - flag: " FROM products"
-        description: "Single table"
-      - flag: " FROM orders o JOIN customers c ON o.customer_id = c.id"
-        description: "Joined tables"
-  - name: "Filter"
-    flags:
-      - flag: " WHERE price > 50"
-        description: "Comparison filter"
-      - flag: " WHERE category IN ('Electronics', 'Books')"
-        description: "IN list filter"
-      - flag: " WHERE name LIKE '%widget%'"
-        description: "Pattern matching"
-      - flag: " WHERE created_at BETWEEN '2025-01-01' AND '2025-12-31'"
-        description: "Date range filter"
-  - name: "Grouping"
-    flags:
-      - flag: " GROUP BY department"
-        description: "Group results"
-      - flag: " GROUP BY department HAVING COUNT(*) > 3"
-        description: "Group with minimum count"
-  - name: "Ordering"
-    flags:
-      - flag: " ORDER BY price ASC"
-        description: "Sort ascending"
-      - flag: " ORDER BY price DESC"
-        description: "Sort descending"
-      - flag: " ORDER BY department, name"
-        description: "Sort by multiple columns"
-  - name: "Limit"
-    flags:
-      - flag: " LIMIT 10"
-        description: "First 10 rows"
-      - flag: " LIMIT 10 OFFSET 20"
-        description: "Rows 21-30 (pagination)"
+base: SELECT
+description: Construct a SELECT query by choosing columns, filtering, grouping, and sorting options.
+options:
+- flag: ''
+  type: select
+  label: Columns
+  choices:
+  - - ' *'
+    - All columns
+  - - ' id, name, price'
+    - Specific columns
+  - - ' department, COUNT(*) AS count'
+    - Aggregation with alias
+  - - ' DISTINCT category'
+    - Unique values only
+- flag: ''
+  type: select
+  label: Source
+  choices:
+  - - ' FROM products'
+    - Single table
+  - - ' FROM orders o JOIN customers c ON o.customer_id = c.id'
+    - Joined tables
+- flag: ''
+  type: select
+  label: Filter
+  choices:
+  - - ' WHERE price > 50'
+    - Comparison filter
+  - - ' WHERE category IN (''Electronics'', ''Books'')'
+    - IN list filter
+  - - ' WHERE name LIKE ''%widget%'''
+    - Pattern matching
+  - - ' WHERE created_at BETWEEN ''2025-01-01'' AND ''2025-12-31'''
+    - Date range filter
+- flag: ''
+  type: select
+  label: Grouping
+  choices:
+  - - ' GROUP BY department'
+    - Group results
+  - - ' GROUP BY department HAVING COUNT(*) > 3'
+    - Group with minimum count
+- flag: ''
+  type: select
+  label: Ordering
+  choices:
+  - - ' ORDER BY price ASC'
+    - Sort ascending
+  - - ' ORDER BY price DESC'
+    - Sort descending
+  - - ' ORDER BY department, name'
+    - Sort by multiple columns
+- flag: ''
+  type: select
+  label: Limit
+  choices:
+  - - ' LIMIT 10'
+    - First 10 rows
+  - - ' LIMIT 10 OFFSET 20'
+    - Rows 21-30 (pagination)
 ```
 
 ---

--- a/Git/commits-and-history.md
+++ b/Git/commits-and-history.md
@@ -332,42 +332,47 @@ steps:
 ```
 
 ```command-builder
-title: "git log Command Builder"
-description: "Build a git log command with formatting and filtering options."
-base: "git log"
-groups:
-  - name: "Display Format"
-    options:
-      - flag: "--oneline"
-        description: "Compact one-line format (short hash + subject)"
-      - flag: "--graph"
-        description: "Draw branch/merge graph with ASCII art"
-      - flag: "--all"
-        description: "Show all branches, not just the current one"
-      - flag: "--decorate"
-        description: "Show branch and tag names next to commits"
-      - flag: "--stat"
-        description: "Show file change statistics per commit"
-      - flag: "-p"
-        description: "Show the full diff (patch) for each commit"
-  - name: "Filtering"
-    options:
-      - flag: "-5"
-        description: "Limit to last 5 commits"
-      - flag: "--since='1 week ago'"
-        description: "Only commits from the last week"
-      - flag: "--author='name'"
-        description: "Filter by author name (partial match)"
-      - flag: "--grep='search term'"
-        description: "Search commit messages"
-      - flag: "-S 'string'"
-        description: "Pickaxe: find commits that add/remove a string"
-  - name: "File Scope"
-    options:
-      - flag: "-- path/to/file"
-        description: "Show only commits affecting this file"
-      - flag: "--follow -- path/to/file"
-        description: "Track file through renames"
+base: git log
+description: Build a git log command with formatting and filtering options.
+options:
+- flag: ''
+  type: select
+  label: Display Format
+  choices:
+  - - --oneline
+    - Compact one-line format (short hash + subject)
+  - - --graph
+    - Draw branch/merge graph with ASCII art
+  - - --all
+    - Show all branches, not just the current one
+  - - --decorate
+    - Show branch and tag names next to commits
+  - - --stat
+    - Show file change statistics per commit
+  - - -p
+    - Show the full diff (patch) for each commit
+- flag: ''
+  type: select
+  label: Filtering
+  choices:
+  - - '-5'
+    - Limit to last 5 commits
+  - - --since='1 week ago'
+    - Only commits from the last week
+  - - --author='name'
+    - Filter by author name (partial match)
+  - - --grep='search term'
+    - Search commit messages
+  - - -S 'string'
+    - 'Pickaxe: find commits that add/remove a string'
+- flag: ''
+  type: select
+  label: File Scope
+  choices:
+  - - -- path/to/file
+    - Show only commits affecting this file
+  - - --follow -- path/to/file
+    - Track file through renames
 ```
 
 ---

--- a/Git/configuring-git.md
+++ b/Git/configuring-git.md
@@ -102,40 +102,45 @@ git config --global --edit
 ```
 
 ```command-builder
-title: "git config Command Builder"
-description: "Build a git config command for reading and writing settings."
-base: "git config"
-groups:
-  - name: "Scope"
-    options:
-      - flag: "--global"
-        description: "User-level config (~/.gitconfig)"
-      - flag: "--local"
-        description: "Repository-level config (.git/config)"
-      - flag: "--system"
-        description: "System-wide config (/etc/gitconfig)"
-  - name: "Action"
-    options:
-      - flag: "--list"
-        description: "List all settings at this scope"
-      - flag: "--show-origin"
-        description: "Show which file each setting comes from"
-      - flag: "--get <key>"
-        description: "Read a specific setting"
-      - flag: "--unset <key>"
-        description: "Remove a specific setting"
-      - flag: "--edit"
-        description: "Open the config file in your editor"
-  - name: "Common Settings"
-    options:
-      - flag: "user.name 'Your Name'"
-        description: "Set your name for commits"
-      - flag: "user.email 'you@example.com'"
-        description: "Set your email for commits"
-      - flag: "core.editor 'vim'"
-        description: "Set the default text editor"
-      - flag: "init.defaultBranch main"
-        description: "Set the default branch name for new repos"
+base: git config
+description: Build a git config command for reading and writing settings.
+options:
+- flag: ''
+  type: select
+  label: Scope
+  choices:
+  - - --global
+    - User-level config (~/.gitconfig)
+  - - --local
+    - Repository-level config (.git/config)
+  - - --system
+    - System-wide config (/etc/gitconfig)
+- flag: ''
+  type: select
+  label: Action
+  choices:
+  - - --list
+    - List all settings at this scope
+  - - --show-origin
+    - Show which file each setting comes from
+  - - --get <key>
+    - Read a specific setting
+  - - --unset <key>
+    - Remove a specific setting
+  - - --edit
+    - Open the config file in your editor
+- flag: ''
+  type: select
+  label: Common Settings
+  choices:
+  - - user.name 'Your Name'
+    - Set your name for commits
+  - - user.email 'you@example.com'
+    - Set your email for commits
+  - - core.editor 'vim'
+    - Set the default text editor
+  - - init.defaultBranch main
+    - Set the default branch name for new repos
 ```
 
 ---

--- a/Git/monorepos-and-scaling.md
+++ b/Git/monorepos-and-scaling.md
@@ -352,30 +352,35 @@ Large monorepos need build systems that understand which projects are affected b
 These tools use the Git commit graph to determine which packages changed and only build/test those, making CI feasible for large monorepos.
 
 ```command-builder
-title: "Clone Strategies for Large Repos"
-description: "Build an optimized clone command for a large repository."
-base: "git clone"
-groups:
-  - name: "Object Filtering"
-    options:
-      - flag: "--filter=blob:none"
-        description: "Blobless: skip file content, fetch on demand"
-      - flag: "--filter=blob:limit=1m"
-        description: "Skip blobs larger than 1MB"
-      - flag: "--filter=tree:0"
-        description: "Treeless: skip trees too (ultra minimal)"
-  - name: "Checkout Scope"
-    options:
-      - flag: "--sparse"
-        description: "Only check out root files (use sparse-checkout to add dirs)"
-      - flag: "--no-checkout"
-        description: "Don't check out any files"
-  - name: "History Depth"
-    options:
-      - flag: "--depth 1"
-        description: "Shallow: only latest commit"
-      - flag: "--single-branch"
-        description: "Only the default branch"
+base: git clone
+description: Build an optimized clone command for a large repository.
+options:
+- flag: ''
+  type: select
+  label: Object Filtering
+  choices:
+  - - --filter=blob:none
+    - 'Blobless: skip file content, fetch on demand'
+  - - --filter=blob:limit=1m
+    - Skip blobs larger than 1MB
+  - - --filter=tree:0
+    - 'Treeless: skip trees too (ultra minimal)'
+- flag: ''
+  type: select
+  label: Checkout Scope
+  choices:
+  - - --sparse
+    - Only check out root files (use sparse-checkout to add dirs)
+  - - --no-checkout
+    - Don't check out any files
+- flag: ''
+  type: select
+  label: History Depth
+  choices:
+  - - --depth 1
+    - 'Shallow: only latest commit'
+  - - --single-branch
+    - Only the default branch
 ```
 
 ---

--- a/Git/remote-repositories.md
+++ b/Git/remote-repositories.md
@@ -328,26 +328,27 @@ git remote show origin
 `git remote show origin` displays useful information: the fetch/push URLs, tracked branches, and whether local branches are ahead or behind.
 
 ```command-builder
-title: "git remote Command Builder"
-description: "Build a git remote command for managing remote connections."
-base: "git remote"
-groups:
-  - name: "Subcommand"
-    options:
-      - flag: "-v"
-        description: "List remotes with fetch/push URLs"
-      - flag: "add <name> <url>"
-        description: "Add a new remote with a short name and URL"
-      - flag: "rename <old> <new>"
-        description: "Rename an existing remote"
-      - flag: "remove <name>"
-        description: "Remove a remote and its tracking branches"
-      - flag: "show <name>"
-        description: "Display details about a specific remote"
-      - flag: "set-url <name> <url>"
-        description: "Change the URL for an existing remote"
-      - flag: "prune <name>"
-        description: "Remove stale remote-tracking branches"
+base: git remote
+description: Build a git remote command for managing remote connections.
+options:
+- flag: ''
+  type: select
+  label: Subcommand
+  choices:
+  - - -v
+    - List remotes with fetch/push URLs
+  - - add <name> <url>
+    - Add a new remote with a short name and URL
+  - - rename <old> <new>
+    - Rename an existing remote
+  - - remove <name>
+    - Remove a remote and its tracking branches
+  - - show <name>
+    - Display details about a specific remote
+  - - set-url <name> <url>
+    - Change the URL for an existing remote
+  - - prune <name>
+    - Remove stale remote-tracking branches
 ```
 
 ---

--- a/Git/stashing-and-worktree.md
+++ b/Git/stashing-and-worktree.md
@@ -178,36 +178,39 @@ steps:
 ```
 
 ```command-builder
-title: "git stash Command Builder"
-description: "Build a git stash command for managing work-in-progress."
-base: "git stash"
-groups:
-  - name: "Action"
-    options:
-      - flag: "push"
-        description: "Save changes to a new stash entry (default action)"
-      - flag: "pop"
-        description: "Apply the latest stash and remove it from the stack"
-      - flag: "apply"
-        description: "Apply a stash but keep it in the stack"
-      - flag: "list"
-        description: "List all stash entries"
-      - flag: "show -p"
-        description: "Show the full diff of the latest stash"
-      - flag: "drop"
-        description: "Remove the latest stash from the stack"
-      - flag: "branch <name>"
-        description: "Create a new branch from the stash point and apply"
-  - name: "Options (for push)"
-    options:
-      - flag: "-m 'description'"
-        description: "Add a descriptive message to the stash"
-      - flag: "-u"
-        description: "Include untracked files in the stash"
-      - flag: "-a"
-        description: "Include untracked AND ignored files"
-      - flag: "-p"
-        description: "Interactively select hunks to stash"
+base: git stash
+description: Build a git stash command for managing work-in-progress.
+options:
+- flag: ''
+  type: select
+  label: Action
+  choices:
+  - - push
+    - Save changes to a new stash entry (default action)
+  - - pop
+    - Apply the latest stash and remove it from the stack
+  - - apply
+    - Apply a stash but keep it in the stack
+  - - list
+    - List all stash entries
+  - - show -p
+    - Show the full diff of the latest stash
+  - - drop
+    - Remove the latest stash from the stack
+  - - branch <name>
+    - Create a new branch from the stash point and apply
+- flag: ''
+  type: select
+  label: Options (for push)
+  choices:
+  - - -m 'description'
+    - Add a descriptive message to the stash
+  - - -u
+    - Include untracked files in the stash
+  - - -a
+    - Include untracked AND ignored files
+  - - -p
+    - Interactively select hunks to stash
 ```
 
 ---

--- a/Git/transfer-protocols.md
+++ b/Git/transfer-protocols.md
@@ -259,36 +259,43 @@ options:
 ```
 
 ```command-builder
-title: "Clone Strategies for Large Repositories"
-description: "Build a git clone command optimized for large repositories."
-base: "git clone"
-groups:
-  - name: "History Depth"
-    options:
-      - flag: "--depth 1"
-        description: "Shallow clone: only the most recent commit"
-      - flag: "--depth 10"
-        description: "Shallow clone: last 10 commits"
-  - name: "Partial Clone"
-    options:
-      - flag: "--filter=blob:none"
-        description: "Skip all blobs, download on demand"
-      - flag: "--filter=blob:limit=1m"
-        description: "Skip blobs larger than 1MB"
-      - flag: "--filter=tree:0"
-        description: "Skip trees too (ultra-minimal)"
-  - name: "Branch Scope"
-    options:
-      - flag: "--single-branch"
-        description: "Only download the default branch"
-      - flag: "--single-branch --branch develop"
-        description: "Only download the develop branch"
-  - name: "Checkout"
-    options:
-      - flag: "--sparse"
-        description: "Enable sparse checkout (combine with --filter)"
-      - flag: "--no-checkout"
-        description: "Clone without checking out files"
+base: git clone
+description: Build a git clone command optimized for large repositories.
+options:
+- flag: ''
+  type: select
+  label: History Depth
+  choices:
+  - - --depth 1
+    - 'Shallow clone: only the most recent commit'
+  - - --depth 10
+    - 'Shallow clone: last 10 commits'
+- flag: ''
+  type: select
+  label: Partial Clone
+  choices:
+  - - --filter=blob:none
+    - Skip all blobs, download on demand
+  - - --filter=blob:limit=1m
+    - Skip blobs larger than 1MB
+  - - --filter=tree:0
+    - Skip trees too (ultra-minimal)
+- flag: ''
+  type: select
+  label: Branch Scope
+  choices:
+  - - --single-branch
+    - Only download the default branch
+  - - --single-branch --branch develop
+    - Only download the develop branch
+- flag: ''
+  type: select
+  label: Checkout
+  choices:
+  - - --sparse
+    - Enable sparse checkout (combine with --filter)
+  - - --no-checkout
+    - Clone without checking out files
 ```
 
 ---


### PR DESCRIPTION
## Summary

Ten guides used a `groups: -> name + (options|flags)` command-builder schema that the JS renderer (`assets/javascripts/components/command-builder.js`) does not understand. The renderer only reads the top-level `options:` array, so every `groups:`-style block has been silently rendering as a no-op since it was authored.

This PR converts each block: each former group becomes one `type: select` option whose label is the group name and whose choices are `[flag_value, description]` pairs. Outer `flag: ""` lets the choice value carry the full flag text, matching the project convention documented in CLAUDE.md.

Flagged in #147 as a cross-topic systemic issue; this PR addresses it.

## Files
- `Databases/sql-essentials.md`
- `Databases/mysql-administration.md`
- `Databases/redis.md`
- `Databases/postgresql-administration.md`
- `Git/monorepos-and-scaling.md`
- `Git/commits-and-history.md`
- `Git/transfer-protocols.md`
- `Git/configuring-git.md`
- `Git/stashing-and-worktree.md`
- `Git/remote-repositories.md`

## Test plan
- [x] `mkdocs build --strict` clean
- [x] `pytest tests/` green (43 passed)
- [x] `npx vitest run tests/js/command-builder.test.js` green (9 passed)
- [x] Each converted block re-parsed with PyYAML and validated against the JS schema (`options` array, every option has `label`+`flag`, every `select` has `choices`)