### PR TITLE
feat(admin): show first-party traffic on the dashboard

### DIFF
--- a/assets/javascripts/components/admin/dashboard.js
+++ b/assets/javascripts/components/admin/dashboard.js
@@ -89,6 +89,74 @@
     ));
   }
 
+  /**
+   * First-party traffic. Rendered as its own section, never merged into the
+   * GA4 tables above.
+   *
+   * The two measure different populations - GA4 sees only readers who accepted
+   * consent and are not blocking it, this sees everyone - so the numbers will
+   * disagree, sometimes by a lot. A single combined table would imply they are
+   * the same quantity measured twice, which is a worse error than showing two
+   * sections and saying what each one covers.
+   */
+  function renderTraffic(root, traffic) {
+    root.appendChild(el("h2", {}, "Traffic (all readers, first-party)"));
+
+    if (!traffic || traffic.error) {
+      root.appendChild(el("p", { class: "admin-error" },
+        "First-party traffic is unavailable. The Google Analytics section above " +
+        "covers consenting, non-blocking readers only."));
+      return;
+    }
+
+    root.appendChild(el("p", {}, traffic.from + " to " + traffic.to + "."));
+
+    var totals = traffic.totals || {};
+    var perDay = totals.visitorsPerDay || {};
+    root.appendChild(table("Traffic totals", ["Metric", "Value"], [
+      ["Page views", totals.pageviews],
+      ["Visitors per day (average)", perDay.avg],
+      ["Visitors per day (busiest day)", perDay.peak],
+      ["Days with any traffic", totals.daysWithTraffic],
+    ]));
+
+    // There is deliberately no "unique visitors this month" row. Visitor
+    // identity is salted per day and the salt is discarded, so no such number
+    // exists to report - summing the daily column would count one person once
+    // per day they visited. Saying so beats leaving a reader to assume the
+    // omission is an oversight.
+    root.appendChild(el("p", { class: "admin-note" },
+      "There is no total visitor count for the whole range. Visitors are " +
+      "identified per day and that identifier is discarded nightly, so the " +
+      "same person cannot be recognised across two days. Page views add up; " +
+      "visitors do not."));
+
+    root.appendChild(table("Daily traffic", ["Day", "Visitors", "Page views", "Signed in"],
+      (traffic.daily || []).map(function (d) {
+        return [d.day, d.visitors, d.pageviews, d.signedIn];
+      })));
+
+    root.appendChild(table("Top pages by views", ["Page", "Topic", "Views"],
+      (traffic.topPages || []).map(function (p) {
+        return [p.path, p.topic || "", p.views];
+      })));
+
+    root.appendChild(table("Entry pages", ["Page", "Entries"],
+      (traffic.topEntryPages || []).map(function (p) {
+        return [p.path, p.entries];
+      })));
+
+    var referrers = traffic.topReferrers || [];
+    root.appendChild(referrers.length
+      ? table("Referrers", ["Source", "Views"],
+          referrers.map(function (r) { return [r.host, r.views]; }))
+      // An empty referrer table reads as broken collection. It usually means
+      // readers arrived directly or the referrer was stripped, which is a
+      // finding rather than a fault.
+      : el("p", {}, "No external referrers recorded in this range. Readers " +
+          "arrived directly, or their browser sent no referrer."));
+  }
+
   var inFlight = false;
 
   async function init() {
@@ -138,9 +206,26 @@
       return;
     }
     renderPayload(root, await res.json());
+
+    // Fetched after the overview has already rendered, and failure is confined
+    // to its own section: first-party traffic is the newest and least proven
+    // part of this page, and it must not be able to blank the metrics that
+    // were already working.
+    var traffic = null;
+    try {
+      var tres = await fetch(API + "/traffic?range=28d", { headers });
+      if (tres.ok) traffic = await tres.json();
+    } catch (e) {
+      traffic = null;
+    }
+    renderTraffic(root, traffic);
   }
 
