### PR TITLE
fix(ci): stop reporting unreachable hosts as broken links

### DIFF
--- a/check-links.sh
+++ b/check-links.sh
@@ -78,7 +78,7 @@ curl_reason() {
 export -f curl_reason
 
 check_url() {
-  local url="$1" req code out rc
+  local url="$1" maxtime="${2:-25}" req code out rc
   # Material's "edit this page" links carry the source path verbatim, so any
   # directory with a space in its name ("Linux Essentials") produces a URL curl
   # cannot request. Encode before asking, report the original.
@@ -86,7 +86,7 @@ check_url() {
 
   # HEAD first: most servers answer it and it costs no body transfer.
   out=$(curl -s -L -o /dev/null -w '%{http_code} %{exitcode}' \
-    --max-time 25 --connect-timeout 10 --retry 1 --retry-delay 2 \
+    --max-time "$maxtime" --connect-timeout 10 --retry 1 --retry-delay 2 \
     -A "$UA" -H "$ACCEPT_HDR" -g -I "$req" 2>/dev/null)
   code="${out%% *}"; rc="${out##* }"
 
@@ -98,7 +98,7 @@ check_url() {
     2*|3*|401|402|418|429|999) ;;
     *)
       out=$(curl -s -L -o /dev/null -w '%{http_code} %{exitcode}' \
-        --max-time 25 --connect-timeout 10 --retry 1 --retry-delay 2 \
+        --max-time "$maxtime" --connect-timeout 10 --retry 1 --retry-delay 2 \
         -A "$UA" -H "$ACCEPT_HDR" -g "$req" 2>/dev/null)
       code="${out%% *}"; rc="${out##* }"
       ;;
@@ -110,9 +110,21 @@ check_url() {
   code="${code:-000}"
   rc="${rc:-99}"
 
-  # No HTTP response at all: report why, since the fix differs by cause.
+  # No HTTP response at all. Separate content rot from a network path this
+  # runner happens not to have.
+  #
+  # A hostname that no longer resolves, or a certificate that does not
+  # validate, is a problem with the link and stays a failure. A connection
+  # that times out is not: gnu.org answers every one of our links with 200
+  # from a normal client and times out for GitHub's runners, so reporting
+  # those as broken filed an issue listing fourteen live pages. An issue that
+  # is mostly false positives trains the reader to close it unread, which
+  # costs more than the check earns.
   if [ "$code" = "000" ]; then
-    printf 'BROKEN\t000\t%s\t%s\n' "$url" "$(curl_reason "$rc")"
+    case "$rc" in
+      6|60) printf 'BROKEN\t000\t%s\t%s\n' "$url" "$(curl_reason "$rc")" ;;
+      *)    printf 'UNREACHABLE\t000\t%s\t%s\n' "$url" "$(curl_reason "$rc")" ;;
+    esac
     return
   fi
 
@@ -142,27 +154,41 @@ printf '%s\n' "$urls" | tr '\n' '\0' \
 
 # Hosts that throttle by connection see the parallel pass as a burst and drop
 # the extra sockets, which looks identical to a dead host (code 000). Recheck
-# every failure serially before believing it.
-grep '^BROKEN' "$results" | cut -f3 > "$retry_in"
+# every failure serially, and with a longer timeout, before believing it.
+grep -E '^(BROKEN|UNREACHABLE)' "$results" | cut -f3 > "$retry_in"
 if [ -s "$retry_in" ]; then
   echo "Rechecking $(wc -l < "$retry_in" | tr -d ' ') failures serially"
   echo
   while IFS= read -r url; do
-    check_url "$url"
-    sleep 1
+    check_url "$url" 45
+    # Spacing the recheck is the point of doing it serially: a host that
+    # dropped us for bursting will do it again if we burst again. Tests drive
+    # a stub curl and set this to 0.
+    sleep "${LINK_CHECK_RETRY_SLEEP:-1}"
   done < "$retry_in" > "$retry_out"
-  grep -v '^BROKEN' "$results" > "$results.keep"
+  grep -Ev '^(BROKEN|UNREACHABLE)' "$results" > "$results.keep"
   cat "$results.keep" "$retry_out" > "$results"
   rm -f "$results.keep"
 fi
 
 blocked=$(grep -c '^BLOCKED' "$results")
 broken=$(grep -c '^BROKEN' "$results")
+unreachable=$(grep -c '^UNREACHABLE' "$results")
 ok=$(grep -c '^OK' "$results")
 
 if [ "$blocked" -gt 0 ]; then
   echo "Blocked by the remote host (not treated as failures):"
   grep '^BLOCKED' "$results" | sort -k3 | awk -F'\t' '{printf "  %s  %s\n", $2, $3}'
+  echo
+fi
+
+if [ "$unreachable" -gt 0 ]; then
+  echo "Unreachable from this runner (not treated as failures):"
+  grep '^UNREACHABLE' "$results" | sort -k3 \
+    | awk -F'\t' '{ printf "  %s  %s%s\n", $2, $3, ($4 == "" ? "" : "  (" $4 ")") }'
+  echo "  These answered nothing over the network but still resolve in DNS."
+  echo "  Confirm one by hand before editing a guide; a host that blocks this"
+  echo "  network commonly serves the same page fine from a browser."
   echo
 fi
 
@@ -173,13 +199,23 @@ if [ "$broken" -gt 0 ]; then
   echo
 fi
 
-echo "$ok ok, $blocked blocked, $broken broken (of $count checked)"
+echo "$ok ok, $blocked blocked, $unreachable unreachable, $broken broken (of $count checked)"
 
 # Postcondition: every extracted URL must be accounted for. If the scan died
 # partway, the counts above would still read like a clean run.
-if [ "$((ok + blocked + broken))" -ne "$count" ]; then
+if [ "$((ok + blocked + unreachable + broken))" -ne "$count" ]; then
   echo
-  echo "FAIL: $((ok + blocked + broken)) results for $count URLs - the scan did not finish" >&2
+  echo "FAIL: $((ok + blocked + unreachable + broken)) results for $count URLs - the scan did not finish" >&2
+  exit 1
+fi
+
+# Not failing on unreachable only holds while unreachable is a fringe. If a
+# large share of the run cannot connect, the runner's network is the problem
+# and the whole result is uninformative - say so rather than reporting a
+# reassuring "0 broken".
+if [ "$count" -gt 0 ] && [ "$((unreachable * 4))" -gt "$count" ]; then
+  echo
+  echo "FAIL: $unreachable of $count URLs unreachable - this run cannot be trusted" >&2
   exit 1
 fi
 

--- a/tests/test_check_links.py
+++ b/tests/test_check_links.py
@@ -1,0 +1,210 @@
+"""Tests for check-links.sh classification.
+
+The weekly checker filed issue #166 listing sixteen links as broken. Every one
+of them was live: gnu.org answers our requests with 200 from a normal client
+and times out for GitHub's runners. A report that is mostly false positives is
+worse than no report, because it trains the reader to close it unread.
+
+These tests drive the real script with a stub `curl` on PATH, so the mapping
+from curl's exit code to a verdict is exercised rather than described.
+"""
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "check-links.sh"
+
+# The script refuses to run on a suspiciously small scan, so every fixture
+# needs to clear that floor.
+FILLER = 60
+
+
+def write_site(tmp_path, urls):
+    """Build a minimal site directory whose HTML links to `urls`."""
+    site = tmp_path / "site"
+    site.mkdir()
+    hrefs = "\n".join(f'<a href="{u}">x</a>' for u in urls)
+    (site / "index.html").write_text(f"<html><body>{hrefs}</body></html>")
+    return site
+
+
+FLAKY = "__flaky__"
+
+
+def write_fake_curl(tmp_path, responses):
+    """Install a stub curl that answers from `responses` (url -> "code rc").
+
+    Anything not listed answers 200, so a test only has to describe the URLs
+    it actually cares about. The special value FLAKY times out for the first
+    two calls (the HEAD and GET of the parallel pass) and succeeds afterwards,
+    which is what a host that throttles by connection looks like.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    counter = tmp_path / "calls"
+    arms = []
+    for url, value in responses.items():
+        if value == FLAKY:
+            arms.append(
+                f'  "{url}")\n'
+                f'    n=$(cat "{counter}" 2>/dev/null || echo 0); n=$((n+1));\n'
+                f'    echo "$n" > "{counter}"\n'
+                f'    if [ "$n" -le 2 ]; then echo "000 28"; else echo "200 0"; fi ;;'
+            )
+        else:
+            arms.append(f'  "{url}") echo "{value}" ;;')
+    (bindir / "curl").write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/bash
+            # Stub curl: the URL is the last argument.
+            url="${@: -1}"
+            case "$url" in
+            %s
+              *) echo "200 0" ;;
+            esac
+            """
+        )
+        % "\n".join(arms)
+    )
+    (bindir / "curl").chmod(0o755)
+    return bindir
+
+
+def run_check(tmp_path, responses, extra_urls=()):
+    urls = [f"https://example{i}.test/page" for i in range(FILLER)]
+    urls.extend(responses)
+    urls.extend(extra_urls)
+    site = write_site(tmp_path, urls)
+    bindir = write_fake_curl(tmp_path, responses)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["LINK_CHECK_JOBS"] = "16"
+    # The recheck's politeness delay is meaningless against a stub curl and
+    # would otherwise dominate the suite's runtime.
+    env["LINK_CHECK_RETRY_SLEEP"] = "0"
+    proc = subprocess.run(
+        [str(SCRIPT), str(site)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+    )
+    return proc
+
+
+@pytest.fixture(autouse=True)
+def require_bash():
+    if not shutil.which("bash"):
+        pytest.skip("bash not available")
+
+
+def test_clean_run_passes(tmp_path):
+    proc = run_check(tmp_path, {})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "0 broken" in proc.stdout
+
+
+def test_not_found_is_broken(tmp_path):
+    url = "https://dead.test/gone"
+    proc = run_check(tmp_path, {url: "404 0"})
+    assert proc.returncode == 1
+    assert "Broken links:" in proc.stdout
+    assert url in proc.stdout.split("Broken links:")[1]
+
+
+def test_timeout_is_unreachable_not_broken(tmp_path):
+    """The #166 case: curl exit 28, no HTTP response, host still resolves."""
+    url = "https://www.gnu.org/software/bash/manual/"
+    proc = run_check(tmp_path, {url: "000 28"})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "Broken links:" not in proc.stdout
+    assert "Unreachable from this runner" in proc.stdout
+    assert url in proc.stdout.split("Unreachable from this runner")[1]
+
+
+def test_connection_refused_is_unreachable(tmp_path):
+    proc = run_check(tmp_path, {"https://refused.test/x": "000 7"})
+    assert proc.returncode == 0
+    assert "Broken links:" not in proc.stdout
+
+
+def test_empty_curl_output_is_unreachable(tmp_path):
+    """curl exit 99 is the script's own sentinel for "curl said nothing"."""
+    proc = run_check(tmp_path, {"https://silent.test/x": ""})
+    assert proc.returncode == 0
+    assert "Unreachable from this runner" in proc.stdout
+
+
+def test_dns_failure_is_broken(tmp_path):
+    """A name that no longer resolves is content rot, not a network path."""
+    url = "https://vanished.test/x"
+    proc = run_check(tmp_path, {url: "000 6"})
+    assert proc.returncode == 1
+    assert "Broken links:" in proc.stdout
+    assert url in proc.stdout.split("Broken links:")[1]
+
+
+def test_bad_certificate_is_broken(tmp_path):
+    url = "https://expiredcert.test/x"
+    proc = run_check(tmp_path, {url: "000 60"})
+    assert proc.returncode == 1
+    assert url in proc.stdout.split("Broken links:")[1]
+
+
+def test_bot_block_is_reported_not_failed(tmp_path):
+    url = "https://blocked.test/x"
+    proc = run_check(tmp_path, {url: "403 0"})
+    assert proc.returncode == 0
+    assert "Blocked by the remote host" in proc.stdout
+    assert url in proc.stdout.split("Blocked by the remote host")[1]
+
+
+def test_serial_recheck_rescues_a_throttled_host(tmp_path):
+    """A host that drops the parallel burst must not be reported at all.
+
+    The first pass sees nothing; the serial recheck gets a 200. Without the
+    recheck this URL would be listed as unreachable.
+    """
+    url = "https://throttled.test/x"
+    proc = run_check(tmp_path, {url: FLAKY})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "Rechecking" in proc.stdout
+    assert "Unreachable from this runner" not in proc.stdout
+    assert f"{FILLER + 1} ok" in proc.stdout
+
+
+def test_widespread_unreachability_fails_the_run(tmp_path):
+    """Tolerating unreachable links only holds while they are a fringe.
+
+    If most of the run cannot connect, the network is the problem and a
+    reassuring "0 broken" would be a lie.
+    """
+    responses = {f"https://down{i}.test/x": "000 28" for i in range(40)}
+    proc = run_check(tmp_path, responses)
+    assert proc.returncode == 1
+    assert "cannot be trusted" in proc.stdout + proc.stderr
+
+
+def test_every_url_is_accounted_for(tmp_path):
+    proc = run_check(
+        tmp_path,
+        {
+            "https://a.test/x": "404 0",
+            "https://b.test/x": "000 28",
+            "https://c.test/x": "403 0",
+        },
+    )
+    line = [l for l in proc.stdout.splitlines() if " ok, " in l][-1]
+    # "N ok, N blocked, N unreachable, N broken (of N checked)"
+    nums = [int(t) for t in line.replace(",", " ").split() if t.isdigit()]
+    ok, blocked, unreachable, broken, total = nums
+    assert (ok, blocked, unreachable, broken) == (FILLER, 1, 1, 1)
+    assert ok + blocked + unreachable + broken == total


### PR DESCRIPTION
Fixes #166.

## The report was wrong

The weekly check filed sixteen broken links. **All sixteen are live.**

```
200  https://cheat.sh
200  https://cvs.nongnu.org/
200  https://www.gnu.org/software/bash/manual/      (and 13 more gnu.org paths)
```

gnu.org answers the script's exact request - its own user agent, its own `Accept` header - with `200` from this network, and times out for GitHub's runners. The headers were never the problem; `curl` with the script's UA and Accept returns `200 0` for every one of them locally.

The defect is in what a timeout was taken to *mean*. Any absence of an HTTP response was classified as broken, which conflates content rot with a network path the runner happens not to have.

A report that is mostly false positives is worse than no report. It teaches the reader to close the issue unread, and then the one real dead link goes with it.

## The change

| curl outcome | Before | After |
|---|---|---|
| Host does not resolve (6) | broken | broken |
| Certificate invalid (60) | broken | broken |
| Timed out (28) | broken | **unreachable, does not fail** |
| Connection refused (7) | broken | **unreachable, does not fail** |
| TLS handshake failed (35) | broken | **unreachable, does not fail** |
| curl said nothing (99) | broken | **unreachable, does not fail** |

Unreachable links are still printed, with a note to confirm one by hand before editing a guide.

Two supporting changes:

- The serial recheck now covers unreachable as well as broken, and uses a longer timeout. Its politeness delay is configurable so tests do not pay for it.
- Tolerating unreachable only holds while it is a fringe. A run where **more than a quarter** of URLs cannot connect now fails outright, rather than reporting a reassuring `0 broken` when the runner's network is the real story.

## Verification

`./verify.sh` passes. Tests drive the **real script** with a stub `curl` on PATH, so the exit-code-to-verdict mapping is exercised, not restated.

Eight mutations. No zero rows, and every one of the 11 tests is broken by at least one mutation:

| Mutation | Tests failed |
|---|---|
| Every no-response is broken again (the #166 behaviour) | 5 |
| A name that no longer resolves is merely unreachable | 2 |
| Drop the widespread-unreachability guard | 1 |
| Treat a bot block as broken | 2 |
| Leave unreachable out of the completeness sum | 4 |
| Do not recheck failures serially | 1 |
| Report a 200 as broken | 7 |
| Report an unrecognised HTTP code as OK | 2 |

The matrix was re-run in full after the retry-sleep refactor rather than carried over.

Real run against the built site: `810 ok, 134 blocked, 0 unreachable, 0 broken (of 944 checked)`, exit 0 - and the total still reconciles with the failing CI run's 944. **This network reaches gnu.org, so that run does not exercise the new unreachable branch**; the tests cover it, and I will dispatch the workflow on a real runner after merge to confirm it there.