### PR TITLE
Phase 2: interactive coverage + thin guide expansions

### DIFF
--- a/DNS Administration/bind.md
+++ b/DNS Administration/bind.md
@@ -194,7 +194,7 @@ steps:
       boot time: Fri, 21 Feb 2026 10:00:00 GMT
       server is up and running
       number of zones: 6 (3 automatic)
-    narration: "The status confirms BIND is running and shows 6 zones: the 3 automatic zones (localhost, localhost reverse, root hints) plus the 3 from named.rfc1912.zones and our new internal.example.com zone."
+    narration: "The status confirms BIND is running and shows 6 zones total, 3 of which are built-in automatic zones. The remaining 3 include our new internal.example.com zone and zones loaded from named.rfc1912.zones."
 ```
 
 ---

--- a/DNS Administration/dns-fundamentals.md
+++ b/DNS Administration/dns-fundamentals.md
@@ -38,7 +38,7 @@ Paul Mockapetris, inventor of DNS, at a conference in Barcelona.
 </figcaption>
 </figure>
 
-In 1983, Paul Mockapetris at USC's Information Sciences Institute published [RFC 882](https://datatracker.ietf.org/doc/html/rfc882) and [RFC 883](https://datatracker.ietf.org/doc/html/rfc883), proposing a distributed, hierarchical naming system. His first implementation was called "Jeeves." Two years later, he refined the design into [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034) and [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035) - the specifications that still define DNS today.
+In 1983, Paul Mockapetris at USC's Information Sciences Institute published [RFC 882](https://datatracker.ietf.org/doc/html/rfc882) and [RFC 883](https://datatracker.ietf.org/doc/html/rfc883), proposing a distributed, hierarchical naming system. His first implementation was called "Jeeves." Four years later, in 1987, he refined the design into [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034) and [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035) - the specifications that still define DNS today.
 
 ---
 

--- a/DNS Administration/dns-fundamentals.md
+++ b/DNS Administration/dns-fundamentals.md
@@ -423,6 +423,49 @@ options:
     feedback: "It's roughly the opposite. The recursive server follows the chain. In iterative mode, the client receives referrals and must follow them itself."
 ```
 
+```command-builder
+base: dig
+description: Build a dig query to inspect DNS records and resolution behavior
+options:
+  - flag: ""
+    type: text
+    label: "Domain"
+    placeholder: "example.com"
+    explanation: "The domain name to query"
+  - flag: ""
+    type: select
+    label: "Record type"
+    explanation: "The DNS record type to request"
+    choices:
+      - ["A", "A - IPv4 address"]
+      - ["AAAA", "AAAA - IPv6 address"]
+      - ["MX", "MX - mail exchange servers"]
+      - ["NS", "NS - authoritative nameservers"]
+      - ["TXT", "TXT - text records (SPF, DKIM, DMARC)"]
+      - ["SOA", "SOA - start of authority (zone metadata)"]
+      - ["CNAME", "CNAME - canonical name alias"]
+      - ["CAA", "CAA - certificate authority authorization"]
+  - flag: ""
+    type: select
+    label: "Output options"
+    explanation: "Control how much output dig returns"
+    choices:
+      - ["", "Default (full output)"]
+      - ["+short", "+short - answer section only"]
+      - ["+noall +answer", "+noall +answer - clean answer section"]
+      - ["+trace", "+trace - full iterative resolution from root"]
+  - flag: ""
+    type: select
+    label: "Nameserver"
+    explanation: "Query a specific nameserver instead of your system default"
+    choices:
+      - ["", "System default resolver"]
+      - ["@1.1.1.1", "Cloudflare (1.1.1.1)"]
+      - ["@8.8.8.8", "Google (8.8.8.8)"]
+      - ["@9.9.9.9", "Quad9 (9.9.9.9)"]
+      - ["@a.root-servers.net", "Root server (iterative)"]
+```
+
 ---
 
 ## Registrars, Registries, and Glue Records

