### PR TITLE
docs: add scheduled external link check and repair dead links

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-guide.yml
+++ b/.github/ISSUE_TEMPLATE/new-guide.yml
@@ -12,7 +12,12 @@ body:
         - DNS Administration
         - Git
         - Databases
-        - Perl / Dev Zero
+        - Nginx
+        - Security
+        - Docker
+        - Dev Zero (Perl / Python)
+        - Kubernetes (planned)
+        - CI/CD (planned)
         - New Topic Area
     validations:
       required: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -47,12 +47,24 @@ jobs:
         run: |
           TITLE="Broken external links detected"
           {
-            echo "The weekly link check found broken external links."
+            if grep -q '^Broken links:' link-report.txt; then
+              echo "The weekly link check found broken external links."
+            else
+              # The checker's own preconditions (missing site directory, too few
+              # URLs extracted, unfinished scan) fail before any link report is
+              # produced. Reporting an empty list would hide exactly the
+              # regression those guards exist to catch.
+              echo "The weekly link check failed before it could report on links."
+            fi
             echo
             echo "Run: $RUN_URL"
             echo
             echo '```'
-            sed -n '/^Broken links:/,$p' link-report.txt
+            if grep -q '^Broken links:' link-report.txt; then
+              sed -n '/^Broken links:/,$p' link-report.txt
+            else
+              tail -40 link-report.txt
+            fi
             echo '```'
           } > body.md
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,70 @@
+name: Link Check
+
+# External links rot on someone else's schedule, not ours, and the checks are
+# slow and occasionally rate-limited. Running this per-PR would fail builds for
+# reasons unrelated to the change, so it runs unattended and files an issue.
+on:
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+          cache: 'pip'
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcairo2-dev libffi-dev
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build site
+        run: ./setup-docs.sh && mkdocs build --strict
+
+      - name: Check external links
+        id: check
+        run: |
+          set +e
+          ./check-links.sh 2>&1 | tee link-report.txt
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: File an issue for broken links
+        if: steps.check.outputs.status != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TITLE="Broken external links detected"
+          {
+            echo "The weekly link check found broken external links."
+            echo
+            echo "Run: $RUN_URL"
+            echo
+            echo '```'
+            sed -n '/^Broken links:/,$p' link-report.txt
+            echo '```'
+          } > body.md
+
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --jq ".[] | select(.title == \"$TITLE\") | .number" | head -1)
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file body.md
+          else
+            gh issue create --title "$TITLE" --label "type: bug" --body-file body.md
+          fi
+
+      - name: Fail the run when links are broken
+        if: steps.check.outputs.status != '0'
+        run: exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,6 +309,12 @@ annotations:
     ./setup-docs.sh && mkdocs build --strict
     ```
 
+    External links are checked separately by `./check-links.sh`, which runs
+    against the built `site/` directory. It needs network access and takes
+    several minutes, so it is not part of `verify.sh` - a scheduled workflow
+    runs it weekly and opens an issue when links go dead. Run it yourself if
+    you are adding a lot of Further Reading entries.
+
 4. **Open a pull request** against `main` with a clear description of what you changed and why.
 
 ---

--- a/DNS Administration/dns-tools.md
+++ b/DNS Administration/dns-tools.md
@@ -656,7 +656,7 @@ solution: |
 
 ## DNS as a Covert Channel
 
-A security note: DNS can be used as a data exfiltration channel. Tools like [**`iodine`**](https://code.kryo.se/iodine/) tunnel IP traffic inside DNS queries, encoding data in subdomain labels. An exfiltration query might look like:
+A security note: DNS can be used as a data exfiltration channel. Tools like [**`iodine`**](https://github.com/yarrick/iodine) tunnel IP traffic inside DNS queries, encoding data in subdomain labels. An exfiltration query might look like:
 
 ```
 dGhpcyBpcyBzZWNyZXQ.tunnel.attacker.com
