### PR TITLE
chore: trim .gitignore and document the full local check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,5 @@
 .DS_Store
 
-# Local tool configs
-CLAUDE.md
-CLAUDE.local.md
-.claude/
-.claude-dev-helper/
-.plugin-config/
-.junie/
-AGENTS.md
-
 # Environment
 .env
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,15 @@ mkdocs serve
 
 3. Open [http://localhost:8000](http://localhost:8000) in your browser. MkDocs will hot-reload as you edit files.
 
+4. If you plan to run the full check (`./verify.sh`), install the test dependencies too:
+
+```bash
+pip install -r requirements-test.txt
+npm ci
+```
+
+`./verify.sh` also runs Deno tests for the Supabase edge function; install [Deno](https://deno.com/) if you are touching `supabase/functions/`.
+
 !!! note
     `setup-docs.sh` creates a `docs/` directory with symlinks to your source content. The `docs/` and `site/` directories are gitignored build artifacts.
 
@@ -264,13 +273,21 @@ annotations:
     docs: fix broken link in README
     ```
 
-3. **Verify the build passes** before pushing:
+3. **Run the full check** before pushing:
+
+    ```bash
+    ./verify.sh
+    ```
+
+    This is the same gate CI runs: Python tests, JavaScript tests, Deno tests,
+    then a strict MkDocs build. Strict mode catches broken links, missing files,
+    and configuration errors.
+
+    For a docs-only change you can run just the build step:
 
     ```bash
     ./setup-docs.sh && mkdocs build --strict
     ```
-
-    Strict mode catches broken links, missing files, and configuration errors.
 
 4. **Open a pull request** against `main` with a clear description of what you changed and why.
 


### PR DESCRIPTION
Two small housekeeping changes.

**`.gitignore`** - dropped the local editor/tool config entries. They are already covered by a global ignore file, so the repo copy was redundant. What remains is build artifacts, environment files, and unused assets.

Verified with `git status --porcelain --untracked-files=all`: no previously-ignored path becomes visible after the change, and `git check-ignore -v` confirms each one still resolves to the global file.

**`CONTRIBUTING.md`** - the contributing guide only mentioned `mkdocs build --strict`, but `./verify.sh` is now the single local gate (Python, JavaScript, and Deno tests plus the strict build) and is what CI runs. Documented it, along with the test-dependency install step, and kept the build-only command as the shortcut for docs-only changes.