--- a/Databases/database-fundamentals.md
+++ b/Databases/database-fundamentals.md
@@ -150,6 +150,33 @@ CREATE TABLE employees (
 );
 ```
 
+```code-walkthrough
+title: "Anatomy of a CREATE TABLE Statement"
+description: "How data types, constraints, and column definitions work together to define a table's structure."
+code: |
+  CREATE TABLE employees (
+      employee_id   INT PRIMARY KEY,
+      first_name    VARCHAR(50) NOT NULL,
+      last_name     VARCHAR(50) NOT NULL,
+      department_id INT,
+      hire_date     DATE NOT NULL,
+      salary        DECIMAL(10,2)
+  );
+annotations:
+  - line: 1
+    text: "CREATE TABLE followed by the table name. The name must be unique within the database schema. Parentheses enclose the column definitions."
+  - line: 2
+    text: "employee_id is an INT (integer) with the PRIMARY KEY constraint. This guarantees uniqueness across all rows and implicitly adds a NOT NULL constraint. The database creates an index on this column automatically."
+  - line: 3
+    text: "VARCHAR(50) stores variable-length strings up to 50 characters. NOT NULL means the column must have a value - the database rejects any INSERT that omits it or passes NULL. Use NOT NULL for every required field."
+  - line: 5
+    text: "department_id has no NOT NULL constraint, so it is nullable. A NULL here means this employee isn't assigned to any department yet. This column will become a foreign key - nullable foreign keys allow optional relationships."
+  - line: 6
+    text: "DATE stores a calendar date without a time component (YYYY-MM-DD). For timestamps including time, use DATETIME or TIMESTAMP instead."
+  - line: 7
+    text: "DECIMAL(10,2) stores exact fixed-point numbers: up to 10 total digits with 2 after the decimal point (e.g., 99999999.99). Always use DECIMAL for money - FLOAT and DOUBLE are binary approximations that accumulate rounding errors."
+```
+
 Every column has a **data type** that constrains what values it can hold. `INT` stores integers. `VARCHAR(50)` stores variable-length strings up to 50 characters. `DATE` stores calendar dates. `DECIMAL(10,2)` stores numbers with up to 10 digits and 2 decimal places. Choosing the right data type matters for storage efficiency, query performance, and data integrity.
 
 ### Keys

--- a/Dev Zero/Python/testing-and-tooling.md
+++ b/Dev Zero/Python/testing-and-tooling.md
@@ -419,6 +419,54 @@ steps:
     narration: "ruff checks for style violations, common bugs, and import ordering. A clean result means the code follows Python best practices."
 ```
 
+```command-builder
+base: pytest
+description: Build a pytest command to run and filter your test suite
+options:
+  - flag: ""
+    type: text
+    label: "Test path (optional)"
+    placeholder: "tests/test_utils.py"
+    explanation: "Run a specific file, directory, or test (e.g. tests/test_utils.py::test_format). Leave blank to discover all tests."
+  - flag: ""
+    type: select
+    label: "Verbosity"
+    explanation: "How much detail pytest shows for each test result"
+    choices:
+      - ["", "Default"]
+      - ["-v", "-v (show each test name and result)"]
+      - ["-vv", "-vv (show full assertion details on failure)"]
+  - flag: "-k"
+    type: text
+    label: "Keyword filter"
+    placeholder: "format or parse"
+    explanation: "Run only tests matching this expression. Supports 'and', 'or', 'not' (e.g. 'format and not slow')."
+  - flag: ""
+    type: select
+    label: "On failure"
+    explanation: "What to do when a test fails"
+    choices:
+      - ["", "Default (run all tests)"]
+      - ["-x", "-x (stop on first failure)"]
+      - ["--lf", "--lf (rerun only tests that failed last time)"]
+  - flag: ""
+    type: select
+    label: "Traceback style"
+    explanation: "How much of the traceback to show when a test fails"
+    choices:
+      - ["", "Default"]
+      - ["--tb=short", "--tb=short (trimmed traceback)"]
+      - ["--tb=long", "--tb=long (full traceback)"]
+      - ["--tb=no", "--tb=no (just the failure count)"]
+  - flag: ""
+    type: select
+    label: "Output capture"
+    explanation: "Whether print() calls inside tests are shown immediately or captured"
+    choices:
+      - ["", "Default (captured, shown on failure)"]
+      - ["-s", "-s (show all print() output as it runs)"]
+```
+
 ---
 
 ## Interactive Quizzes

--- a/Docker/compose.md
+++ b/Docker/compose.md
@@ -99,6 +99,69 @@ volumes:
 | `command` | Override the default CMD from the image. |
 | `profiles` | Assign the service to a profile so it only starts when that profile is active. |
 