-  window.RunbookAdminDashboard = { renderPayload: renderPayload, init: init };
+  window.RunbookAdminDashboard = {
+    renderPayload: renderPayload,
+    renderTraffic: renderTraffic,
+    init: init,
+  };
 
   if (document.getElementById("admin-root")) {
     document.addEventListener("runbook:auth-changed", init);

--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -4,6 +4,7 @@ import { parseRange } from "./lib/range.ts";
 import { isFresh, selectPayload } from "./lib/cache.ts";
 import { fetchGa4 } from "./lib/ga4.ts";
 import { fetchProgress } from "./lib/progress.ts";
+import { fetchTraffic } from "./lib/traffic.ts";
 import { buildPayload } from "./lib/merge.ts";
 
 /** Look the caller up in admin_users using the service-role client. */
@@ -61,6 +62,20 @@ export default {
 
     if (route === "health") {
       return json({ admin: true }, 200, origin);
+    }
+
+    // Deliberately uncached, unlike /overview. That one caches because GA4 is a
+    // rate-limited third party whose failure has to survive as stale data; this
+    // reads local Postgres in one query, so a cache would buy nothing and cost
+    // the freshness that makes the panel worth looking at.
+    if (route === "traffic") {
+      let range;
+      try {
+        range = parseRange(url.searchParams.get("range"));
+      } catch {
+        return json({ error: "invalid range" }, 400, origin);
+      }
+      return json(await fetchTraffic(ctx.supabaseAdmin, range.days), 200, origin);
     }
 
     if (route === "overview") {

--- a/supabase/functions/admin-api/lib/traffic.ts
+++ b/supabase/functions/admin-api/lib/traffic.ts
@@ -1,0 +1,83 @@
+export interface TrafficDay {
+  day: string;
+  visitors: number;
+  pageviews: number;
+  signedIn: number;
+}
+
+export interface TrafficPayload {
+  from: string;
+  to: string;
+  days: number;
+  daily: TrafficDay[];
+  totals: {
+    pageviews: number;
+    visitorsPerDay: { avg: number; peak: number };
+    daysWithTraffic: number;
+  };
+  topPages: Array<{ path: string; topic: string | null; views: number }>;
+  topReferrers: Array<{ host: string; views: number }>;
+  topEntryPages: Array<{ path: string; entries: number }>;
+}
+
+/**
+ * Expand the sparse daily series into one entry per day in the window.
+ *
+ * The RPC omits days with no traffic rather than emitting zero rows, because in
+ * the database a zero row and an absent row would be indistinguishable. A chart
+ * needs the opposite: every day present, or a quiet Sunday silently shortens
+ * the x-axis and the line joins Saturday straight to Monday, which reads as
+ * continuous traffic that never dipped.
+ *
+ * Dates are handled as YYYY-MM-DD strings throughout. Parsing them into Date
+ * objects to iterate would reintroduce a local-timezone shift on a series the
+ * database already fixed to UTC.
+ */
+export function fillDays(
+  daily: TrafficDay[],
+  from: string,
+  to: string,
+): TrafficDay[] {
+  const bySeen = new Map(daily.map((d) => [d.day, d]));
+  const out: TrafficDay[] = [];
+
+  // Iterate in UTC milliseconds. Date.UTC avoids the local offset that
+  // `new Date("2026-07-01")` plus getDate() would introduce west of Greenwich.
+  const start = Date.parse(`${from}T00:00:00Z`);
+  const end = Date.parse(`${to}T00:00:00Z`);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return [];
+
+  const DAY_MS = 86_400_000;
+  // Bounded independently of the arguments: a malformed pair that slipped the
+  // checks above must not become an unbounded loop inside the request handler.
+  const MAX_DAYS = 400;
+  let count = 0;
+  for (let t = start; t <= end && count < MAX_DAYS; t += DAY_MS, count++) {
+    const day = new Date(t).toISOString().slice(0, 10);
+    out.push(bySeen.get(day) ?? { day, visitors: 0, pageviews: 0, signedIn: 0 });
+  }
+  return out;
+}
+
+/**
+ * Read the window aggregate.
+ *
+ * One RPC call rather than selecting the daily views over PostgREST: PostgREST
+ * caps a response at max_rows and truncates silently, so summing a REST result
+ * would produce a confidently wrong smaller number. The database does the
+ * summation where nothing is capped.
+ */
+export async function fetchTraffic(
+  supabaseAdmin: any,
+  days: number,
+  limit = 10,
+): Promise<TrafficPayload> {
+  const { data, error } = await supabaseAdmin.rpc("analytics_traffic", {
+    p_days: days,
+    p_limit: limit,
+  });
+  if (error) throw error;
+
+  const payload = data as TrafficPayload;
+  return { ...payload, daily: fillDays(payload.daily ?? [], payload.from, payload.to) };
+}

--- a/supabase/functions/admin-api/tests/traffic_test.ts
+++ b/supabase/functions/admin-api/tests/traffic_test.ts
@@ -1,0 +1,154 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert@1";
+import { fetchTraffic, fillDays } from "../lib/traffic.ts";
+
+const EMPTY = { day: "", visitors: 0, pageviews: 0, signedIn: 0 };
+const day = (d: string, pv: number) => ({ ...EMPTY, day: d, pageviews: pv, visitors: 1 });
+
+Deno.test("fillDays returns one entry per day in the window", () => {
+  const out = fillDays([day("2026-07-03", 5)], "2026-07-01", "2026-07-05");
+  assertEquals(out.length, 5);
+  assertEquals(out.map((d) => d.day), [
+    "2026-07-01",
+    "2026-07-02",
+    "2026-07-03",
+    "2026-07-04",
+    "2026-07-05",
+  ]);
+});
+
+Deno.test("fillDays zero-fills the days the database omitted", () => {
+  const out = fillDays([day("2026-07-03", 5)], "2026-07-01", "2026-07-03");
+  assertEquals(out[0], { day: "2026-07-01", visitors: 0, pageviews: 0, signedIn: 0 });
+  assertEquals(out[1].pageviews, 0);
+  assertEquals(out[2].pageviews, 5);
+});
+
+Deno.test("fillDays preserves the real values it was given", () => {
+  const real = { day: "2026-07-02", visitors: 9, pageviews: 40, signedIn: 3 };
+  const out = fillDays([real], "2026-07-01", "2026-07-02");
+  assertEquals(out[1], real);
+});
+
+Deno.test("fillDays crosses a month boundary without skipping a day", () => {
+  // Naive day-of-month arithmetic produces "2026-07-32" here.
+  const out = fillDays([], "2026-07-30", "2026-08-02");
+  assertEquals(out.map((d) => d.day), [
+    "2026-07-30",
+    "2026-07-31",
+    "2026-08-01",
+    "2026-08-02",
+  ]);
+});
+
+Deno.test("fillDays crosses a year boundary", () => {
+  const out = fillDays([], "2026-12-31", "2027-01-01");
+  assertEquals(out.map((d) => d.day), ["2026-12-31", "2027-01-01"]);
+});
+
+Deno.test("fillDays covers a leap day", () => {
+  const out = fillDays([], "2028-02-28", "2028-03-01");
+  assertEquals(out.map((d) => d.day), ["2028-02-28", "2028-02-29", "2028-03-01"]);
+});
+
+Deno.test("fillDays handles a single-day window", () => {
+  const out = fillDays([], "2026-07-01", "2026-07-01");
+  assertEquals(out.length, 1);
+  assertEquals(out[0].day, "2026-07-01");
+});
+
+Deno.test("fillDays returns nothing for an inverted window", () => {
+  assertEquals(fillDays([], "2026-07-05", "2026-07-01"), []);
+});
+
+Deno.test("fillDays returns nothing for unparseable dates", () => {
+  assertEquals(fillDays([], "not-a-date", "2026-07-01"), []);
+  assertEquals(fillDays([], "2026-07-01", "nonsense"), []);
+});
+
+Deno.test("fillDays cannot loop unboundedly on an absurd window", () => {
+  // The RPC bounds p_days, but this function must not depend on that: a bad
+  // pair reaching it should terminate rather than hang the request handler.
+  const out = fillDays([], "1970-01-01", "2100-01-01");
+  assertEquals(out.length, 400);
+});
+
+Deno.test("fillDays does not shift days by a local timezone offset", () => {
+  // Date.parse("2026-07-01") without the Z is UTC, but constructing days via
+  // getDate()/setDate() in a negative-offset zone rolls each label back one
+  // day. The first entry must equal `from` exactly.
+  const out = fillDays([], "2026-07-01", "2026-07-04");
+  assertEquals(out[0].day, "2026-07-01");
+  assertEquals(out[out.length - 1].day, "2026-07-04");
+});
+
+// ------------------------------------------------------------- fetchTraffic
+
+function stubClient(response: { data?: unknown; error?: unknown }) {
+  const calls: Array<{ fn: string; args: unknown }> = [];
+  return {
+    calls,
+    rpc(fn: string, args: unknown) {
+      calls.push({ fn, args });
+      return Promise.resolve({ data: response.data ?? null, error: response.error ?? null });
+    },
+  };
+}
+
+const PAYLOAD = {
+  from: "2026-07-01",
+  to: "2026-07-03",
+  days: 3,
+  daily: [{ day: "2026-07-02", visitors: 2, pageviews: 7, signedIn: 1 }],
+  totals: { pageviews: 7, visitorsPerDay: { avg: 2, peak: 2 }, daysWithTraffic: 1 },
+  topPages: [],
+  topReferrers: [],
+  topEntryPages: [],
+};
+
+Deno.test("fetchTraffic calls the aggregation RPC, not a table select", () => {
+  // Selecting the daily views over PostgREST would be silently truncated at
+  // max_rows; the whole point is that the sum happens in the database.
+  const client = stubClient({ data: PAYLOAD });
+  return fetchTraffic(client, 28).then(() => {
+    assertEquals(client.calls.length, 1);
+    assertEquals(client.calls[0].fn, "analytics_traffic");
+    assertEquals(client.calls[0].args, { p_days: 28, p_limit: 10 });
+  });
+});
+
+Deno.test("fetchTraffic passes an explicit limit through", async () => {
+  const client = stubClient({ data: PAYLOAD });
+  await fetchTraffic(client, 7, 25);
+  assertEquals(client.calls[0].args, { p_days: 7, p_limit: 25 });
+});
+
+Deno.test("fetchTraffic fills the daily series before returning", async () => {
+  const out = await fetchTraffic(stubClient({ data: PAYLOAD }), 3);
+  assertEquals(out.daily.length, 3);
+  assertEquals(out.daily.map((d) => d.pageviews), [0, 7, 0]);
+});
+
+Deno.test("fetchTraffic leaves the totals exactly as the database computed them", async () => {
+  const out = await fetchTraffic(stubClient({ data: PAYLOAD }), 3);
+  // Zero-filling the series must not change any total. Recomputing totals in
+  // the API from a filled series is how a padded day becomes a real one.
+  assertEquals(out.totals, PAYLOAD.totals);
+});
+
+Deno.test("fetchTraffic reports no window-wide visitor count", async () => {
+  const out = await fetchTraffic(stubClient({ data: PAYLOAD }), 3);
+  assertEquals((out.totals as Record<string, unknown>).visitors, undefined);
+});
+
+Deno.test("fetchTraffic surfaces a database error rather than returning empty", async () => {
+  // Swallowing this would render an empty chart, which claims "no traffic" for
+  // what is actually "the query failed".
+  await assertRejects(() => fetchTraffic(stubClient({ error: { message: "boom" } }), 28));
+});
+
+Deno.test("fetchTraffic tolerates a payload with no daily array", async () => {
+  const client = stubClient({ data: { ...PAYLOAD, daily: null } });
+  const out = await fetchTraffic(client, 3);
+  assertEquals(out.daily.length, 3);
+  assertEquals(out.daily.every((d) => d.pageviews === 0), true);
+});

--- a/supabase/migrations/20260731170000_analytics_traffic_rpc.sql
+++ b/supabase/migrations/20260731170000_analytics_traffic_rpc.sql
@@ -1,0 +1,138 @@
+-- Range aggregation for the admin dashboard.
+--
+-- Why an RPC rather than the dashboard reading the daily views over PostgREST:
+-- PostgREST caps a response at max_rows (1000 by default) and does so
+-- SILENTLY - a truncated result is a normal 200 with fewer rows, and a
+-- dashboard summing it would report a confidently wrong smaller number. Per-day
+-- per-page rows cross 1000 quickly on a site with a few hundred pages, so the
+-- summation has to happen in the database where nothing is capped.
+--
+-- The whole window is returned as one jsonb document in one round trip, which
+-- also means the API layer cannot accidentally sum a partial page of results.
+
+create or replace function public.analytics_traffic(
+  p_days  integer default 28,
+  p_limit integer default 10
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+stable
+as $$
+declare
+  v_from date;
+  v_to   date;
+  v_out  jsonb;
+begin
+  -- Bound both inputs. p_days feeds a date subtraction and p_limit feeds a
+  -- LIMIT, so an unbounded value is a cheap way to ask for the entire table.
+  if p_days is null or p_days < 1 or p_days > 400 then
+    raise exception 'p_days must be between 1 and 400, got %', p_days;
+  end if;
+  if p_limit is null or p_limit < 1 or p_limit > 100 then
+    raise exception 'p_limit must be between 1 and 100, got %', p_limit;
+  end if;
+
+  -- Inclusive window ending today, in UTC, matching the views' day boundary.
+  v_to   := (now() at time zone 'UTC')::date;
+  v_from := v_to - (p_days - 1);
+
+  select jsonb_build_object(
+    'from', v_from,
+    'to',   v_to,
+    'days', p_days,
+
+    -- Per-day series. Days with no traffic are absent rather than zero-filled;
+    -- the presentation layer fills gaps, because a zero row here would be
+    -- indistinguishable from a real day that genuinely saw nothing.
+    'daily', coalesce((
+      select jsonb_agg(jsonb_build_object(
+               'day',       t.day,
+               'visitors',  t.visitors,
+               'pageviews', t.pageviews,
+               'signedIn',  t.signed_in_visitors
+             ) order by t.day)
+      from public.analytics_daily_traffic t
+      where t.day between v_from and v_to
+    ), '[]'::jsonb),
+
+    -- Totals contain pageviews but NOT a window visitor count, and that
+    -- omission is deliberate. Visitor identity is salted per day and the salt
+    -- is discarded, so the same person is a different hash tomorrow: summing
+    -- the daily columns counts them once per day they visited, and there is no
+    -- other number to compute. What is honest is the shape of the daily series,
+    -- so that is what is reported.
+    'totals', (
+      select jsonb_build_object(
+               'pageviews',       coalesce(sum(t.pageviews), 0),
+               'visitorsPerDay',  jsonb_build_object(
+                 'avg',  coalesce(round(avg(t.visitors), 1), 0),
+                 'peak', coalesce(max(t.visitors), 0)
+               ),
+               'daysWithTraffic', count(*)
+             )
+      from public.analytics_daily_traffic t
+      where t.day between v_from and v_to
+    ),
+
+    'topPages', coalesce((
+      select jsonb_agg(x)
+      from (
+        select jsonb_build_object(
+                 'path',  p.page_path,
+                 'topic', p.topic,
+                 'views', sum(p.views)
+               ) as x
+        from public.analytics_daily_pages p
+        where p.day between v_from and v_to
+        group by p.page_path, p.topic
+        order by sum(p.views) desc, p.page_path
+        limit p_limit
+      ) ranked
+    ), '[]'::jsonb),
+
+    'topReferrers', coalesce((
+      select jsonb_agg(x)
+      from (
+        select jsonb_build_object(
+                 'host',  r.referrer_host,
+                 'views', sum(r.views)
+               ) as x
+        from public.analytics_daily_referrers r
+        where r.day between v_from and v_to
+        group by r.referrer_host
+        order by sum(r.views) desc, r.referrer_host
+        limit p_limit
+      ) ranked
+    ), '[]'::jsonb),
+
+    'topEntryPages', coalesce((
+      select jsonb_agg(x)
+      from (
+        select jsonb_build_object(
+                 'path',    e.page_path,
+                 'entries', sum(e.entries)
+               ) as x
+        from public.analytics_daily_entries e
+        where e.day between v_from and v_to
+        group by e.page_path
+        order by sum(e.entries) desc, e.page_path
+        limit p_limit
+      ) ranked
+    ), '[]'::jsonb)
+  ) into v_out;
+
+  return v_out;
+end;
+$$;
+
+-- A security definer function is granted EXECUTE to PUBLIC on creation, so the
+-- revoke is what actually locks it down. Without it the published anon key
+-- could call this over PostgREST's /rpc/ endpoint and read the whole dataset
+-- straight through the definer rights.
+revoke all on function public.analytics_traffic(integer, integer) from public, anon, authenticated;
+grant execute on function public.analytics_traffic(integer, integer) to service_role;
+
+comment on function public.analytics_traffic(integer, integer) is
+  'Window aggregation for the admin dashboard, computed in-database so PostgREST row caps cannot silently truncate a sum. Service-role only.';

--- a/supabase/tests/analytics_traffic_test.sql
+++ b/supabase/tests/analytics_traffic_test.sql
@@ -1,0 +1,174 @@
+-- pgTAP tests for analytics_traffic(), the window aggregation behind the
+-- dashboard's traffic section.
+--
+-- Two things here matter more than the arithmetic:
+--   1. The function must aggregate ACROSS more rows than PostgREST would
+--      return, since dodging the silent max_rows truncation is the entire
+--      reason it exists. One test seeds past that cap deliberately.
+--   2. It is security definer, which grants EXECUTE to PUBLIC on creation.
+--      The privilege tests assert the revoke landed, independent of data.
+
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select plan(21);
+
+select has_function('public', 'analytics_traffic', 'analytics_traffic exists');
+
+-- ------------------------------------------------------------ input bounds
+--
+-- Both arguments reach a date subtraction and a LIMIT. Rejecting them at the
+-- edge of the function keeps "give me everything" from being a valid call.
+
+select throws_ok(
+  $$select public.analytics_traffic(0)$$, null, null,
+  'p_days of 0 is rejected'
+);
+select throws_ok(
+  $$select public.analytics_traffic(401)$$, null, null,
+  'p_days beyond retention is rejected'
+);
+select throws_ok(
+  $$select public.analytics_traffic(null)$$, null, null,
+  'a null p_days is rejected rather than defaulting'
+);
+select throws_ok(
+  $$select public.analytics_traffic(28, 0)$$, null, null,
+  'p_limit of 0 is rejected'
+);
+select throws_ok(
+  $$select public.analytics_traffic(28, 101)$$, null, null,
+  'an oversized p_limit is rejected'
+);
+select lives_ok(
+  $$select public.analytics_traffic(400, 100)$$,
+  'the upper bound of each argument is accepted'
+);
+
+-- -------------------------------------------------------------- empty table
+
+delete from public.analytics_events;
+
+-- An empty window must produce empty arrays and zeroes, not nulls. A null here
+-- would reach the dashboard as "no data available" for a site that simply had
+-- a quiet week, and the two are not the same claim.
+select is(
+  (public.analytics_traffic(28) -> 'daily'),
+  '[]'::jsonb,
+  'an empty window yields an empty daily array, not null'
+);
+select is(
+  (public.analytics_traffic(28) -> 'totals' ->> 'pageviews')::int,
+  0,
+  'an empty window totals zero pageviews'
+);
+select is(
+  (public.analytics_traffic(28) -> 'topPages'),
+  '[]'::jsonb,
+  'an empty window yields an empty topPages array'
+);
+
+-- ------------------------------------------------------------- aggregation
+
+delete from public.analytics_events;
+
+insert into public.analytics_events
+  (occurred_at, visitor_hash, event_name, page_path, topic, referrer_host, is_bot)
+values
+  -- Today: three visitors, four page views, one non-pageview event. The page
+  -- totals are deliberately NOT tied (basics 3, root 2), or the ranking
+  -- assertion below would be decided by the alphabetical tiebreak and would
+  -- pass whether or not the ordering by views worked at all.
+  (now(),                'v1', 'page_view',   '/Git/',        'Git', 'news.example', false),
+  (now(),                'v1', 'page_view',   '/Git/basics/', 'Git', null,           false),
+  (now(),                'v1', 'quiz_answer', '/Git/basics/', 'Git', null,           false),
+  (now(),                'v2', 'page_view',   '/Git/basics/', 'Git', null,           false),
+  (now(),                'v3', 'page_view',   '/Git/basics/', 'Git', null,           false),
+  -- Yesterday: one visitor, one view.
+  (now() - interval '1 day', 'v1', 'page_view', '/Git/',      'Git', null,           false),
+  -- A bot today, which must not appear anywhere.
+  (now(),                'bot', 'page_view',  '/Git/',        'Git', 'crawler.example', true),
+  -- Outside the window: proves the date filter does something.
+  (now() - interval '40 days', 'old', 'page_view', '/Old/',   'Old', null,           false);
+
+select is(
+  (public.analytics_traffic(7) -> 'totals' ->> 'pageviews')::int,
+  5,
+  'pageviews sum across days and exclude non-pageview events and bots'
+);
+select is(
+  jsonb_array_length(public.analytics_traffic(7) -> 'daily'),
+  2,
+  'only days inside the window appear in the series'
+);
+select is(
+  (public.analytics_traffic(7) -> 'totals' ->> 'daysWithTraffic')::int,
+  2,
+  'daysWithTraffic counts days present, not days elapsed'
+);
+
+-- The window total deliberately has no visitor count. Summing the daily column
+-- would count one person once per day they visited, and the rotating salt
+-- makes any other number impossible - so the contract is that it is absent.
+select ok(
+  (public.analytics_traffic(7) -> 'totals' -> 'visitors') is null,
+  'totals carry no window-wide visitor count'
+);
+select is(
+  (public.analytics_traffic(7) -> 'totals' -> 'visitorsPerDay' ->> 'peak')::int,
+  3,
+  'the busiest day visitor count is reported instead'
+);
+
+select is(
+  (public.analytics_traffic(7) -> 'topPages' -> 0 ->> 'path'),
+  '/Git/basics/',
+  'topPages ranks by summed views across the window'
+);
+select is(
+  (public.analytics_traffic(7) -> 'topReferrers' -> 0 ->> 'host'),
+  'news.example',
+  'bot referrers are excluded from topReferrers'
+);
+
+-- ------------------------------------------------- past the PostgREST cap
+--
+-- The reason this function exists. 1200 distinct paths on one day is more
+-- per-day rows than PostgREST would hand back, so a dashboard summing a REST
+-- response would silently report a fraction of the real total. Aggregating
+-- in-database has no such ceiling.
+
+delete from public.analytics_events;
+
+insert into public.analytics_events
+  (occurred_at, visitor_hash, event_name, page_path, topic, is_bot)
+select now(), 'v' || i, 'page_view', '/p/' || i || '/', 'Bulk', false
+from generate_series(1, 1200) i;
+
+select is(
+  (public.analytics_traffic(7) -> 'totals' ->> 'pageviews')::int,
+  1200,
+  'the sum covers more rows than PostgREST would return in one page'
+);
+select is(
+  jsonb_array_length(public.analytics_traffic(7, 10) -> 'topPages'),
+  10,
+  'p_limit still bounds the returned list'
+);
+
+-- -------------------------------------------------------------- privileges
+
+select ok(
+  not has_function_privilege('anon',
+    'public.analytics_traffic(integer,integer)', 'EXECUTE'),
+  'anon cannot execute the aggregation over PostgREST /rpc/'
+);
+select ok(
+  has_function_privilege('service_role',
+    'public.analytics_traffic(integer,integer)', 'EXECUTE'),
+  'service_role can execute the aggregation'
+);
+
+select * from finish();
+rollback;

--- a/tests/js/admin-dashboard.test.js
+++ b/tests/js/admin-dashboard.test.js
@@ -147,3 +147,119 @@ describe("admin dashboard auth states", () => {
     delete global.fetch;
   });
 });
+
+const TRAFFIC = {
+  from: "2026-07-01",
+  to: "2026-07-03",
+  days: 3,
+  daily: [
+    { day: "2026-07-01", visitors: 4, pageviews: 11, signedIn: 1 },
+    { day: "2026-07-02", visitors: 0, pageviews: 0, signedIn: 0 },
+    { day: "2026-07-03", visitors: 6, pageviews: 19, signedIn: 2 },
+  ],
+  totals: {
+    pageviews: 30,
+    visitorsPerDay: { avg: 3.3, peak: 6 },
+    daysWithTraffic: 2,
+  },
+  topPages: [{ path: "/Git/git-basics/", topic: "Git", views: 12 }],
+  topReferrers: [{ host: "news.ycombinator.com", views: 9 }],
+  topEntryPages: [{ path: "/Git/git-basics/", entries: 5 }],
+};
+
+describe("admin dashboard first-party traffic", () => {
+  let root;
+
+  beforeEach(async () => {
+    root = document.createElement("div");
+    document.body.appendChild(root);
+    await loadComponent("admin/dashboard");
+  });
+
+  afterEach(() => cleanup());
+
+  it("renders every figure as table text, never only as a chart", () => {
+    window.RunbookAdminDashboard.renderTraffic(root, TRAFFIC);
+    const text = root.textContent;
+    expect(text).toContain("30");
+    expect(text).toContain("6");
+    expect(text).toContain("news.ycombinator.com");
+    expect(text).toContain("/Git/git-basics/");
+    // A canvas cannot be voiced by a screen reader, so there must not be one.
+    expect(root.querySelector("canvas")).toBeNull();
+  });
+
+  it("labels the section as covering all readers, not the GA4 population", () => {
+    window.RunbookAdminDashboard.renderTraffic(root, TRAFFIC);
+    expect(root.textContent).toContain("first-party");
+    expect(root.textContent.toLowerCase()).toContain("all readers");
+  });
+
+  it("shows every day in the range, including days with no traffic", () => {
+    window.RunbookAdminDashboard.renderTraffic(root, TRAFFIC);
+    expect(root.textContent).toContain("2026-07-02");
+  });
+
+  it("reports no window-wide visitor total and explains the omission", () => {
+    window.RunbookAdminDashboard.renderTraffic(root, TRAFFIC);
+    const text = root.textContent.toLowerCase();
+    // The absence is the point: a reader who sees per-day visitors but no
+    // total will otherwise assume it was forgotten.
+    expect(text).toContain("no total visitor count");
+    expect(text).toContain("discarded");
+
+    // Also assert the table cannot grow one. The prose alone would still read
+    // correctly next to a row that quietly summed the daily column.
+    const totals = Array.from(root.querySelectorAll("table"))
+      .find((t) => t.querySelector("caption").textContent === "Traffic totals");
+    const labels = Array.from(totals.querySelectorAll("tbody th"))
+      .map((th) => th.textContent.toLowerCase());
+    expect(labels).not.toContain("visitors");
+    expect(labels.some((l) => l === "total visitors" || l === "unique visitors")).toBe(false);
+    expect(labels.length).toBe(4);
+  });
+
+  it("gives every table a caption and scoped headers", () => {
+    window.RunbookAdminDashboard.renderTraffic(root, TRAFFIC);
+    const tables = root.querySelectorAll("table");
+    expect(tables.length).toBeGreaterThan(0);
+    tables.forEach((t) => {
+      expect(t.querySelector("caption")).not.toBeNull();
+      t.querySelectorAll("th").forEach((th) => {
+        expect(th.getAttribute("scope")).toBeTruthy();
+      });
+    });
+  });
+
+  it("says so in words when there are no referrers, rather than showing an empty table", () => {
+    window.RunbookAdminDashboard.renderTraffic(root, { ...TRAFFIC, topReferrers: [] });
+    expect(root.textContent.toLowerCase()).toContain("no external referrers");
+  });
+
+  it("reports unavailable traffic without implying zero traffic", () => {
+    window.RunbookAdminDashboard.renderTraffic(root, null);
+    const text = root.textContent.toLowerCase();
+    expect(text).toContain("unavailable");
+    // "0 page views" would be a claim about the site; this is a claim about
+    // the query. They must not look the same.
+    expect(root.querySelector("table")).toBeNull();
+  });
+
+  it("leaves the GA4 section intact when first-party traffic fails", () => {
+    window.RunbookAdminDashboard.renderPayload(root, PAYLOAD);
+    window.RunbookAdminDashboard.renderTraffic(root, null);
+    expect(root.textContent).toContain("1234");
+    expect(root.textContent).toContain("all visitors");
+  });
+
+  it("keeps the two populations in separate sections", () => {
+    window.RunbookAdminDashboard.renderPayload(root, PAYLOAD);
+    window.RunbookAdminDashboard.renderTraffic(root, TRAFFIC);
+    const headings = Array.from(root.querySelectorAll("h2")).map((h) => h.textContent);
+    // Two distinct traffic headings, each naming its own population. One
+    // merged table would imply the numbers are the same quantity.
+    expect(headings.filter((h) => h.startsWith("Traffic")).length).toBe(2);
+    expect(headings.some((h) => h.includes("all visitors"))).toBe(true);
+    expect(headings.some((h) => h.includes("first-party"))).toBe(true);
+  });
+});


### PR DESCRIPTION
The presentation half of the first-party analytics work. #170 landed collection; this reads it back onto the admin dashboard.

**Nothing here is deployed.** The migration is not pushed and the function is not redeployed.

## Why an RPC rather than reading the views over REST

`analytics_traffic()` computes the whole window in-database and returns one `jsonb` document.

The obvious alternative - select the daily views over PostgREST, sum in the API - is wrong in a way that would not have surfaced in testing. PostgREST caps a response at `max_rows` and truncates **silently**: a truncated result is a normal 200 with fewer rows. A quiet month would look correct and a busy one would report a confidently wrong smaller number, with no error anywhere to notice. Per-day per-page rows cross the cap quickly on a site with a few hundred pages, so a pgTAP case seeds 1200 rows in a single day specifically to cross it.

Both arguments are bounded inside the function. The `revoke` is what actually locks it down - a `security definer` function is granted `EXECUTE` to `PUBLIC` on creation, so without it the published anon key could read the entire dataset through `/rpc/` under definer rights. That is the same shape as the `admin_progress_rollup` exposure, so it is asserted rather than assumed.

## The total that is deliberately missing

There is no window-wide visitor count, and the dashboard says so in plain words rather than leaving a gap.

Visitor identity is salted per day and the salt is discarded, so summing the daily column counts one person once per day they visited, and no other number exists to compute. What is honest is the daily average and the busiest day, so that is what is reported. A test asserts the totals table cannot grow such a row - the explanatory prose would still read perfectly well sitting next to one, so prose alone is not a guard.

## Presentation

GA4 and first-party stay in **separate sections**, each labelled with the population it measures. They will disagree, sometimes by a lot: GA4 sees consenting non-blocking readers, this sees everyone. One merged table would imply they are the same quantity measured twice, which is a worse error than showing two numbers and saying what each covers.

Everything is table text with captions and scoped headers, no canvas - a screen reader cannot voice a chart. Quiet days are zero-filled, because a missing day silently shortens the axis and joins Saturday to Monday as unbroken traffic. `fillDays` iterates in UTC milliseconds; day-of-month arithmetic produces `2026-07-32`, and parsing to local `Date` shifts every label west of Greenwich, so both have tests.

The traffic fetch runs **after** the overview has rendered and its failure is confined to its own section. The newest and least proven part of the page must not be able to blank the metrics that already worked. An unavailable payload renders as "unavailable", never as zero - "0 page views" is a claim about the site, this is a claim about the query.

## Verification

`./verify.sh`: 54 pytest, 140 vitest, 69 Deno. `./verify-db.sh`: 60 pgTAP.

| Suite | Count |
|---|---|
| pgTAP (RPC) | 21 |
| Deno (traffic lib) | 18 |
| Vitest (renderer) | 9 |

Two mutation matrices, no zero rows, and each row confirmed to fail the *intended* assertion rather than merely failing:

| SQL mutation | Failed |
|---|---|
| `p_days` upper bound removed | 1 |
| `p_limit` upper bound removed | 1 |
| totals grow a window-wide visitor sum | 1 |
| `topPages` ordered by path, not views | 1 |
| `topPages` ignores `p_limit` | 1 |
| totals ignore the date window | 1 |
| `daily` returns null instead of `[]` | 1 |
| the definer-rights revoke is dropped | 1 |

| Renderer mutation | Failed |
|---|---|
| section heading drops its population label | 2 |
| totals table grows a summed visitor row | 1 |
| the explanation of the missing total is deleted | 1 |
| an empty referrer list renders as an empty table | 1 |
| an unavailable payload falls through to rendering | 2 |
| tables lose their captions | 3 |
| quiet days are dropped from the daily table | 1 |

The first pgTAP run caught two of my own mistakes worth recording: a plan count of 18 against 21 tests, and a fixture where the two page totals were tied, so the ranking assertion was decided by the alphabetical tiebreak and would have passed whether or not ordering by views worked at all.

## Not in this PR

- Scheduling `analytics_prune()` for the 400-day retention window
- Any deployment