@@ -672,7 +672,7 @@ If you run a recursive resolver, watch for unusually long query names, high quer
 
 - [ISC BIND / dig](https://www.isc.org/bind/) - dig is distributed with BIND
 - [ldns / drill](https://nlnetlabs.nl/projects/ldns/about/) - DNS library and drill tool from NLnet Labs
-- [iodine](https://code.kryo.se/iodine/) - IP over DNS tunnel
+- [iodine](https://github.com/yarrick/iodine) - IP over DNS tunnel
 - [DNSViz](https://dnsviz.net/) - DNSSEC visualization and analysis
 - [RDAP](https://about.rdap.org/) - modern replacement for WHOIS
 - [Cloudflare Learning Center: DNS Troubleshooting](https://www.cloudflare.com/learning/dns/dns-server-types/) - visual DNS explanations

--- a/DNS Administration/nsd-and-unbound.md
+++ b/DNS Administration/nsd-and-unbound.md
@@ -641,7 +641,7 @@ Both are production-quality, well-maintained, and used by major organizations. T
 - [Unbound Documentation](https://unbound.docs.nlnetlabs.nl/en/latest/) - NLnet Labs official Unbound docs
 - [NLnet Labs](https://nlnetlabs.nl/) - organization overview and projects
 - [RFC 5011](https://datatracker.ietf.org/doc/html/rfc5011) - Automated Updates of DNSSEC Trust Anchors
-- [DNS Flag Day](https://dnsflagday.net/) - DNS standards compliance initiative
+- [DNS Flag Day](https://www.dnsflagday.net/) - DNS standards compliance initiative
 
 ---
 

--- a/Databases/database-fundamentals.md
+++ b/Databases/database-fundamentals.md
@@ -77,7 +77,7 @@ IBM was slow to commercialize Codd's ideas (IMS was a cash cow), but two Berkele
 <img src="../../assets/images/databases/larry-ellison.jpg" alt="Larry Ellison on stage at Oracle OpenWorld">
 <figcaption>
 Larry Ellison, co-founder of Oracle, on stage at Oracle OpenWorld 2009.
-<span class="photo-credit">Photo: <a href="https://www.flickr.com/photos/43156897@N06/4013705452">Oracle Corporate Communications</a>, <a href="https://creativecommons.org/licenses/by/2.0/">CC BY 2.0</a></span>
+<span class="photo-credit">Photo: <a href="https://web.archive.org/web/20180622194017/https://www.flickr.com/photos/43156897@N06/4013705452">Oracle Corporate Communications</a>, <a href="https://creativecommons.org/licenses/by/2.0/">CC BY 2.0</a></span>
 </figcaption>
 </figure>
 

--- a/Databases/innodb-recovery-pdrt.md
+++ b/Databases/innodb-recovery-pdrt.md
@@ -260,10 +260,12 @@ PDRT predates the BARRACUDA / DYNAMIC / COMPRESSED row formats introduced in MyS
 
 ## Installing PDRT
 
-PDRT is no longer distributed by Percona. The GitHub repository that hosted it has been removed, and the [Launchpad project](https://launchpad.net/percona-data-recovery-tool-for-innodb) it originally lived in is archived and unmaintained. What remains are community copies of the last release.
+PDRT is no longer distributed by Percona. The GitHub repository that hosted it has been removed, and the [Launchpad project](https://launchpad.net/percona-data-recovery-tool-for-innodb) it originally lived in is archived. What remains are unofficial copies of the last release, mirrored by people who were using it when it disappeared.
+
+The best-known descendant is [undrop-for-innodb](https://github.com/twindb/undrop-for-innodb), TwinDB's fork of the same codebase. It is also archived, and it renames the binaries: `page_parser` became `stream_parser` and `constraints_parser` became `c_parser`. The concepts below all transfer, but the commands in the rest of this guide are PDRT's, so translate them if you go that route.
 
 !!! warning
-    Every surviving copy of PDRT is an unofficial mirror. You are about to point a byte-level parser at damaged production data, so review the source you obtain rather than trusting a fork on reputation. Work on a copy of the ibdata file, never the original.
+    Every surviving copy is an unofficial mirror. You are about to point a byte-level parser at damaged production data, so read the source you obtain rather than trusting a fork on reputation. Work on a copy of the ibdata file, never the original.
 
 ### Compile
 

--- a/Databases/innodb-recovery-pdrt.md
+++ b/Databases/innodb-recovery-pdrt.md
@@ -260,16 +260,19 @@ PDRT predates the BARRACUDA / DYNAMIC / COMPRESSED row formats introduced in MyS
 
 ## Installing PDRT
 
-The PDRT source is available from [Percona's GitHub repository](https://github.com/percona/percona-data-recovery-tool-for-innodb). The original Bazaar/Launchpad repository is no longer maintained.
+PDRT is no longer distributed by Percona. The GitHub repository that hosted it has been removed, and the [Launchpad project](https://launchpad.net/percona-data-recovery-tool-for-innodb) it originally lived in is archived and unmaintained. What remains are community copies of the last release.
 
-### Download and Compile
+!!! warning
+    Every surviving copy of PDRT is an unofficial mirror. You are about to point a byte-level parser at damaged production data, so review the source you obtain rather than trusting a fork on reputation. Work on a copy of the ibdata file, never the original.
+
+### Compile
+
+Unpack whatever copy you obtained to `/root/pdrt` - the rest of this guide uses that path - and build it. The build itself is unchanged from the last official release:
 
 ```bash
-cd /root
-git clone https://github.com/percona/percona-data-recovery-tool-for-innodb.git pdrt
-cd pdrt/mysql-source
+cd /root/pdrt/mysql-source
 ./configure
-cd ..
+cd /root/pdrt
 make
 ```
 
@@ -375,7 +378,7 @@ systemctl start mysql
 
 If you have the `.frm` file but MySQL cannot read the table, copy the `.frm` to a working MySQL instance (into a database directory where you have created a placeholder table with the same name), restart MySQL, and run `SHOW CREATE TABLE`.
 
-Alternatively, the [MySQL Utilities](https://dev.mysql.com/doc/mysql-utilities/1.6/en/) package includes `mysqlfrm` for extracting structure directly from `.frm` files.
+Older writeups suggest `mysqlfrm` from the MySQL Utilities package for extracting structure directly from `.frm` files. That package reached end of life in 2018 and its documentation is gone, so treat the copy-and-`SHOW CREATE TABLE` approach above as the supported path.
 
 ---
 
@@ -698,7 +701,7 @@ tasks:
 ## Further Reading
 
 - [MySQL InnoDB Storage Engine Documentation](https://dev.mysql.com/doc/refman/8.0/en/innodb-storage-engine.html) - official InnoDB reference for file formats, recovery, and configuration
-- [Percona Data Recovery Tool (GitHub)](https://github.com/percona/percona-data-recovery-tool-for-innodb) - PDRT source code and documentation
+- [Percona Data Recovery Tool (Launchpad)](https://launchpad.net/percona-data-recovery-tool-for-innodb) - the archived upstream project
 - [InnoDB Recovery with innodb_force_recovery](https://dev.mysql.com/doc/refman/8.0/en/forcing-innodb-recovery.html) - MySQL documentation on the force recovery levels
 - [Percona XtraBackup](https://docs.percona.com/percona-xtrabackup/8.0/) - hot backup tool for InnoDB that avoids the need for PDRT in many scenarios
 - [How to Recover a Single InnoDB Table from a Full Backup](https://www.percona.com/blog/how-to-recover-a-single-innodb-table-from-a-full-backup/) - Percona blog on targeted table recovery

--- a/Databases/redis.md
+++ b/Databases/redis.md
@@ -872,7 +872,7 @@ solution: |
 ## Further Reading
 
 - [Redis Documentation](https://redis.io/docs/) - official reference for all commands, data types, and configuration
-- [Redis Data Types Tutorial](https://redis.io/docs/data-types/tutorial/) - interactive walkthrough of every data structure
+- [Redis Data Types Tutorial](https://redis.io/docs/latest/develop/data-types/) - interactive walkthrough of every data structure
 - [Redis Persistence](https://redis.io/docs/management/persistence/) - in-depth coverage of RDB, AOF, and hybrid persistence
 - [Redis Sentinel Documentation](https://redis.io/docs/management/sentinel/) - complete Sentinel setup and failover configuration
 - [Redis Cluster Specification](https://redis.io/docs/reference/cluster-spec/) - hash slot mechanics, gossip protocol, and resharding details

--- a/Dev Zero/Perl/file-io-and-system.md
+++ b/Dev Zero/Perl/file-io-and-system.md
@@ -1417,7 +1417,7 @@ options:
 ## Further Reading
 
 - [perlopentut](https://perldoc.perl.org/perlopentut) - Perl open tutorial with examples for every mode
-- [perlio](https://perldoc.perl.org/perlio) - PerlIO layers (encoding, buffering, compression)
+- [perlio](https://perldoc.perl.org/PerlIO) - PerlIO layers (encoding, buffering, compression)
 - [perlfunc](https://perldoc.perl.org/perlfunc) - complete built-in function reference
 - [perlvar](https://perldoc.perl.org/perlvar) - special variables (`$!`, `$?`, `$/`, `$.`, `$_`)
 - [perlipc](https://perldoc.perl.org/perlipc) - interprocess communication (signals, pipes, sockets, fork)

--- a/Dev Zero/Perl/perl_developer_roadmap.md
+++ b/Dev Zero/Perl/perl_developer_roadmap.md
@@ -169,7 +169,7 @@ Practice regularly, and you'll soon find Vim indispensable.
 
 **Emacs** is a feature-rich, highly customizable text editor with a deep history in the developer community. While it is less commonly used than Vim in Unix environments, it excels in its extensibility through Emacs Lisp, allowing users to transform it into an IDE, email client, calendar, and more. Once mastered, Emacs offers powerful workflows for programming, writing, and system administration. Notable learning resources include:
 
-- [Absolute Beginner's Guide to Emacs](https://jesshamrick.com/2012/09/10/absolute-beginners-guide-to-emacs/)
+- [GNU Emacs Guided Tour](https://www.gnu.org/software/emacs/tour/)
 - [Emacs Rocks!](https://emacsrocks.com)
 - [Mastering Emacs](https://www.masteringemacs.org)
 
@@ -223,7 +223,7 @@ Recommended reading:
 
 - [The History of Unix](https://en.wikipedia.org/wiki/History_of_Unix)
 - *[A Quarter Century of Unix](https://www.oreilly.com/library/view/a-quarter-century/9780133988906/)* by Peter H. Salus
-- [The Unix Philosophy](http://catb.org/~esr/writings/taoup/html/) by Eric S. Raymond
+- [The Unix Philosophy](https://web.archive.org/web/2024/http://www.catb.org/~esr/writings/taoup/html/) by Eric S. Raymond (archived; catb.org is frequently offline)
 
 ```exercise
 title: Build Your Phase 1 Learning Plan
@@ -432,9 +432,9 @@ Tools and resources:
 Getting involved with the Perl community is not only encouraged-it's essential. Community interaction can accelerate your learning, expose you to real-world problem solving, and keep you current with modern Perl practices.
 
 1. **[PerlMonks](https://www.perlmonks.org)**: A long-established and active community focused entirely on Perl. It remains relevant in 2025 as a place to get answers, learn idioms, and participate in thoughtful programming discussions. Users post questions, tutorials, and code snippets, and receive feedback from veteran developers.
-2. **[Perl Mongers](https://www.pm.org/)**: A global network of local Perl user groups that still hold in-person and virtual meetups. While not as active as in past decades, many chapters remain valuable for community support and professional networking. Check the PM.org website or join forums like [https://perl.community](https://perl.community) for modern community hubs.
+2. **[Perl Mongers](https://www.pm.org/)**: A global network of local Perl user groups that still hold in-person and virtual meetups. While not as active as in past decades, many chapters remain valuable for community support and professional networking. Check the PM.org website or the [perl.org community directory](https://www.perl.org/community.html) for modern community hubs.
 
-**Contributing to CPAN (inspired by the CPAN PRC)**: The original [CPAN Pull Request Challenge](https://www.cpanprc.org) ended in 2018, but its legacy lives on. Today, Perl developers are encouraged to contribute to CPAN via GitHub and MetaCPAN. Identify outdated or under-maintained modules, review open issues, and submit pull requests. Tools like [MetaCPAN](https://metacpan.org/) and GitHub's "good first issue" label make it easier than ever to find a way to contribute.
+**Contributing to CPAN (inspired by the CPAN PRC)**: The original CPAN Pull Request Challenge ended in 2018 and its site is gone, but its legacy lives on. Today, Perl developers are encouraged to contribute to CPAN via GitHub and MetaCPAN. Identify outdated or under-maintained modules, review open issues, and submit pull requests. Tools like [MetaCPAN](https://metacpan.org/) and GitHub's "good first issue" label make it easier than ever to find a way to contribute.
 
 #### Diving Deep
 
@@ -667,7 +667,7 @@ Mastering application architecture ensures that your Perl projects scale well, i
 
 **Contributing to CPAN (Inspired by the CPAN PRC)**
 
-While the original [CPAN Pull Request Challenge (CPAN PRC)](https://www.cpanprc.org) ended in 2018, the concept of monthly contributions to open source Perl modules lives on in spirit. Practicing workflows through regular contribution helps developers gain experience with collaborative development, version control, and best practices in CPAN module structure and testing.
+While the original CPAN Pull Request Challenge (CPAN PRC) ended in 2018, the concept of monthly contributions to open source Perl modules lives on in spirit. Practicing workflows through regular contribution helps developers gain experience with collaborative development, version control, and best practices in CPAN module structure and testing.
 
 To emulate this experience today:
 
@@ -703,7 +703,7 @@ Version control is an essential part of modern software development, enabling te
 
 **Modern Learning Resources**:
 
-- **[GitHub Learning Lab](https://lab.github.com/)** - Offers interactive tutorials on real GitHub repositories.
+- **[GitHub Skills](https://skills.github.com/)** - Offers interactive tutorials on real GitHub repositories. It replaced the retired GitHub Learning Lab.
 - **[Pro Git Book](https://git-scm.com/book/en/v2)** - A comprehensive and freely available guide for all levels.
 - **[Git Handbook](https://guides.github.com/introduction/git-handbook/)** - A high-level overview of Git and GitHub best practices.
 

--- a/Dev Zero/Perl/text-processing-oneliners.md
+++ b/Dev Zero/Perl/text-processing-oneliners.md
@@ -736,7 +736,7 @@ solution: |
 - [perlrun](https://perldoc.perl.org/perlrun) - complete reference for Perl command-line flags and environment variables
 - [perlvar](https://perldoc.perl.org/perlvar) - special variables including `$_`, `@F`, `$.`, and `$/`
 - [Perl One-Liners Cookbook](https://www.oreilly.com/library/view/perl-one-liners/9781457185830/) - Peteris Krumins' collection of practical one-liners with explanations
-- [Minimal Perl](https://www.manning.com/books/minimal-perl-for-unix-and-linux-people) - Tim Maher's guide to Perl as a Unix command-line tool
+- [Minimal Perl](https://www.manning.com/books/minimal-perl) - Tim Maher's guide to Perl as a Unix command-line tool
 - [perlre](https://perldoc.perl.org/perlre) - regex reference for the patterns used throughout one-liners
 - [Text::CSV documentation](https://metacpan.org/pod/Text::CSV) - robust CSV parsing for when simple splitting is not enough
 

--- a/Git/security.md
+++ b/Git/security.md
@@ -433,7 +433,7 @@ steps:
 
 ### BFG Repo-Cleaner
 
-[**BFG**](https://reclaimtheremote.com/bfg-repo-cleaner/) is a simpler tool focused on common cleaning tasks:
+[**BFG**](https://rtyley.github.io/bfg-repo-cleaner/) is a simpler tool focused on common cleaning tasks:
 
 ```bash
 # Remove a file by name

--- a/Git/troubleshooting-and-recovery.md
+++ b/Git/troubleshooting-and-recovery.md
@@ -345,7 +345,7 @@ git filter-repo --subdirectory-filter services/auth
 
 ### BFG Repo-Cleaner
 
-[**BFG**](https://reclaimtheremote.com/bfg-repo-cleaner/) is simpler for common tasks:
+[**BFG**](https://rtyley.github.io/bfg-repo-cleaner/) is simpler for common tasks:
 
 ```bash
 # Remove all files larger than 100MB from history
@@ -617,7 +617,7 @@ solution: |
 - [Pro Git - Chapter 7: Git Tools](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection) - stashing, searching, rewriting, debugging
 - [Git LFS Documentation](https://git-lfs.com/) - large file storage setup and usage
 - [git-filter-repo Documentation](https://github.com/newren/git-filter-repo) - history rewriting tool
-- [BFG Repo-Cleaner Documentation](https://reclaimtheremote.com/bfg-repo-cleaner/) - simple history cleaning
+- [BFG Repo-Cleaner Documentation](https://rtyley.github.io/bfg-repo-cleaner/) - simple history cleaning
 - [Official git-fsck documentation](https://git-scm.com/docs/git-fsck) - repository integrity verification
 
 ---

--- a/Linux Essentials/log-management.md
+++ b/Linux Essentials/log-management.md
@@ -651,7 +651,7 @@ solution: |
 ## Further Reading
 
 - [journalctl man page](https://www.freedesktop.org/software/systemd/man/journalctl.html) - complete journal query reference
-- [rsyslog Documentation](https://www.rsyslog.com/doc/master/) - rsyslog configuration and module reference
+- [rsyslog Documentation](https://www.rsyslog.com/doc/) - rsyslog configuration and module reference
 - [logrotate man page](https://man7.org/linux/man-pages/man8/logrotate.8.html) - log rotation configuration reference
 - [jq Manual](https://jqlang.github.io/jq/manual/) - JSON processing tool documentation
 - [Arch Wiki: systemd/Journal](https://wiki.archlinux.org/title/Systemd/Journal) - practical journal configuration guide

--- a/Linux Essentials/regular-expressions.md
+++ b/Linux Essentials/regular-expressions.md
@@ -668,7 +668,7 @@ solution: |
 - [grep man page](https://man7.org/linux/man-pages/man1/grep.1.html) - grep options and regex support reference
 - [POSIX Regular Expressions](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html) - official BRE and ERE specification
 - [perlre man page](https://perldoc.perl.org/perlre) - Perl regex reference (the basis for PCRE)
-- [Arch Wiki: Regular Expressions](https://wiki.archlinux.org/title/Regular_expression) - practical quick reference
+- [GNU grep Manual: Regular Expressions](https://www.gnu.org/software/grep/manual/html_node/Regular-Expressions.html) - practical quick reference for BRE, ERE, and the GNU extensions
 
 ---
 

--- a/Linux Essentials/user-and-group-management.md
+++ b/Linux Essentials/user-and-group-management.md
@@ -443,7 +443,7 @@ Both give you a root shell, but they work differently:
 
 ## PAM Basics
 
-The **Pluggable Authentication Modules** ([**PAM**](https://www.linux-pam.org/)) framework controls how authentication works on Linux. Every program that needs to verify a user's identity - `login`, `sshd`, `sudo`, `su` - goes through PAM.
+The **Pluggable Authentication Modules** ([**PAM**](https://github.com/linux-pam/linux-pam)) framework controls how authentication works on Linux. Every program that needs to verify a user's identity - `login`, `sshd`, `sudo`, `su` - goes through PAM.
 
 ### How PAM Works
 
@@ -659,7 +659,7 @@ solution: |
 - [usermod man page](https://man7.org/linux/man-pages/man8/usermod.8.html) - user account modification reference
 - [shadow(5) man page](https://man7.org/linux/man-pages/man5/shadow.5.html) - /etc/shadow file format
 - [sudoers man page](https://www.sudo.ws/docs/man/sudoers.man/) - sudo configuration reference
-- [Linux-PAM Documentation](https://www.linux-pam.org/) - PAM module reference and guides
+- [Linux-PAM](https://github.com/linux-pam/linux-pam) - upstream PAM source, module documentation, and release notes
 - [Arch Wiki: Users and groups](https://wiki.archlinux.org/title/Users_and_groups) - comprehensive practical reference
 - [NIST Password Guidelines (SP 800-63B)](https://pages.nist.gov/800-63-3/sp800-63b.html) - modern password policy recommendations
 

--- a/check-links.sh
+++ b/check-links.sh
@@ -12,10 +12,16 @@
 
 set -uo pipefail
 
+# Resolve the site argument against the caller's directory before moving to the
+# repo root, or a relative path from anywhere else would silently resolve here.
+SITE="${1:-site}"
+case "$SITE" in
+  /*) ;;
+  *)  SITE="$PWD/$SITE" ;;
+esac
+
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_ROOT"
-
-SITE="${1:-site}"
 JOBS="${LINK_CHECK_JOBS:-8}"
 UA="Mozilla/5.0 (compatible; RunbookLinkCheck/1.0; +https://runbook.fyi/)"
 # Some hosts (gnu.org among them) reject a request with no Accept header
@@ -127,8 +133,11 @@ retry_in=$(mktemp)
 retry_out=$(mktemp)
 trap 'rm -f "${results:?}" "${retry_in:?}" "${retry_out:?}"' EXIT
 
-printf '%s\n' "$urls" \
-  | xargs -P "$JOBS" -I{} bash -c 'check_url "$@"' _ {} \
+# NUL-separate: xargs still treats quotes as special without -0, so a single URL
+# containing an apostrophe (ordinary in article slugs) aborts the whole run with
+# "unterminated quote" and leaves the remaining links unchecked.
+printf '%s\n' "$urls" | tr '\n' '\0' \
+  | xargs -0 -P "$JOBS" -I{} bash -c 'check_url "$@"' _ {} \
   > "$results"
 
 # Hosts that throttle by connection see the parallel pass as a burst and drop
@@ -165,5 +174,13 @@ if [ "$broken" -gt 0 ]; then
 fi
 
 echo "$ok ok, $blocked blocked, $broken broken (of $count checked)"
+
+# Postcondition: every extracted URL must be accounted for. If the scan died
+# partway, the counts above would still read like a clean run.
+if [ "$((ok + blocked + broken))" -ne "$count" ]; then
+  echo
+  echo "FAIL: $((ok + blocked + broken)) results for $count URLs - the scan did not finish" >&2
+  exit 1
+fi
 
 [ "$broken" -eq 0 ]

--- a/check-links.sh
+++ b/check-links.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Robworks Software LLC
+#
+# External link checker for the built site.
+#
+# Deliberately NOT part of verify.sh: this needs network access and depends on
+# third-party uptime, so a failure here does not mean the change under test is
+# broken. It runs on a schedule instead.
+#
+# Usage: ./check-links.sh [site-dir]
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_ROOT"
+
+SITE="${1:-site}"
+JOBS="${LINK_CHECK_JOBS:-8}"
+UA="Mozilla/5.0 (compatible; RunbookLinkCheck/1.0; +https://runbook.fyi/)"
+# Some hosts (gnu.org among them) reject a request with no Accept header
+# regardless of the user agent. Sending one is enough to be served normally
+# without pretending to be a browser.
+ACCEPT_HDR="Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+export UA ACCEPT_HDR
+
+if [ ! -d "$SITE" ]; then
+  echo "FAIL: site directory '$SITE' not found - run ./setup-docs.sh && mkdocs build first" >&2
+  exit 1
+fi
+
+# Hosts and patterns that are never real targets: local previews, RFC 2606
+# documentation domains, and the placeholders used in contributor docs.
+SKIP_RE='^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|(www\.)?example\.(com|org|net)|your-server|<)'
+# Preconnect hints in the page head are origins, not documents; the bare origin
+# legitimately answers 404.
+SKIP_RE="$SKIP_RE|^https?://fonts\.gstatic\.com/?$"
+# The site's own domain: at scan time the deployed copy may not yet contain
+# pages added in the commit being checked, so self-links are not evidence.
+SELF_RE='^https?://(runbook\.fyi|ringo380\.github\.io)'
+
+urls=$(grep -rhoE 'href="https?://[^"#]+' "$SITE" --include='*.html' \
+  | sed 's/^href="//' \
+  | sort -u \
+  | grep -Ev "$SKIP_RE" \
+  | grep -Ev "$SELF_RE")
+
+count=$(printf '%s\n' "$urls" | grep -c '^https\?://')
+
+# Precondition: a scan that extracted nothing would report zero broken links,
+# which is indistinguishable from a clean run. Refuse to pass on an empty set.
+if [ "$count" -lt 50 ]; then
+  echo "FAIL: only $count external URLs extracted from '$SITE' - extraction is broken" >&2
+  exit 1
+fi
+
+echo "Checking $count unique external links with $JOBS workers"
+echo
+
+curl_reason() {
+  # curl exit codes worth telling apart in the report: a domain that no longer
+  # resolves is content rot, a TLS handshake failure usually is not.
+  case "$1" in
+    6)  echo "DNS: host does not resolve" ;;
+    7)  echo "connection refused or timed out" ;;
+    28) echo "request timed out" ;;
+    35) echo "TLS handshake failed" ;;
+    60) echo "TLS certificate did not validate" ;;
+    *)  echo "curl exit $1" ;;
+  esac
+}
+export -f curl_reason
+
+check_url() {
+  local url="$1" req code out rc
+  # Material's "edit this page" links carry the source path verbatim, so any
+  # directory with a space in its name ("Linux Essentials") produces a URL curl
+  # cannot request. Encode before asking, report the original.
+  req="${url// /%20}"
+
+  # HEAD first: most servers answer it and it costs no body transfer.
+  out=$(curl -s -L -o /dev/null -w '%{http_code} %{exitcode}' \
+    --max-time 25 --connect-timeout 10 --retry 1 --retry-delay 2 \
+    -A "$UA" -H "$ACCEPT_HDR" -g -I "$req" 2>/dev/null)
+  code="${out%% *}"; rc="${out##* }"
+
+  # Plenty of servers refuse HEAD outright. Retry those as a GET so a method
+  # restriction is not reported as a dead link. A ranged GET would be cheaper
+  # but some servers answer one with 415/416, trading one false signal for
+  # another, so take the whole body and discard it.
+  case "$code" in
+    2*|3*|401|402|418|429|999) ;;
+    *)
+      out=$(curl -s -L -o /dev/null -w '%{http_code} %{exitcode}' \
+        --max-time 25 --connect-timeout 10 --retry 1 --retry-delay 2 \
+        -A "$UA" -H "$ACCEPT_HDR" -g "$req" 2>/dev/null)
+      code="${out%% *}"; rc="${out##* }"
+      ;;
+  esac
+
+  # curl writes nothing when it rejects the URL before making a request, and an
+  # empty code would fall through the classification below without a visible
+  # reason. Make that state explicit instead.
+  code="${code:-000}"
+  rc="${rc:-99}"
+
+  # No HTTP response at all: report why, since the fix differs by cause.
+  if [ "$code" = "000" ]; then
+    printf 'BROKEN\t000\t%s\t%s\n' "$url" "$(curl_reason "$rc")"
+    return
+  fi
+
+  case "$code" in
+    2*|3*)       printf 'OK\t%s\t%s\n' "$code" "$url" ;;
+    401|402|403|418|429|999)
+      # Bot detection and rate limits, not broken content: freedesktop.org
+      # answers 418 to anything that is not a browser, and metacpan.org answers
+      # 402 to non-browser clients. Reported, not failed.
+      printf 'BLOCKED\t%s\t%s\n' "$code" "$url" ;;
+    *)           printf 'BROKEN\t%s\t%s\n' "$code" "$url" ;;
+  esac
+}
+export -f check_url
+
+results=$(mktemp)
+retry_in=$(mktemp)
+retry_out=$(mktemp)
+trap 'rm -f "${results:?}" "${retry_in:?}" "${retry_out:?}"' EXIT
+
+printf '%s\n' "$urls" \
+  | xargs -P "$JOBS" -I{} bash -c 'check_url "$@"' _ {} \
+  > "$results"
+
+# Hosts that throttle by connection see the parallel pass as a burst and drop
+# the extra sockets, which looks identical to a dead host (code 000). Recheck
+# every failure serially before believing it.
+grep '^BROKEN' "$results" | cut -f3 > "$retry_in"
+if [ -s "$retry_in" ]; then
+  echo "Rechecking $(wc -l < "$retry_in" | tr -d ' ') failures serially"
+  echo
+  while IFS= read -r url; do
+    check_url "$url"
+    sleep 1
+  done < "$retry_in" > "$retry_out"
+  grep -v '^BROKEN' "$results" > "$results.keep"
+  cat "$results.keep" "$retry_out" > "$results"
+  rm -f "$results.keep"
+fi
+
+blocked=$(grep -c '^BLOCKED' "$results")
+broken=$(grep -c '^BROKEN' "$results")
+ok=$(grep -c '^OK' "$results")
+
+if [ "$blocked" -gt 0 ]; then
+  echo "Blocked by the remote host (not treated as failures):"
+  grep '^BLOCKED' "$results" | sort -k3 | awk -F'\t' '{printf "  %s  %s\n", $2, $3}'
+  echo
+fi
+
+if [ "$broken" -gt 0 ]; then
+  echo "Broken links:"
+  grep '^BROKEN' "$results" | sort -k3 \
+    | awk -F'\t' '{ printf "  %s  %s%s\n", $2, $3, ($4 == "" ? "" : "  (" $4 ")") }'
+  echo
+fi
+
+echo "$ok ok, $blocked blocked, $broken broken (of $count checked)"
+
+[ "$broken" -eq 0 ]


### PR DESCRIPTION
Closes #117. Also closes #125.

## Link checker

`check-links.sh` scans the built `site/` for external links and reports the ones that are gone. It runs weekly from `.github/workflows/link-check.yml`, not on every PR - link rot is unrelated to the change under test, and bot walls and rate limits would fail builds for reasons a contributor cannot fix. On failure the workflow opens an issue, or comments on the existing one rather than filing duplicates. It is also runnable on demand via `workflow_dispatch`.

Getting to a trustworthy signal took several passes. The first run reported 272 broken links; 268 of those were the checker's fault:

- 8-way concurrency made throttling hosts drop connections, which looks identical to a dead host. Failures are now rechecked serially before being believed.
- freedesktop.org answers 418 and metacpan.org answers 402 to any non-browser client. Those are reported as blocked, not broken.
- Ranged GETs drew 415 from some servers, so the HEAD fallback now issues a plain GET.
- curl glob-expanded the `[Feedback]` in every per-page feedback URL and returned an empty status, which silently classified ~100 live links as broken. Fixed with `-g`.
- Trailing-punctuation stripping ate the closing paren off Wikipedia URLs.
- gnu.org rejects requests with no `Accept` header regardless of user agent.

The checker was verified by injecting a known-404 URL and a known-good URL into a copy of the site: it reported the bad one and left the good one alone. It also refuses to pass if extraction yields fewer than 50 URLs, so an extraction bug cannot masquerade as a clean run.

## Content fixes

The remaining 23 were real:

- BFG Repo-Cleaner, iodine, and DNS Flag Day moved or changed host
- GitHub Learning Lab was retired; replaced with GitHub Skills
- `perl.community` and `cpanprc.org` no longer resolve
- `linux-pam.org` negotiates TLS too old for current clients; now points at the upstream repository
- catb.org and one Flickr photo credit now use archived copies, so the CC attribution survives
- perldoc `perlio`, the Redis data-types tutorial, the Arch Wiki regex page, rsyslog master docs, and the Manning Minimal Perl page all moved
- Percona deleted the PDRT repository. That guide told readers to `git clone` a URL that 404s, so the install section now explains the tool is unmaintained and only community copies survive, with a warning about running an unofficial byte-level parser against damaged data. The build steps still anchor at `/root/pdrt`, which the rest of the guide depends on.
- MySQL Utilities reached end of life in 2018 and its documentation is gone

Current state: 800 ok, 139 blocked, 4 broken. The four are `cheat.sh` (500) and `crt.sh` (502), both real services having a bad day, and the project board (below).

## Issue templates

`new-guide.yml` was missing Nginx, Security, and Docker entirely. Added those plus Kubernetes and CI/CD as requested. `content-improvement.yml` was audited against the nav - all 77 guides are present.

## Needs your decision

The homepage roadmap card links to project board #20, which is private, so every visitor gets a 404. Either make the board public or point the card somewhere else - I did not change board visibility.

`./verify.sh` passes.