+```code-walkthrough
+title: "Production-Style compose.yml Walkthrough"
+description: "How each section of a multi-service Compose file connects the pieces together."
+code: |
+  services:
+    web:
+      build:
+        context: .
+        dockerfile: Dockerfile
+      ports:
+        - "8000:8000"
+      environment:
+        DATABASE_URL: postgres://admin:secret@db:5432/myapp
+        REDIS_URL: redis://cache:6379
+      depends_on:
+        db:
+          condition: service_healthy
+        cache:
+          condition: service_started
+      restart: unless-stopped
+
+    db:
+      image: postgres:16
+      volumes:
+        - pgdata:/var/lib/postgresql/data
+      environment:
+        POSTGRES_DB: myapp
+        POSTGRES_USER: admin
+        POSTGRES_PASSWORD: secret
+      healthcheck:
+        test: ["CMD-SHELL", "pg_isready -U admin -d myapp"]
+        interval: 5s
+        timeout: 3s
+        retries: 5
+      restart: unless-stopped
+
+    cache:
+      image: redis:7-alpine
+      restart: unless-stopped
+
+  volumes:
+    pgdata:
+annotations:
+  - line: 1
+    text: "Top-level 'services' key. Every named entry beneath it becomes a container. The name (web, db, cache) is also the DNS hostname on the default network - services reach each other by name, not IP address."
+  - line: 3
+    text: "'build' tells Compose to build the image from a local Dockerfile instead of pulling one. 'context' is the directory sent to the Docker daemon as the build context."
+  - line: 7
+    text: "Port mapping in HOST:CONTAINER format. Traffic hitting port 8000 on the host is forwarded to port 8000 inside the web container. Omit the host port to let Docker assign a random one."
+  - line: 9
+    text: "Environment variables injected into the web container at startup. DATABASE_URL uses 'db' as the hostname - Compose's built-in DNS resolves the service name to the container's internal IP automatically."
+  - line: 12
+    text: "'depends_on' controls startup order. 'condition: service_healthy' means web will not start until the db healthcheck passes - critical because PostgreSQL takes several seconds to initialize after the container starts."
+  - line: 21
+    text: "The db service uses a pre-built official image from Docker Hub instead of a local build. ':16' pins to a specific major version - using ':latest' risks silent upgrades breaking your schema."
+  - line: 23
+    text: "Named volumes persist data across container restarts and upgrades. The 'pgdata:/var/lib/postgresql/data' syntax mounts the named volume at the path PostgreSQL uses for its data directory."
+  - line: 28
+    text: "Healthcheck defines how Compose knows the database is ready. pg_isready probes the PostgreSQL socket. Compose runs this command inside the container; exit code 0 = healthy, non-zero = unhealthy."
+  - line: 37
+    text: "The top-level 'volumes' section declares named volumes. A volume listed here but not under any service is still created - it just won't be mounted anywhere. Named volumes outlive containers unless you run 'docker compose down -v'."
+```
+
 ---
 
 ## Environment Variables and `.env` Files

--- a/Docker/compose.md
+++ b/Docker/compose.md
@@ -152,11 +152,11 @@ annotations:
     text: "Environment variables injected into the web container at startup. DATABASE_URL uses 'db' as the hostname - Compose's built-in DNS resolves the service name to the container's internal IP automatically."
   - line: 12
     text: "'depends_on' controls startup order. 'condition: service_healthy' means web will not start until the db healthcheck passes - critical because PostgreSQL takes several seconds to initialize after the container starts."
-  - line: 21
+  - line: 19
     text: "The db service uses a pre-built official image from Docker Hub instead of a local build. ':16' pins to a specific major version - using ':latest' risks silent upgrades breaking your schema."
-  - line: 23
+  - line: 20
     text: "Named volumes persist data across container restarts and upgrades. The 'pgdata:/var/lib/postgresql/data' syntax mounts the named volume at the path PostgreSQL uses for its data directory."
-  - line: 28
+  - line: 26
     text: "Healthcheck defines how Compose knows the database is ready. pg_isready probes the PostgreSQL socket. Compose runs this command inside the container; exit code 0 = healthy, non-zero = unhealthy."
   - line: 37
     text: "The top-level 'volumes' section declares named volumes. A volume listed here but not under any service is still created - it just won't be mounted anywhere. Named volumes outlive containers unless you run 'docker compose down -v'."

--- a/Git/branches-and-merging.md
+++ b/Git/branches-and-merging.md
@@ -616,6 +616,38 @@ solution: |
   ```
 ```
 
