### PR TITLE
fix(site): read consent from the key Material actually writes

### DIFF
--- a/overrides/partials/integrations/analytics/google.html
+++ b/overrides/partials/integrations/analytics/google.html
@@ -32,32 +32,60 @@
     gtag("js", new Date());
     gtag("config", property);
 
-    // Material stores consent as JSON in localStorage["__consent"], e.g.
-    // {"analytics": true}. The cookie name is defined under
-    // theme.consent.cookies.analytics in mkdocs.yml.
+    // Material stores consent as JSON under a key SCOPED BY SITE PATH, not
+    // under a bare "__consent". On runbook.fyi the real key is "/.__consent"
+    // (the sibling "/.__palette" key is written the same way). Reading the
+    // unscoped name returned null even for visitors who had accepted, so the
+    // "granted" update below was never sent and GA4 only ever saw cookieless
+    // consent-mode pings. Check every key that could hold it rather than
+    // hardcoding one guess about Material's prefix.
     var granted = false;
-    function hasAnalyticsConsent() {
+    function readConsent() {
+      var candidates = ["__consent"];
       try {
-        var c = JSON.parse(localStorage.getItem("__consent"));
-        return !!(c && c.analytics);
+        for (var i = 0; i < localStorage.length; i++) {
+          var k = localStorage.key(i);
+          if (k && k !== "__consent" && k.slice(-10) === ".__consent") {
+            candidates.push(k);
+          }
+        }
       } catch (e) {
-        return false;
+        // localStorage can throw outright (Safari private mode, blocked
+        // third-party context). Fall through with what we have.
       }
+      for (var j = 0; j < candidates.length; j++) {
+        try {
+          var c = JSON.parse(localStorage.getItem(candidates[j]));
+          if (c && c.analytics) return true;
+        } catch (e) {
+          // Malformed value under one key must not hide a valid one.
+        }
+      }
+      return false;
     }
     function syncConsent() {
       if (granted) return;
-      if (hasAnalyticsConsent()) {
+      if (readConsent()) {
         gtag("consent", "update", { analytics_storage: "granted" });
         granted = true;
-        if (poll) { clearInterval(poll); poll = null; }
+        stopPolling();
       }
+    }
+    function stopPolling() {
+      if (poll) { clearInterval(poll); poll = null; }
     }
 
     // Returning visitors who accepted previously.
     syncConsent();
     // Catch a same-tab "Accept" without a page reload (Material does not
     // reload on consent change, and the storage event is cross-tab only).
-    var poll = granted ? null : setInterval(syncConsent, 1000);
+    // Bounded: a visitor who has not decided within two minutes is not going
+    // to be caught by a timer that runs for the life of the tab.
+    var ticks = 0;
+    var poll = granted ? null : setInterval(function () {
+      if (++ticks > 120) return stopPolling();
+      syncConsent();
+    }, 1000);
   })();
 </script>
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.extra.analytics.property }}"></script>

