### PR TITLE
fix(admin): load dashboard after the auth chain, drop comments from the admin page

### DIFF
--- a/admin.md
+++ b/admin.md
@@ -1,6 +1,7 @@
 ---
 template: admin.html
 sitemap_exclude: true
+comments: false
 search:
   exclude: true
 ---
@@ -10,5 +11,3 @@ search:
 <div id="admin-root" role="region" aria-label="Admin dashboard" aria-live="polite">
 <p id="admin-status">Checking authorization...</p>
 </div>
-
-<script src="../assets/javascripts/components/admin/dashboard.js" defer></script>

--- a/assets/javascripts/components/admin/dashboard.js
+++ b/assets/javascripts/components/admin/dashboard.js
@@ -89,16 +89,36 @@
     ));
   }
 
+  var inFlight = false;
+
   async function init() {
     var root = document.getElementById("admin-root");
     if (!root) return;
+    if (inFlight) return;
     var status = document.getElementById("admin-status");
 
-    if (!window.RunbookAuth) {
-      if (status) status.textContent = "Authentication unavailable.";
+    // No RunbookAuth, or no client behind it, means the auth chain itself
+    // failed to load. That is distinct from being signed out, which is
+    // something the reader can act on.
+    var client = window.RunbookAuth && window.RunbookAuth.getClient();
+    if (!client) {
+      if (status) {
+        status.textContent =
+          "Sign-in is unavailable right now. Reload the page to try again.";
+      }
       return;
     }
-    var session = await window.RunbookAuth.getClient().auth.getSession();
+
+    inFlight = true;
+    try {
+      await load(root, status, client);
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  async function load(root, status, client) {
+    var session = await client.auth.getSession();
     var token = session.data.session && session.data.session.access_token;
     if (!token) {
       if (status) status.textContent = "Sign in to view this page.";

--- a/assets/javascripts/interactive.js
+++ b/assets/javascripts/interactive.js
@@ -28,6 +28,7 @@
     progress: "assets/javascripts/components/progress.js",
     "topic-cards": "assets/javascripts/components/topic-cards.js",
     "auth-ui": "assets/javascripts/components/auth-ui.js",
+    "admin-dashboard": "assets/javascripts/components/admin/dashboard.js",
   };
 
   const loadedScripts = new Set();
@@ -126,6 +127,12 @@
         loadScript(COMPONENT_SCRIPTS["topic-cards"]).catch(() => {});
         // Always load auth UI (self-initializes in header)
         loadScript(COMPONENT_SCRIPTS["auth-ui"]).catch(() => {});
+        // Admin dashboard, only on the admin page. Loaded here rather than
+        // from a script tag in admin.md so it runs after the auth chain has
+        // resolved and window.RunbookAuth exists.
+        if (document.getElementById("admin-root")) {
+          loadScript(COMPONENT_SCRIPTS["admin-dashboard"]).catch(() => {});
+        }
       })
       .catch(() => {
         // Storage failed to load - initialize components without it
@@ -135,6 +142,12 @@
           .then(() => loadScript("assets/javascripts/lib/topics.js"))
           .then(() => loadScript("assets/javascripts/lib/analytics-journey.js"))
           .catch(() => {});
+        // Auth never loads on this path, so the dashboard can only report the
+        // failure. Load it anyway so the page says so instead of sitting on
+        // its "Checking authorization..." placeholder.
+        if (document.getElementById("admin-root")) {
+          loadScript(COMPONENT_SCRIPTS["admin-dashboard"]).catch(() => {});
+        }
         const types = Object.keys(COMPONENT_SCRIPTS);
         types.forEach((type) => {
           const divs = document.querySelectorAll(`.interactive-${type}`);

--- a/assets/javascripts/lib/auth.js
+++ b/assets/javascripts/lib/auth.js
@@ -54,10 +54,11 @@
         const {
           data: { session },
         } = await sb.auth.getSession();
-        if (session) {
-          currentUser = session.user;
-          fireAuthChanged(currentUser, "INITIAL_SESSION");
-        }
+        currentUser = session ? session.user : null;
+        // Fire for the signed-out case too. Listeners that registered before
+        // auth finished loading need a resolved state, not silence, or they
+        // sit on their placeholder text forever.
+        fireAuthChanged(currentUser, "INITIAL_SESSION");
       } catch (e) {
         console.warn("[Runbook] Failed to get auth session:", e);
       }

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: MIT | Copyright (c) 2025-2026 Robworks Software LLC -->
 <!-- Giscus comments - GitHub Discussions-backed -->
-{% if not page.is_homepage %}
+{% if not page.is_homepage and page.meta.get("comments", true) %}
   <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
 
   <script

--- a/tests/js/admin-dashboard.test.js
+++ b/tests/js/admin-dashboard.test.js
@@ -80,3 +80,70 @@ describe("admin dashboard renderer", () => {
     expect(root.textContent).toContain("7");
   });
 });
+
+describe("admin dashboard auth states", () => {
+  let status;
+
+  function mountAdminRoot() {
+    const el = document.createElement("div");
+    el.id = "admin-root";
+    status = document.createElement("p");
+    status.id = "admin-status";
+    status.textContent = "Checking authorization...";
+    el.appendChild(status);
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function sessionClient(accessToken) {
+    return {
+      auth: {
+        getSession: async () => ({
+          data: { session: accessToken ? { access_token: accessToken } : null },
+        }),
+      },
+    };
+  }
+
+  beforeEach(async () => {
+    mountAdminRoot();
+    await loadComponent("admin/dashboard");
+  });
+
+  afterEach(() => {
+    delete window.RunbookAuth;
+    cleanup();
+  });
+
+  it("tells a signed-out reader to sign in rather than reporting a failure", async () => {
+    window.RunbookAuth = { getClient: () => sessionClient(null) };
+    await window.RunbookAdminDashboard.init();
+    expect(status.textContent).toBe("Sign in to view this page.");
+  });
+
+  it("distinguishes a broken auth chain from being signed out", async () => {
+    // RunbookAuth absent entirely: the chain failed to load.
+    await window.RunbookAdminDashboard.init();
+    expect(status.textContent).toContain("unavailable");
+    expect(status.textContent).not.toBe("Sign in to view this page.");
+  });
+
+  it("treats a present RunbookAuth with no client as a broken chain", async () => {
+    window.RunbookAuth = { getClient: () => null };
+    await window.RunbookAdminDashboard.init();
+    expect(status.textContent).toContain("unavailable");
+  });
+
+  it("reports unauthorized when the edge function rejects an admin check", async () => {
+    window.RunbookAuth = { getClient: () => sessionClient("jwt") };
+    const calls = [];
+    global.fetch = async (url) => {
+      calls.push(url);
+      return { ok: false };
+    };
+    await window.RunbookAdminDashboard.init();
+    expect(calls[0]).toContain("/health");
+    expect(status.textContent).toBe("Not authorized.");
+    delete global.fetch;
+  });
+});


### PR DESCRIPTION
Fixes #158 and #159.

## #158 - "Authentication unavailable" on /admin/

`admin.md` loaded `dashboard.js` from a raw `<script defer>` tag, which the built page placed at line ~4201 while `interactive.js` sat at ~4494. `interactive.js` owns the chain that defines `window.RunbookAuth`, so `dashboard.js` `init()` always ran first and always took the no-auth branch. The `runbook:auth-changed` listener was supposed to recover, but `auth.js` fired that event only when a session already existed, so a signed-out reader got silence and the message stuck.

- `admin/dashboard.js` is now registered in `COMPONENT_SCRIPTS` and loaded from `interactive.js` only when `#admin-root` exists, after the auth chain settles. CLAUDE.md already required this for self-initializing components; this one had been missed.
- It also loads on the storage-failure path, where auth never comes up, so the page reports the failure instead of sitting on "Checking authorization..." forever.
- `auth.js` now fires `runbook:auth-changed` for the signed-out initial state. Both existing listeners (`sync.js:211`, `auth-ui.js:173`) already handle a null user, so this is safe.
- `dashboard.js` separates the two states: no auth client means the chain is broken ("Sign-in is unavailable right now. Reload the page to try again."), no session means a signed-out reader ("Sign in to view this page."). Added a re-entrancy guard since the event now fires more often.

## #159 - Giscus thread on /admin/

`overrides/partials/comments.html` only excluded the homepage. It now honors a `comments: false` front matter key, which `admin.md` sets. Chose the front matter opt-out over hardcoding a second path so future utility pages can suppress the thread without touching the partial.

## Verification

`./verify.sh` passes end to end: pytest, vitest, deno, strict MkDocs build, and the site invariants.

Built-HTML assertions on `site/admin/index.html`: no `giscus.app/client.js`, no `id="__comments"`, no raw `dashboard.js` script tag, `#admin-root` still present. Control checks confirm the opt-out is targeted, not a site-wide disable: `site/Git/collaboration-workflows/index.html` still carries Giscus, and the homepage is still excluded as before.

Four new tests cover the auth states. Mutation matrix, each row failing exactly one intended test with no collateral, baseline green before and after:

| Mutation | Result |
|---|---|
| Collapse the client guard to a bare `RunbookAuth` check | fails "treats a present RunbookAuth with no client as a broken chain" |
| Signed-out path reports the failure message instead | fails "tells a signed-out reader to sign in rather than reporting a failure" |
| Skip the `/health` authorization check | fails "reports unauthorized when the edge function rejects an admin check" |