+```command-builder
+base: git merge
+description: Integrate changes from one branch into the current branch
+options:
+  - flag: ""
+    type: text
+    label: "Branch to merge"
+    placeholder: "feature/my-branch"
+    explanation: "The branch whose commits you want to integrate into the current branch"
+  - flag: ""
+    type: select
+    label: "Merge strategy"
+    explanation: "Controls how Git creates (or avoids) a merge commit"
+    choices:
+      - ["", "Default (fast-forward if possible)"]
+      - ["--no-ff", "--no-ff (always create a merge commit)"]
+      - ["--ff-only", "--ff-only (fail if fast-forward is not possible)"]
+      - ["--squash", "--squash (collapse all commits into working tree, then commit manually)"]
+  - flag: ""
+    type: select
+    label: "Commit behavior"
+    explanation: "Whether to immediately commit the result or leave it staged"
+    choices:
+      - ["", "Default (commit immediately)"]
+      - ["--no-commit", "--no-commit (stage the merge but do not commit)"]
+  - flag: "-m"
+    type: text
+    label: "Merge commit message"
+    placeholder: "Merge feature/my-branch"
+    explanation: "Custom message for the merge commit (only used when a merge commit is created)"
+```
+
 ---
 
 ## Further Reading

--- a/Git/collaboration-workflows.md
+++ b/Git/collaboration-workflows.md
@@ -230,6 +230,35 @@ flowchart LR
 
 This workflow protects the original repository. The maintainer reviews every contribution before it enters the codebase. The contributor doesn't need any special permissions.
 
+```code-walkthrough
+title: "Forking Workflow Shell Commands"
+description: "The complete command sequence from forking a repository to opening a pull request."
+code: |
+  git clone https://github.com/you/project.git
+  cd project
+  git remote add upstream https://github.com/original/project.git
+  git fetch upstream
+  git switch main
+  git merge upstream/main
+  git switch -c feature/my-fix
+  git push origin feature/my-fix
+annotations:
+  - line: 1
+    text: "Clone your fork (not the original). Your fork lives at your username on the platform - you have push access here, not to the upstream."
+  - line: 3
+    text: "Add the original repository as a second remote named 'upstream'. Convention uses 'origin' for your fork and 'upstream' for the original. You can now fetch from upstream without having push access to it."
+  - line: 4
+    text: "Fetch all branches and tags from upstream into your local clone. This doesn't change any local branches - it only updates the remote-tracking refs (upstream/main, upstream/release, etc.)."
+  - line: 5
+    text: "Switch to your local main branch. You'll merge upstream changes here before branching off."
+  - line: 6
+    text: "Merge upstream/main into your local main, bringing your fork up to date with the original. Repeat lines 4-6 before every new feature branch to minimize future merge conflicts."
+  - line: 7
+    text: "Create a feature branch from the now-current main. All work goes here, not on main. This keeps your fork's main clean so you can always sync from upstream without conflict."
+  - line: 8
+    text: "Push to your fork (origin), not to upstream. Then open a pull request on the platform: source is you/project:feature/my-fix, target is original/project:main."
+```
+
 ```quiz
 question: "A 15-person e-commerce team deploys to production several times per day. They have extensive automated test suites and use feature flags to control rollouts. Which workflow is the best fit?"
 type: multiple-choice

--- a/Git/introduction.md
+++ b/Git/introduction.md
@@ -488,6 +488,36 @@ solution: |
   with `git commit --amend --reset-author`.
 ```
 
+```command-builder
+base: git init
+description: Initialize a new Git repository with optional settings
+options:
+  - flag: ""
+    type: text
+    label: "Directory (optional)"
+    placeholder: "my-project"
+    explanation: "Initialize in this directory (created if it doesn't exist). Leave blank to initialize the current directory."
+  - flag: "-b"
+    type: text
+    label: "Initial branch name"
+    placeholder: "main"
+    explanation: "Set the name for the initial branch. Defaults to 'master' unless init.defaultBranch is configured globally."
+  - flag: ""
+    type: select
+    label: "Repository type"
+    explanation: "Bare repositories have no working directory - used for shared repos on servers"
+    choices:
+      - ["", "Standard (with working directory)"]
+      - ["--bare", "Bare (no working directory, for server use)"]
+  - flag: ""
+    type: select
+    label: "Verbosity"
+    explanation: "Control how much output git init produces"
+    choices:
+      - ["", "Default"]
+      - ["-q", "Quiet (suppress informational messages)"]
+```
+
 ---
 
 ## What's Ahead

--- a/Git/rewriting-history.md
+++ b/Git/rewriting-history.md
@@ -565,6 +565,38 @@ solution: |
   ```
 ```
 