--- a/tests/js/consent-mode.test.js
+++ b/tests/js/consent-mode.test.js
@@ -1,0 +1,159 @@
+/**
+ * Tests for the Consent Mode v2 partial.
+ *
+ * overrides/partials/integrations/analytics/google.html read consent from
+ * localStorage["__consent"], but Material writes the key scoped by site path
+ * ("/.__consent" on runbook.fyi). The read always returned null, so the
+ * "granted" consent update was never sent and GA4 recorded only cookieless
+ * pings even for visitors who had explicitly accepted analytics.
+ *
+ * These run the partial's real script, extracted from the template, rather
+ * than a copy of its logic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const PARTIAL = readFileSync(
+  resolve(
+    __dirname,
+    "../../overrides/partials/integrations/analytics/google.html"
+  ),
+  "utf8"
+);
+
+// The consent block is the first inline <script> in the partial.
+const match = PARTIAL.match(/<script>([\s\S]*?)<\/script>/);
+if (!match) throw new Error("Could not extract the consent script");
+const SOURCE = match[1].replace(
+  /\{\{\s*config\.extra\.analytics\.property\s*\}\}/g,
+  "G-TEST"
+);
+
+/** Run the partial's script and return every gtag() call it made. */
+function run() {
+  const calls = [];
+  window.dataLayer = undefined;
+  window.gtag = undefined;
+  // eslint-disable-next-line no-new-func
+  new Function(SOURCE)();
+  // dataLayer.push receives the arguments object from each gtag() call.
+  for (const entry of window.dataLayer || []) {
+    calls.push(Array.from(entry));
+  }
+  return calls;
+}
+
+function granted(calls) {
+  return calls.some(
+    (c) =>
+      c[0] === "consent" &&
+      c[1] === "update" &&
+      c[2] &&
+      c[2].analytics_storage === "granted"
+  );
+}
+
+describe("consent mode partial", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete window.dataLayer;
+    delete window.gtag;
+  });
+
+  it("always defaults analytics_storage to denied", () => {
+    const calls = run();
+    const dflt = calls.find((c) => c[0] === "consent" && c[1] === "default");
+    expect(dflt).toBeDefined();
+    expect(dflt[2].analytics_storage).toBe("denied");
+  });
+
+  it("grants when consent is stored under the path-scoped key", () => {
+    // The real-world case: this is the ONLY key Material writes. If the
+    // partial reads the unscoped name, this test fails.
+    localStorage.setItem(
+      "/.__consent",
+      JSON.stringify({ github: true, analytics: true })
+    );
+    expect(granted(run())).toBe(true);
+  });
+
+  it("grants when consent is stored under a bare key", () => {
+    localStorage.setItem("__consent", JSON.stringify({ analytics: true }));
+    expect(granted(run())).toBe(true);
+  });
+
+  it("grants when the site is served from a subpath", () => {
+    localStorage.setItem(
+      "/guides/.__consent",
+      JSON.stringify({ analytics: true })
+    );
+    expect(granted(run())).toBe(true);
+  });
+
+  it("does not grant when nothing is stored", () => {
+    expect(granted(run())).toBe(false);
+  });
+
+  it("does not grant when analytics was declined", () => {
+    localStorage.setItem(
+      "/.__consent",
+      JSON.stringify({ github: true, analytics: false })
+    );
+    expect(granted(run())).toBe(false);
+  });
+
+  it("only reads consent keys, not every scoped key", () => {
+    // Deliberately consent-shaped, under a key that is not consent. A scan
+    // that matched any scoped key rather than the ".__consent" suffix would
+    // grant here. Material really does write "/.__palette" alongside consent.
+    localStorage.setItem("/.__palette", JSON.stringify({ analytics: true }));
+    expect(granted(run())).toBe(false);
+  });
+
+  it("is not blinded by a malformed value under another key", () => {
+    localStorage.setItem("__consent", "not json");
+    localStorage.setItem("/.__consent", JSON.stringify({ analytics: true }));
+    expect(granted(run())).toBe(true);
+  });
+
+  it("catches a same-tab accept without a reload", () => {
+    const before = run();
+    expect(granted(before)).toBe(false);
+
+    localStorage.setItem("/.__consent", JSON.stringify({ analytics: true }));
+    vi.advanceTimersByTime(2000);
+
+    const after = Array.from(window.dataLayer).map((e) => Array.from(e));
+    expect(granted(after)).toBe(true);
+  });
+
+  it("stops polling once consent is granted", () => {
+    localStorage.setItem("/.__consent", JSON.stringify({ analytics: true }));
+    const clear = vi.spyOn(globalThis, "clearInterval");
+    run();
+    vi.advanceTimersByTime(5000);
+    const updates = Array.from(window.dataLayer)
+      .map((e) => Array.from(e))
+      .filter((c) => c[0] === "consent" && c[1] === "update");
+    // Granted synchronously, so it never starts an interval, and it never
+    // sends the update twice.
+    expect(updates).toHaveLength(1);
+    clear.mockRestore();
+  });
+
+  it("stops polling for a visitor who never decides", () => {
+    run();
+    const clear = vi.spyOn(globalThis, "clearInterval");
+    // Well past the two-minute bound.
+    vi.advanceTimersByTime(200 * 1000);
+    expect(clear).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+    clear.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #165.

## The bug

`overrides/partials/integrations/analytics/google.html` read `localStorage.getItem("__consent")`. Material writes that key **scoped by site path**, so on runbook.fyi it is `/.__consent`. The read always returned `null`, so `gtag("consent", "update", { analytics_storage: "granted" })` was never sent.

Live evidence from a browser on the deployed site:

```
localStorage["/.__consent"]  ->  {"github":true,"analytics":true}   // accepted
localStorage["__consent"]    ->  null                                // what the code read
partialWouldSeeConsent       ->  false                               // its own logic, verbatim
```

A visitor who explicitly accepted analytics was treated as having declined. GA4 returned `204` for the hits but recorded them as cookieless consent-mode pings, which never populate standard or realtime reports.

This is one of the two independent causes of #163. The other is ad blockers dropping `gtag/js` outright, which no GA4-side change addresses and which the first-party design in `specs/2026-07-26-first-party-analytics-design.md` exists to cover.

## The fix

Scan localStorage for any key with the `.__consent` suffix instead of hardcoding one guess at Material's prefix, keeping the bare key as a candidate. A subpath deployment works without further change, and a malformed value under one key no longer hides a valid one under another.

Also bound the recovery poll. It previously ran `setInterval(syncConsent, 1000)` for the life of the tab; it now stops after two minutes.

## Verification

`./verify.sh` passes. Tests run the partial's **real** script, extracted from the template, so they cannot drift from a copy of the logic.

Every assertion is mutation-checked. Six mutations, each breaking exactly one thing:

| Mutation | Tests failed |
|---|---|
| Read only the unscoped key (the original bug) | 5 |
| Unbounded poll | 1 |
| Any stored consent object counts as acceptance | 1 |
| Never latch `granted` | 1 |
| Default `analytics_storage` to granted | 1 |
| Scan every scoped key, not just consent keys | 1 |

No zero rows: one test initially passed in every row, because a `/.__palette` value has no `analytics` field and so was rejected by the value check before the key filter mattered. It was rewritten to store a consent-shaped value under a non-consent key, which is the boundary it was meant to guard, and it now fails under row 6 alone.

Confirmed in the built output rather than only in source: 105 built pages contain the new scan, 0 contain the old unscoped read.