### PR TITLE
feat(analytics): schedule the retention prune

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -385,6 +385,22 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# The readers being measured are anonymous, so there is no token to require and
+# the gateway must not demand one. Recorded here rather than passed as a deploy
+# flag, so the setting is reproducible and reviewable instead of living in
+# whatever command someone last ran.
+#
+# What protects the table is not authentication: only allowlisted event names
+# are stored, paths and props are bounded, and every response is a bodyless 204
+# so the allowlist cannot be probed.
+[functions.collect]
+verify_jwt = false
+
+# The opposite: the gateway rejects anything without a valid user JWT before
+# the handler runs, and the handler then checks admin membership.
+[functions.admin-api]
+verify_jwt = true
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/migrations/20260731190000_analytics_prune_schedule.sql
+++ b/supabase/migrations/20260731190000_analytics_prune_schedule.sql
@@ -1,0 +1,35 @@
+-- Make the 400-day retention real.
+--
+-- analytics_prune() has existed since 20260730220000 but nothing called it, so
+-- the retention window was a claim the system did not honour and
+-- analytics_events would have grown without bound.
+--
+-- Scheduled with pg_cron rather than an external scheduler on purpose: the
+-- retention rule then lives in the same database as the data it governs and
+-- keeps running whether or not any other service is up. A GitHub Actions cron
+-- would make a privacy property depend on a workflow in a different system
+-- staying green, and a silently disabled workflow looks exactly like a working
+-- one from here.
+
+create extension if not exists pg_cron;
+
+-- Idempotent: migrations get replayed against a fresh database on every
+-- verify-db run, and cron.schedule on an existing name would either error or
+-- quietly leave a duplicate depending on version.
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'analytics-prune') then
+    perform cron.unschedule('analytics-prune');
+  end if;
+end;
+$$;
+
+-- 03:20 UTC daily. Deliberately not midnight: analytics_record() rotates the
+-- salt on the first write after a day boundary, and stacking the two at the
+-- same instant makes any future problem in one look like a problem in the
+-- other.
+select cron.schedule(
+  'analytics-prune',
+  '20 3 * * *',
+  $$select public.analytics_prune(400)$$
+);

--- a/supabase/tests/analytics_prune_schedule_test.sql
+++ b/supabase/tests/analytics_prune_schedule_test.sql
@@ -1,0 +1,57 @@
+-- pgTAP tests for the retention schedule.
+--
+-- The interesting failure here is not a broken job but an ABSENT one: without
+-- a schedule, analytics_prune() still exists, still passes its own tests, and
+-- still never runs. Retention would read as implemented and be unenforced.
+
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select plan(6);
+
+select has_function('public', 'analytics_prune', 'the prune function exists');
+
+select is(
+  (select count(*)::int from cron.job where jobname = 'analytics-prune'),
+  1,
+  'exactly one prune job is scheduled'
+);
+
+select is(
+  (select active from cron.job where jobname = 'analytics-prune'),
+  true,
+  'the prune job is active, not merely present'
+);
+
+select is(
+  (select schedule from cron.job where jobname = 'analytics-prune'),
+  '20 3 * * *',
+  'the prune job runs daily'
+);
+
+-- The scheduled command must call the function with an explicit window. A bare
+-- call would still work today, but the retention period would then live only
+-- in a default and change silently if that default were ever edited.
+select matches(
+  (select command from cron.job where jobname = 'analytics-prune'),
+  'analytics_prune\(400\)',
+  'the schedule pins the retention window explicitly'
+);
+
+-- Prove the job body actually deletes. A schedule pointing at a no-op would
+-- satisfy every assertion above.
+delete from public.analytics_events;
+insert into public.analytics_events (occurred_at, visitor_hash, event_name, page_path)
+values
+  (now() - interval '401 days', 'old',  'page_view', '/old/'),
+  (now(),                       'new',  'page_view', '/new/');
+select public.analytics_prune(400);
+select is(
+  (select count(*)::int from public.analytics_events),
+  1,
+  'the scheduled window deletes expired rows and keeps current ones'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #172.

`analytics_prune()` has existed since the schema landed but nothing called it. The 400-day retention was a claim the system did not honour, and `analytics_events` would have grown without bound.

The failure mode worth naming: not a broken job, an **absent** one. The function existed, passed its own tests, and never ran - so retention read as implemented while being entirely unenforced. Nothing in the previous test suite could have told the difference.

## Why pg_cron

The rule lives in the same database as the data it governs and keeps running whether or not any other service is up.

A GitHub Actions cron would make a privacy property depend on a workflow in a different system staying green, and a silently disabled workflow is indistinguishable from a working one when viewed from the database. This repo's convention is that scheduled work earns a workflow only when it genuinely cannot live closer to the thing it acts on; retention can.

03:20 UTC, deliberately not midnight - `analytics_record()` rotates the salt on the first write after a day boundary, and stacking the two at the same instant would make a future problem in one look like a problem in the other.

The schedule pins `analytics_prune(400)` explicitly rather than relying on the function's default, which could otherwise be edited and change retention silently.

## Verification

`./verify-db.sh`: 66 pgTAP (up from 60). `./verify.sh` passes.

Tests assert the job exists, is **active** rather than merely present, runs daily, names the window explicitly, and that the function it points at actually deletes expired rows while keeping current ones - a schedule aimed at a no-op would satisfy every other assertion.

| Mutation | Failed |
|---|---|
| the schedule is never created | 4 |
| job runs yearly instead of daily | 1 |
| retention window left to the default | 1 |
| schedule points at a no-op | 1 |

No zero rows.

## Also here

Edge function JWT posture recorded in `config.toml` rather than living in whatever deploy command was last run: `collect` must not require a token, because the readers it measures are anonymous and there is no credential to ask for; `admin-api` must. Reproducible and reviewable instead of implicit.