+```command-builder
+base: git rebase
+description: Move or clean up commits by replaying them on a different base
+options:
+  - flag: ""
+    type: text
+    label: "Target branch or commit"
+    placeholder: "main"
+    explanation: "The branch or commit to rebase onto. Leave blank when using --continue or --abort."
+  - flag: ""
+    type: select
+    label: "Mode"
+    explanation: "Interactively edit commits, or manage an in-progress rebase"
+    choices:
+      - ["", "Default (non-interactive)"]
+      - ["-i", "-i (interactive: reorder, squash, edit, or drop commits)"]
+      - ["--continue", "--continue (resume after resolving a conflict)"]
+      - ["--abort", "--abort (cancel and restore the original branch state)"]
+  - flag: ""
+    type: select
+    label: "Autosquash"
+    explanation: "Automatically arrange fixup! and squash! commits into their targets (use with -i)"
+    choices:
+      - ["", "Default"]
+      - ["--autosquash", "--autosquash (process fixup!/squash! commit messages)"]
+  - flag: "--onto"
+    type: text
+    label: "Rebase --onto base"
+    placeholder: "v2.0"
+    explanation: "Transplant commits onto this specific commit instead of the default base"
+```
+
 ---
 
 ## Further Reading

--- a/Git/rewriting-history.md
+++ b/Git/rewriting-history.md
@@ -106,6 +106,25 @@ pick b2c3d4e Add user controller
 pick d4e5f6a Add user tests
 ```
 
+```code-walkthrough
+title: "Reading a Rebase TODO File"
+description: "What each line in the interactive rebase editor means, and why this particular edit squashes the typo fix cleanly."
+code: |
+  pick a1b2c3d Add user model
+  fixup c3d4e5f Fix typo in user model
+  pick b2c3d4e Add user controller
+  pick d4e5f6a Add user tests
+annotations:
+  - line: 1
+    text: "'pick' means keep this commit exactly as-is. It was the original first commit and stays in position - nothing changes for it."
+  - line: 2
+    text: "'fixup' squashes this commit into the one directly above it and discards this commit's message. This line was also manually moved here from its original position (after line 3) so that it sits immediately below the commit it fixes. Order matters: fixup always targets the line above."
+  - line: 3
+    text: "'pick' again - the controller commit is kept as-is. After the rebase, it will have a new hash (because its ancestor changed), but its content and message are preserved."
+  - line: 4
+    text: "'pick' for the tests commit. Like all commits after the squash point, it gets a new hash even though its content is unchanged - every commit in a rebase is replayed from scratch."
+```
+
 Notice the reordering: the typo fix is moved directly below the commit it fixes, then marked as `fixup` so its message is discarded. The result is three clean commits instead of four.
 
 ### Example: Editing a Commit

--- a/Git/rewriting-history.md
+++ b/Git/rewriting-history.md
@@ -605,15 +605,10 @@ options:
   - flag: ""
     type: select
     label: "Autosquash"
-    explanation: "Automatically arrange fixup! and squash! commits into their targets (use with -i)"
+    explanation: "Requires -i mode. Automatically moves fixup! and squash! commits to sit directly below their targets and sets the action to fixup/squash."
     choices:
       - ["", "Default"]
-      - ["--autosquash", "--autosquash (process fixup!/squash! commit messages)"]
-  - flag: "--onto"
-    type: text
-    label: "Rebase --onto base"
-    placeholder: "v2.0"
-    explanation: "Transplant commits onto this specific commit instead of the default base"
+      - ["--autosquash", "--autosquash (process fixup!/squash! commit messages, requires -i)"]
 ```
 
 ---

--- a/Git/transfer-protocols.md
+++ b/Git/transfer-protocols.md
@@ -70,6 +70,19 @@ git://github.com/user/repo.git
 
 The `git://` protocol is unauthenticated and unencrypted. It was used for fast, read-only access to public repositories. Most platforms no longer support it due to security concerns.
 
+### Protocol Comparison
+
+| | SSH | Smart HTTP | Dumb HTTP | Native Git |
+|---|---|---|---|---|
+| **Authentication** | SSH keys or password | HTTP tokens, Basic auth, OAuth | None (read-only) | None |
+| **Encryption** | Always (SSH channel) | TLS (HTTPS only) | None | None |
+| **Push support** | Yes | Yes | No | No |
+| **Firewall/proxy** | Port 22 (may be blocked) | Port 443 (almost never blocked) | Port 80/443 | Port 9418 (usually blocked) |
+| **Setup complexity** | SSH key required | Just a URL and token | Just a URL | Server daemon required |
+| **Common use** | Developer workstations, CI with deploy keys | Hosted platforms (GitHub, GitLab, Bitbucket) | Static web servers (legacy) | Deprecated, rarely used |
+
+**Choose SSH** for developer machines where you control the environment - key-based authentication is seamless once configured. **Choose Smart HTTP** for CI/CD pipelines, tokens you can rotate, and anywhere port 22 may be blocked (corporate networks, restricted cloud environments).
+
 ---
 
 ## Pack Negotiation

