### PR TITLE
fix(site): stop a blocked analytics.js from taking down sign-in

### DIFF
--- a/assets/javascripts/interactive.js
+++ b/assets/javascripts/interactive.js
@@ -66,29 +66,44 @@
     });
   }
 
+  // Analytics is optional and is a common ad-blocker target: lib/analytics.js
+  // matches filter-list rules for "/analytics.js" and gets blocked outright.
+  // Loading it inside the main .then() chain let one blocked file reject
+  // everything downstream, which took auth down with it. Swallow the failure
+  // here so an optional script can never break a required one. Every
+  // RunbookAnalytics call site is already guarded on the global existing.
+  function loadOptionalScript(src) {
+    return loadScript(src).catch((err) => {
+      console.warn("[Runbook] Optional script unavailable:", src, err.message || err);
+    });
+  }
+
+  // Auth must not depend on analytics or storage having loaded, so it lives in
+  // its own chain that both the normal and storage-failure paths call.
+  function loadAuthChain() {
+    return loadScript("assets/javascripts/lib/supabase-config.js")
+      .then(() => {
+        const cdnUrl = window.RunbookSupabaseConfig && window.RunbookSupabaseConfig.cdnUrl;
+        return cdnUrl ? loadExternalScript(cdnUrl) : Promise.reject(new Error("No CDN URL"));
+      })
+      .then(() => loadScript("assets/javascripts/lib/auth.js"))
+      .then(() => loadScript("assets/javascripts/lib/sync.js"))
+      .then(() => {
+        if (window.RunbookAuth) return window.RunbookAuth.init();
+      })
+      .catch((err) => {
+        console.warn("[Runbook] Auth unavailable:", err.message || err);
+      });
+  }
+
   function initComponents() {
     // Load storage first - components depend on window.RunbookStorage
     loadScript("assets/javascripts/lib/storage.js")
-      .then(() => loadScript("assets/javascripts/lib/analytics.js"))
-      .then(() => loadScript("assets/javascripts/lib/analytics-observers.js"))
-      .then(() => loadScript("assets/javascripts/lib/topics.js"))
-      .then(() => loadScript("assets/javascripts/lib/analytics-journey.js"))
-      .then(() =>
-        // Load auth chain (graceful degradation - if any step fails, site works without auth)
-        loadScript("assets/javascripts/lib/supabase-config.js")
-          .then(() => {
-            const cdnUrl = window.RunbookSupabaseConfig && window.RunbookSupabaseConfig.cdnUrl;
-            return cdnUrl ? loadExternalScript(cdnUrl) : Promise.reject(new Error("No CDN URL"));
-          })
-          .then(() => loadScript("assets/javascripts/lib/auth.js"))
-          .then(() => loadScript("assets/javascripts/lib/sync.js"))
-          .then(() => {
-            if (window.RunbookAuth) return window.RunbookAuth.init();
-          })
-          .catch((err) => {
-            console.warn("[Runbook] Auth unavailable:", err.message || err);
-          })
-      )
+      .then(() => loadOptionalScript("assets/javascripts/lib/analytics.js"))
+      .then(() => loadOptionalScript("assets/javascripts/lib/analytics-observers.js"))
+      .then(() => loadOptionalScript("assets/javascripts/lib/topics.js"))
+      .then(() => loadOptionalScript("assets/javascripts/lib/analytics-journey.js"))
+      .then(() => loadAuthChain())
       .then(() => {
         // Find all interactive divs on the page
         const types = Object.keys(COMPONENT_SCRIPTS);
@@ -135,19 +150,20 @@
         }
       })
       .catch(() => {
-        // Storage failed to load - initialize components without it
+        // Only reachable when storage.js itself failed: every optional step
+        // above swallows its own error now.
         console.warn("[Runbook] Storage unavailable, progress will not persist");
-        loadScript("assets/javascripts/lib/analytics.js")
-          .then(() => loadScript("assets/javascripts/lib/analytics-observers.js"))
-          .then(() => loadScript("assets/javascripts/lib/topics.js"))
-          .then(() => loadScript("assets/javascripts/lib/analytics-journey.js"))
-          .catch(() => {});
-        // Auth never loads on this path, so the dashboard can only report the
-        // failure. Load it anyway so the page says so instead of sitting on
-        // its "Checking authorization..." placeholder.
-        if (document.getElementById("admin-root")) {
-          loadScript(COMPONENT_SCRIPTS["admin-dashboard"]).catch(() => {});
-        }
+        loadOptionalScript("assets/javascripts/lib/analytics.js")
+          .then(() => loadOptionalScript("assets/javascripts/lib/analytics-observers.js"))
+          .then(() => loadOptionalScript("assets/javascripts/lib/topics.js"))
+          .then(() => loadOptionalScript("assets/javascripts/lib/analytics-journey.js"));
+        // Sign-in does not need storage, so still bring up auth here.
+        loadAuthChain().then(() => {
+          loadScript(COMPONENT_SCRIPTS["auth-ui"]).catch(() => {});
+          if (document.getElementById("admin-root")) {
+            loadScript(COMPONENT_SCRIPTS["admin-dashboard"]).catch(() => {});
+          }
+        });
         const types = Object.keys(COMPONENT_SCRIPTS);
         types.forEach((type) => {
           const divs = document.querySelectorAll(`.interactive-${type}`);

--- a/tests/js/interactive-loader.test.js
+++ b/tests/js/interactive-loader.test.js
@@ -1,0 +1,131 @@
+/**
+ * Regression tests for the interactive.js script-loading chain.
+ *
+ * lib/analytics.js matches common ad-blocker filter rules for "/analytics.js"
+ * and is blocked outright in the browser for a large share of readers. It used
+ * to sit inside the main .then() chain, so that one blocked file rejected
+ * everything downstream and took the auth chain with it: no sign-in control
+ * anywhere on the site, and the admin dashboard reporting a broken auth chain.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const SOURCE = readFileSync(
+  resolve(__dirname, "../../assets/javascripts/interactive.js"),
+  "utf8"
+);
+
+/**
+ * Run interactive.js with a fake script loader. Scripts whose src matches an
+ * entry in `blocked` fire onerror, like a blocked request; everything else
+ * fires onload. Returns the list of every src the page attempted.
+ */
+async function runLoader(blocked = []) {
+  const attempted = [];
+  const realAppend = document.head.appendChild.bind(document.head);
+
+  vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
+    if (node.tagName !== "SCRIPT" || !node.src) return realAppend(node);
+    attempted.push(node.src);
+    const isBlocked = blocked.some((b) => node.src.includes(b));
+    // Async, like a real network response.
+    setTimeout(() => {
+      if (isBlocked) {
+        if (node.onerror) node.onerror(new Event("error"));
+        return;
+      }
+      // Reproduce the one side effect the chain reads back: without it the
+      // auth chain bails on "No CDN URL" and never reaches auth.js, which
+      // would make these tests pass for the wrong reason.
+      if (node.src.includes("lib/supabase-config.js")) {
+        window.RunbookSupabaseConfig = {
+          url: "https://example.supabase.co",
+          anonKey: "anon",
+          cdnUrl: "https://cdn.example/supabase.js",
+        };
+      }
+      if (node.onload) node.onload();
+    }, 0);
+    return node;
+  });
+
+  // eslint-disable-next-line no-new-func
+  new Function(SOURCE)();
+
+  // Let the promise chain drain.
+  for (let i = 0; i < 40; i++) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  return attempted;
+}
+
+describe("interactive.js loading chain", () => {
+  beforeEach(() => {
+    window.__md_scope = "https://runbook.fyi/";
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete window.__md_scope;
+    delete window.RunbookSupabaseConfig;
+  });
+
+  it("reaches the auth chain when nothing is blocked", async () => {
+    const attempted = await runLoader();
+    expect(attempted.some((s) => s.includes("lib/supabase-config.js"))).toBe(true);
+    // Baseline: the harness can actually get all the way to auth.js. Without
+    // this the blocked-analytics cases below could pass for the wrong reason.
+    expect(attempted.some((s) => s.includes("lib/auth.js"))).toBe(true);
+  });
+
+  it("still reaches the auth chain when analytics.js is blocked", async () => {
+    const attempted = await runLoader(["lib/analytics.js"]);
+    expect(attempted.some((s) => s.includes("lib/analytics.js"))).toBe(true);
+    expect(attempted.some((s) => s.includes("lib/supabase-config.js"))).toBe(true);
+    expect(attempted.some((s) => s.includes("lib/auth.js"))).toBe(true);
+  });
+
+  it("keeps the normal path when analytics.js is blocked", async () => {
+    // The failure path skips progress tracking and topic cards. A blocked
+    // optional script must not divert us into it: the run should look exactly
+    // like an unblocked one apart from analytics itself.
+    const attempted = await runLoader(["lib/analytics.js"]);
+    expect(attempted.some((s) => s.includes("components/progress.js"))).toBe(true);
+    expect(attempted.some((s) => s.includes("components/topic-cards.js"))).toBe(true);
+    expect(console.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("Storage unavailable")
+    );
+  });
+
+  it("still reaches the auth chain when every optional lib is blocked", async () => {
+    const attempted = await runLoader([
+      "lib/analytics.js",
+      "lib/analytics-observers.js",
+      "lib/analytics-journey.js",
+      "lib/topics.js",
+    ]);
+    expect(attempted.some((s) => s.includes("lib/supabase-config.js"))).toBe(true);
+    expect(attempted.some((s) => s.includes("lib/auth.js"))).toBe(true);
+  });
+
+  it("brings up auth even when storage itself is blocked", async () => {
+    const attempted = await runLoader(["lib/storage.js"]);
+    expect(attempted.some((s) => s.includes("lib/supabase-config.js"))).toBe(true);
+    expect(attempted.some((s) => s.includes("components/auth-ui.js"))).toBe(true);
+  });
+
+  it("loads the admin dashboard only when #admin-root is on the page", async () => {
+    const without = await runLoader();
+    expect(without.some((s) => s.includes("admin/dashboard.js"))).toBe(false);
+
+    const root = document.createElement("div");
+    root.id = "admin-root";
+    document.body.appendChild(root);
+    const withRoot = await runLoader();
+    expect(withRoot.some((s) => s.includes("admin/dashboard.js"))).toBe(true);
+    root.remove();
+  });
+});


### PR DESCRIPTION
Fixes #161.

Found while verifying the /admin/ fixes in Chrome. The admin page reported a broken auth chain, and the cause turned out to be site-wide rather than admin-specific.

## What was happening

`lib/analytics.js` matches ad-blocker filter rules for `/analytics.js` and is blocked in the browser. `interactive.js` chained every library load with `.then()`, so that one blocked file rejected everything downstream, including the auth chain.

On a live guide page with an ad blocker: no `window.RunbookAuth`, no `window.RunbookSync`, no sign-in control in the header, no progress sync. The only console output was `[Runbook] Storage unavailable, progress will not persist`, which was wrong - `window.RunbookStorage` was present. A single trailing `.catch()` attributed every rejection to storage.

A per-script probe from the page confirmed `lib/analytics.js` was the only failure, while `analytics-observers.js` and `analytics-journey.js` loaded fine, so the rule targets the filename specifically. `curl` returns 200, so it is client-side blocking.

## Changes

- `loadOptionalScript()` swallows its own failure; the four analytics/topics libs use it. An optional script can no longer reject the chain. Every `RunbookAnalytics` call site is already guarded on the global existing, so a missing module degrades cleanly - I checked all 15 files, and the apparent unguarded sites in `progress.js` sit inside an enclosing `!wasAlreadyRead && window.RunbookAnalytics` guard.
- `loadAuthChain()` extracted and also called from the storage-failure path. Sign-in does not depend on storage. That path now brings up `auth-ui` too.
- The failure-path warning is corrected and is now only reachable when `storage.js` itself fails.

## Verification

`./verify.sh` passes: 43 Python, 102 JS, 20 Deno, strict MkDocs build, site invariants.

New `tests/js/interactive-loader.test.js` drives `interactive.js` with a fake script loader that fires `onerror` for a chosen blocklist.

Mutation matrix, each row failing exactly one intended test, baseline green before and after:

| Mutation | Result |
|---|---|
| Put analytics.js back in the hard chain | fails "keeps the normal path when analytics.js is blocked" |
| Drop the auth chain from the storage-failure path | fails "brings up auth even when storage itself is blocked" |
| Load the admin dashboard unconditionally | fails "loads the admin dashboard only when #admin-root is on the page" |

Worth recording: the first version of these tests had a **zero row** - reverting the analytics fix broke nothing, because the failure path now also loads auth, so auth came up either way and the test passed for the wrong reason. The test was rewritten to assert the actual user-visible loss on that path, which is that `progress.js` and `topic-cards.js` get skipped. The harness also needed to reproduce `supabase-config.js`s side effect, or the chain bailed on "No CDN URL" before reaching `auth.js` and the assertions would have been vacuous.

## Not fixed here

GA4 events are still lost for ad-blocking readers, since the file is still blocked. Renaming it to something filter lists do not match would restore that data. Noted in #161 as a follow-up.