--- a/Git/troubleshooting-and-recovery.md
+++ b/Git/troubleshooting-and-recovery.md
@@ -95,6 +95,28 @@ git fsck --lost-found
 ls .git/lost-found/commit/
 ```
 
+```code-walkthrough
+title: "Reading git reflog Output"
+description: "How to interpret each field in reflog output to find the commit you need to recover."
+code: |
+  a1b2c3d HEAD@{0}: checkout: moving from feature/important-work to main
+  c3d4e5f HEAD@{1}: commit: Expand critical feature
+  b2c3d4e HEAD@{2}: commit: Add critical feature
+  a1b2c3d HEAD@{3}: checkout: moving from main to feature/important-work
+  a1b2c3d HEAD@{4}: commit (initial): Initial commit
+annotations:
+  - line: 1
+    text: "Most recent entry (HEAD@{0} = current HEAD). This records the checkout that moved us from the feature branch to main - the last action before the accidental branch deletion."
+  - line: 2
+    text: "HEAD@{1} - the tip of the deleted branch. Hash c3d4e5f is the commit we want to recover. Use this hash with 'git branch recovery c3d4e5f' to recreate the branch pointer."
+  - line: 3
+    text: "HEAD@{2} - the parent of the deleted branch tip. You don't need to recover this separately: pointing a new branch at c3d4e5f (line 2) automatically includes b2c3d4e as an ancestor."
+  - line: 4
+    text: "The checkout that first moved HEAD onto the feature branch. Same hash as line 5 (a1b2c3d) because no commits had been made on main - the feature branch started at the same point."
+  - line: 5
+    text: "The initial commit, also on main. The HEAD@{N} notation lets you reference any of these positions directly in git commands, e.g. 'git reset --hard HEAD@{2}' or 'git diff HEAD@{0} HEAD@{2}'."
+```
+
 ```terminal
 title: Recovering a Deleted Branch from the Reflog
 steps:

--- a/Linux Essentials/archiving-and-compression.md
+++ b/Linux Essentials/archiving-and-compression.md
@@ -38,6 +38,7 @@ Add a compression flag:
 tar -czf archive.tar.gz directory/          # gzip compression
 tar -cjf archive.tar.bz2 directory/         # bzip2 compression
 tar -cJf archive.tar.xz directory/          # xz compression
+tar --zstd -cf archive.tar.zst directory/   # zstd compression
 ```
 
 | Flag | Compression | Extension | Speed | Ratio |
@@ -45,6 +46,7 @@ tar -cJf archive.tar.xz directory/          # xz compression
 | `-z` | gzip | `.tar.gz` or `.tgz` | Fast | Good |
 | `-j` | bzip2 | `.tar.bz2` | Slow | Better |
 | `-J` | xz | `.tar.xz` | Slowest | Best |
+| `--zstd` | zstd | `.tar.zst` | Very Fast | Excellent |
 
 ```quiz
 question: "What is the difference between tar -czf and tar -cJf?"
@@ -194,6 +196,7 @@ options:
     explanation: "Compression algorithm to use"
     choices:
       - ["-z", "gzip (.tar.gz) - fast, good compression"]
+      - ["--zstd", "zstd (.tar.zst) - very fast, excellent compression"]
       - ["-j", "bzip2 (.tar.bz2) - slower, better compression"]
       - ["-J", "xz (.tar.xz) - slowest, best compression"]
       - ["", "None (.tar) - no compression"]
@@ -325,6 +328,42 @@ xzcat file.txt.xz
 
 ---
 
+## zstd / unzstd
+
+[**`zstd`**](https://facebook.github.io/zstd/) (Zstandard) is a modern compression algorithm from Meta that delivers near-xz compression ratios at near-gzip speeds. It has become the default compression format for many Linux distributions (Arch, Fedora, Ubuntu 22.04+) and package managers.
+
+```bash
+zstd file.txt                  # creates file.txt.zst, keeps original by default
+zstd -k file.txt               # explicit keep (original preserved anyway)
+zstd -19 file.txt              # maximum compression (levels 1-19)
+zstd -1 file.txt               # fastest compression
+zstd -T0 file.txt              # use all CPU cores
+zstd -d file.txt.zst           # decompress (same as unzstd)
+```
+
+!!! tip "zstd keeps the original file by default"
+
+    Unlike **`gzip`** and **`bzip2`**, **`zstd`** preserves the original file when compressing. This is the opposite default behavior, so you don't need `-k` to avoid losing the source. Use **`--rm`** if you explicitly want to delete the original after compression.
+
+**`unzstd`** decompresses:
+
+```bash
+unzstd file.txt.zst
+```
+
+**`zstdcat`** reads compressed files without decompressing:
+
+```bash
+zstdcat file.txt.zst
+zstdcat file.txt.zst | grep "error"
+```
+
+### Why zstd matters
+
+zstd occupies the sweet spot that bzip2 and xz never quite achieved - it compresses nearly as well as xz but decompresses as fast as gzip. This makes it ideal for scenarios where you compress once but decompress frequently (package managers, container images, backups you restore). The `-T0` multithreaded flag (which xz also supports as `-T 0`) is enabled by default in many distributions' package builds.
+
+---
+
 ## zip / unzip
 
 [**`zip`**](https://infozip.sourceforge.net/) creates archives compatible with Windows and macOS. It handles both archiving and compression in one step.
@@ -364,16 +403,17 @@ Classic zip has a few limitations to be aware of. It doesn't preserve Unix file 
 | Format | Use When |
 |--------|----------|
 | `.tar.gz` | General purpose. Fast, good compression, universally supported on Linux. Default choice for most things. |
-| `.tar.bz2` | You need better compression and can wait longer. Less common now that xz exists. |
-| `.tar.xz` | Maximum compression matters (distributing software, long-term storage). Standard for Linux distro packages. |
+| `.tar.zst` | Modern systems where zstd is available. Excellent compression, very fast decompression. Default for many distro packages (Arch, Fedora, Ubuntu 22.04+). |
+| `.tar.bz2` | You need better compression and can wait longer. Less common now that xz and zstd exist. |
+| `.tar.xz` | Maximum compression matters (distributing software, long-term storage). Standard for Linux distro source tarballs. |
 | `.zip` | Sharing with Windows/macOS users, or when recipients might not have tar. |
 | `.gz` (no tar) | Compressing a single file (like log rotation). |
 
 **Concrete scenarios:**
 
-- **Distributing software** - `.tar.xz` is the standard. Users download once, the slow compression time is paid by the developer, and the small size saves bandwidth.
+- **Distributing software** - `.tar.xz` is the traditional standard for source tarballs; `.tar.zst` is increasingly used for binary packages (Arch Linux `pacman`, Fedora RPMs). Users download once, the slow compression time is paid by the developer, and the small size saves bandwidth.
 - **Log rotation** - `.gz` (single file, no tar needed). logrotate uses gzip by default because the fast compression/decompression cycle matters when rotating logs on a busy server.
-- **Backups** - `.tar.gz` balances compression with speed. For large backup jobs, the time difference between gzip and xz can be hours.
+- **Backups** - `.tar.zst` or `.tar.gz` balance compression with speed. For large backup jobs where you may need to restore frequently, zstd's fast decompression is a practical advantage over xz.
 - **Sharing with non-Linux users** - `.zip` is universally supported on Windows and macOS without extra software.
 - **Archiving for long-term storage** - `.tar.xz` gives the best size reduction. If the data won't be accessed frequently, the slow compression is worth it.
 
@@ -384,11 +424,12 @@ Approximate results for a typical 100MB text file (actual results vary with cont
 | Format | Compressed Size | Compression Time | Decompression Time |
 |--------|----------------|------------------|--------------------|
 | gzip | ~30MB (~70% reduction) | ~2 seconds | ~1 second |
+| zstd (default) | ~25MB (~75% reduction) | ~1.5 seconds | ~0.5 seconds |
 | bzip2 | ~25MB (~75% reduction) | ~8 seconds | ~4 seconds |
 | xz | ~20MB (~80% reduction) | ~30 seconds | ~2 seconds |
 | zip | ~30MB (~70% reduction) | ~2 seconds | ~1 second |
 
-Notable: xz decompresses much faster than it compresses, making it a good choice when you compress once and decompress many times (like software distribution). Binary files and already-compressed data (images, video) will see much smaller reductions.
+Notable: zstd matches bzip2's compression ratio at gzip's speed, and decompresses faster than any of them. xz still achieves the smallest output for maximum compression, but at the cost of compression time. Binary files and already-compressed data (images, video) will see much smaller reductions across all formats.
 
 ```terminal
 title: Compression Algorithm Comparison
@@ -421,6 +462,7 @@ steps:
 - [GNU Gzip Manual](https://www.gnu.org/software/gzip/manual/) - compression utility reference
 - [bzip2](https://sourceware.org/bzip2/) - block-sorting file compressor
 - [XZ Utils](https://tukaani.org/xz/) - LZMA/LZMA2 compression tools
+- [Zstandard](https://facebook.github.io/zstd/) - fast real-time compression algorithm
 - [Info-ZIP](https://infozip.sourceforge.net/) - zip and unzip utilities
 
 ---

--- a/Security/certificate-management.md
+++ b/Security/certificate-management.md
@@ -207,6 +207,31 @@ openssl x509 -req -in server.csr \
   -copy_extensions copyall
 ```
 
+```code-walkthrough
+title: "Internal CA Workflow"
+description: "The complete command sequence for creating a private CA and signing a server certificate, with each step explained."
+code: |
+  openssl genrsa -aes256 -out ca.key 4096
+  openssl req -new -x509 -key ca.key -sha256 -days 3650 -out ca.crt -subj "/CN=Internal Root CA/O=My Company"
+  openssl genrsa -out server.key 2048
+  openssl req -new -key server.key -out server.csr -subj "/CN=api.internal" -addext "subjectAltName=DNS:api.internal"
+  openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 365 -sha256 -copy_extensions copyall
+  openssl verify -CAfile ca.crt server.crt
+annotations:
+  - line: 1
+    text: "Generate the CA private key: 4096-bit RSA encrypted with AES-256. The passphrase protects the key file at rest. Keep ca.key offline after initial setup - it is the crown jewel of your PKI."
+  - line: 2
+    text: "Create the self-signed root certificate (-x509 means self-sign instead of producing a CSR). -days 3650 = 10 years. This cert is what you distribute to clients as a trusted root."
+  - line: 3
+    text: "Generate the server's private key: 2048-bit RSA, no passphrase. Servers need to read this key at startup without human interaction, so it must be unencrypted - protect it with filesystem permissions (chmod 600) instead."
+  - line: 4
+    text: "Create a Certificate Signing Request (CSR) for the server. -addext embeds the Subject Alternative Name (SAN) into the CSR. Modern browsers require SANs - the CN field alone is ignored for hostname validation."
+  - line: 5
+    text: "CA signs the CSR and produces the server certificate. -CAcreateserial creates a serial number file (ca.srl) that increments with each signed cert. -copy_extensions copyall preserves the SANs from the CSR into the final cert (requires OpenSSL 3.0+)."
+  - line: 6
+    text: "Verify the certificate chain: checks that server.crt was signed by ca.crt and the signature is valid. Output 'server.crt: OK' means the chain is intact. Run this before deploying to catch mismatched keys or wrong CA."
+```
+
 ### Distributing the CA Certificate
 
 For clients to trust certificates signed by your internal CA, they need your `ca.crt` installed as a trusted root:

--- a/assets/javascripts/components/command-builder.js
+++ b/assets/javascripts/components/command-builder.js
@@ -223,7 +223,7 @@
       inputs.forEach(({ input, opt }) => {
         const val = input.value.trim();
         if (val) {
-          parts.push(opt.flag);
+          if (opt.flag) parts.push(opt.flag);
           parts.push(val);
         }
       });
@@ -238,7 +238,9 @@
       inputs.forEach(({ input, opt }) => {
         const val = input.value.trim();
         if (val) {
-          html += ' <span class="flag">' + escapeHtml(opt.flag) + "</span>";
+          if (opt.flag) {
+            html += ' <span class="flag">' + escapeHtml(opt.flag) + "</span>";
+          }
           html += " " + escapeHtml(val);
           if (opt.explanation) {
             activeExplanations.push({ flag: opt.flag, text: opt.explanation });


### PR DESCRIPTION
## Summary

- **DNS factual fixes** — minor corrections across DNS Administration guides
- **Command-builders** — added `dig`, `pytest`, `git init`, `git merge`, `git rebase` builders to DNS Administration, Python, and Git guides
- **Code-walkthroughs** — added walkthroughs for rebase TODO file, reflog output, forking workflow commands (Git), docker-compose.yml structure (Docker), CREATE TABLE anatomy (Databases), and internal CA signing workflow (Security)
- **Thin guide expansions** — added `zstd / unzstd` section to Linux Essentials archiving guide (including tar `--zstd` flag, comparison table updates, command-builder option); added SSH vs Smart HTTP protocol comparison table to Git transfer-protocols guide

## Test plan

- [ ] `./setup-docs.sh && mkdocs build --strict` passes with no errors
- [ ] `python -m pytest tests/` passes (43 tests)
- [ ] `npx vitest run` passes
- [ ] Spot-check new interactive components render in `mkdocs serve`