### PR TITLE
fix(site): stop the loader injecting every script twice

### DIFF
--- a/assets/javascripts/interactive.js
+++ b/assets/javascripts/interactive.js
@@ -31,39 +31,53 @@
     "admin-dashboard": "assets/javascripts/components/admin/dashboard.js",
   };
 
-  const loadedScripts = new Set();
+  // Keyed by src, holding the in-flight promise rather than a "done" marker.
+  //
+  // This used to be a Set that a src was added to on LOAD, which meant two
+  // concurrent callers both passed the guard before either finished and both
+  // injected a tag. initComponents() runs twice on a first page load - once
+  // from DOMContentLoaded and once because Material's document$ emits the
+  // current document immediately on subscribe - so that race fired on every
+  // visit, not in some rare interleaving.
+  //
+  // The consequences were live: storage.js loaded twice and the second copy
+  // threw "Identifier 'STORAGE_KEY' has already been declared", and collect.js
+  // loaded twice, giving each copy its own module scope so neither could see
+  // that the other had already sent the page view. Every page view was counted
+  // twice - an inflated number that looks entirely plausible.
+  //
+  // Registering the promise BEFORE the load settles is what closes it: the
+  // second caller gets the first caller's promise instead of a second tag.
+  const loadedScripts = new Map();
 
-  function loadScript(src) {
-    if (loadedScripts.has(src)) {
-      return Promise.resolve();
-    }
-    return new Promise((resolve, reject) => {
+  function injectScript(key, href) {
+    const existing = loadedScripts.get(key);
+    if (existing) return existing;
+
+    const pending = new Promise((resolve, reject) => {
       const script = document.createElement("script");
-      // Resolve relative to site root (__md_scope is set by MkDocs Material per page)
-      script.src = new URL(src, window.__md_scope || document.baseURI).href;
-      script.onload = () => {
-        loadedScripts.add(src);
-        resolve();
+      script.src = href;
+      script.onload = () => resolve();
+      script.onerror = () => {
+        // Do not cache a failure as though it were a completed load. A blocked
+        // script that becomes available later should be retryable.
+        loadedScripts.delete(key);
+        reject(new Error(`Failed to load ${key}`));
       };
-      script.onerror = () => reject(new Error(`Failed to load ${src}`));
       document.head.appendChild(script);
     });
+
+    loadedScripts.set(key, pending);
+    return pending;
+  }
+
+  function loadScript(src) {
+    // Resolve relative to site root (__md_scope is set by MkDocs Material per page)
+    return injectScript(src, new URL(src, window.__md_scope || document.baseURI).href);
   }
 
   function loadExternalScript(url) {
-    if (loadedScripts.has(url)) {
-      return Promise.resolve();
-    }
-    return new Promise((resolve, reject) => {
-      const script = document.createElement("script");
-      script.src = url;
-      script.onload = () => {
-        loadedScripts.add(url);
-        resolve();
-      };
-      script.onerror = () => reject(new Error(`Failed to load ${url}`));
-      document.head.appendChild(script);
-    });
+    return injectScript(url, url);
   }
 
   // Analytics is optional and is a common ad-blocker target: lib/analytics.js

--- a/assets/javascripts/lib/collect.js
+++ b/assets/javascripts/lib/collect.js
@@ -23,6 +23,17 @@
 (function () {
   "use strict";
 
+  // Refuse to run twice.
+  //
+  // The dedupe state below is module-local, so a second evaluation of this file
+  // gets a fresh copy that cannot see the first one's page view and sends a
+  // duplicate. That is not hypothetical: a loader race double-injected this
+  // script in production and every page view was counted twice. The loader is
+  // fixed, but the guard stays - a beacon whose count silently doubles when
+  // something upstream loads it twice is worse than one that does not fire,
+  // because the wrong number looks perfectly reasonable.
+  if (window.RunbookCollect) return;
+
   var ENDPOINT =
     "https://smulobzymizulakvaito.supabase.co/functions/v1/collect";
 

--- a/tests/js/collect.test.js
+++ b/tests/js/collect.test.js
@@ -208,4 +208,26 @@ describe("collect beacon", () => {
     expect(() => window.RunbookCollect.send(null, null)).not.toThrow();
     expect(() => window.RunbookCollect.send("page_view", undefined)).not.toThrow();
   });
+
+  it("does not send a second page view when the file is evaluated twice", () => {
+    // A loader race double-injected this script in production, giving each
+    // copy its own module scope, so the 1s dedupe below could not see the
+    // other copy and every page view was counted twice. The loader is fixed;
+    // this asserts the beacon is independently safe, because a count that
+    // silently doubles looks perfectly plausible.
+    const { sent } = load();
+    expect(sent).toHaveLength(1);
+
+    // eslint-disable-next-line no-new-func
+    new Function(SOURCE)();
+    expect(sent).toHaveLength(1);
+  });
+
+  it("leaves the already-installed API in place on a second evaluation", () => {
+    load();
+    const first = window.RunbookCollect;
+    // eslint-disable-next-line no-new-func
+    new Function(SOURCE)();
+    expect(window.RunbookCollect).toBe(first);
+  });
 });

--- a/tests/js/interactive-loader.test.js
+++ b/tests/js/interactive-loader.test.js
@@ -22,7 +22,7 @@ const SOURCE = readFileSync(
  * entry in `blocked` fire onerror, like a blocked request; everything else
  * fires onload. Returns the list of every src the page attempted.
  */
-async function runLoader(blocked = []) {
+async function runLoader(blocked = [], { doubleInit = false, loadDelay = 0 } = {}) {
   const attempted = [];
   const realAppend = document.head.appendChild.bind(document.head);
 
@@ -30,7 +30,11 @@ async function runLoader(blocked = []) {
     if (node.tagName !== "SCRIPT" || !node.src) return realAppend(node);
     attempted.push(node.src);
     const isBlocked = blocked.some((b) => node.src.includes(b));
-    // Async, like a real network response.
+    // Async, like a real network response. loadDelay matters: interactive.js
+    // defers the document$ re-init by 50ms, so with instant loads the first
+    // chain finishes before the second run starts and the two never overlap.
+    // A race test against non-overlapping runs passes no matter what the code
+    // does - it must outlast that 50ms to reproduce anything.
     setTimeout(() => {
       if (isBlocked) {
         if (node.onerror) node.onerror(new Event("error"));
@@ -47,16 +51,33 @@ async function runLoader(blocked = []) {
         };
       }
       if (node.onload) node.onload();
-    }, 0);
+    }, loadDelay);
     return node;
   });
+
+  if (doubleInit) {
+    // Reproduce the real mechanism rather than approximating it. Material's
+    // document$ is a replaying observable: subscribing emits the CURRENT
+    // document straight away. interactive.js has already run initComponents
+    // from the readyState check by then, so the subscribe callback is a second
+    // concurrent run inside the SAME evaluation - sharing one loadedScripts
+    // map. Evaluating the file twice instead would give each run its own map
+    // and could not reproduce this at all.
+    window.document$ = { subscribe: (cb) => cb() };
+  }
 
   // eslint-disable-next-line no-new-func
   new Function(SOURCE)();
 
-  // Let the promise chain drain.
+  // Let the promise chain drain. The document$ callback is deferred by 50ms,
+  // so this must outlast that or the second run would simply never happen and
+  // the test would pass for the wrong reason.
   for (let i = 0; i < 40; i++) {
     await new Promise((r) => setTimeout(r, 0));
+  }
+  // Outlast the 50ms re-init plus a full chain of delayed loads.
+  for (let i = 0; i < 16; i++) {
+    await new Promise((r) => setTimeout(r, loadDelay + 20));
   }
   return attempted;
 }
@@ -71,6 +92,7 @@ describe("interactive.js loading chain", () => {
     vi.restoreAllMocks();
     delete window.__md_scope;
     delete window.RunbookSupabaseConfig;
+    delete window.document$;
   });
 
   it("reaches the auth chain when nothing is blocked", async () => {
@@ -140,5 +162,48 @@ describe("interactive.js loading chain", () => {
     const withRoot = await runLoader();
     expect(withRoot.some((s) => s.includes("admin/dashboard.js"))).toBe(true);
     root.remove();
+  });
+
+  it("injects each script once when the loader runs twice concurrently", async () => {
+    // The production defect. initComponents() runs twice on a first load - once
+    // from DOMContentLoaded and once because Material's document$ emits the
+    // current document immediately on subscribe. The old guard registered a src
+    // only after its load RESOLVED, so both runs passed the check before either
+    // finished and both injected a tag.
+    //
+    // Live consequences: storage.js loaded twice and the second copy threw
+    // "Identifier 'STORAGE_KEY' has already been declared", and collect.js
+    // loaded twice into separate module scopes, so every page view was counted
+    // twice.
+    const attempted = await runLoader([], { doubleInit: true, loadDelay: 60 });
+    const counts = attempted.reduce((acc, src) => {
+      acc[src] = (acc[src] || 0) + 1;
+      return acc;
+    }, {});
+    const duplicated = Object.keys(counts).filter((s) => counts[s] > 1);
+    expect(duplicated).toEqual([]);
+  });
+
+  it("injects storage.js exactly once across concurrent runs", async () => {
+    // Named separately because this one is not merely a duplicate request: the
+    // second copy is a hard SyntaxError on a top-level const redeclaration.
+    const attempted = await runLoader([], { doubleInit: true, loadDelay: 60 });
+    expect(attempted.filter((s) => s.includes("lib/storage.js"))).toHaveLength(1);
+  });
+
+  it("injects the beacon exactly once across concurrent runs", async () => {
+    const attempted = await runLoader([], { doubleInit: true, loadDelay: 60 });
+    expect(attempted.filter((s) => s.includes("lib/collect.js"))).toHaveLength(1);
+  });
+
+  it("allows a retry after a script genuinely failed to load", async () => {
+    // A failure must not be cached as though it were a completed load, or a
+    // script blocked once could never be loaded again in that page session.
+    //
+    // loadDelay 0 on purpose: this is about a SEQUENTIAL retry after the first
+    // attempt failed. With overlapping runs the second caller correctly shares
+    // the first's in-flight promise and no retry is expected at all.
+    const attempted = await runLoader(["lib/topics.js"], { doubleInit: true, loadDelay: 0 });
+    expect(attempted.filter((s) => s.includes("lib/topics.js")).length).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
Found by loading the live site in a headless browser after deploying first-party analytics. Two separate faults, one root cause.

**Root cause.** `initComponents()` runs twice on every first page load: once from the `readyState` check and once because Material's `document$` is a replaying observable that emits the current document immediately on subscribe. `loadScript()` guarded against duplicates with a `Set` that a src was added to **on load**, so both runs passed the check before either finished and both injected a script tag. Not a rare interleaving - it fired on every visit.

**Consequence 1: a live JS error.** `storage.js` loaded twice and the second copy threw

```
Uncaught SyntaxError: Identifier 'STORAGE_KEY' has already been declared
```

**Consequence 2: every page view counted twice.** `collect.js` loaded twice into two separate module scopes, so its 1s page-view dedupe could not see the other copy. Confirmed against production: one headless page load produced two `page_view` rows 0.5ms apart, and a second load produced two more 41ms apart.

The second one is the worse failure. A beacon that goes silent is obvious; a beacon that doubles produces a number that looks entirely plausible and would have quietly overstated traffic from day one.

**Fix.** `loadedScripts` becomes a Map of in-flight promises registered *before* the load settles, so a concurrent caller receives the first caller's promise instead of injecting a second tag. A genuine load failure deletes the key so a blocked script stays retryable. `collect.js` additionally returns early if `window.RunbookCollect` already exists, so a double-load upstream can never double-count again.

**Testing note worth keeping.** The first version of the regression test passed against the unfixed code. The harness resolved script loads instantly, so the first chain completed before the 50ms re-init and the two runs never overlapped - a race test against non-overlapping runs passes regardless of the code. It only became a real test once the harness's load delay was made to outlast that 50ms. The mutation row went from 0 failures to 3.


---

Found by loading the deployed site in a headless browser rather than by reading the code. Nothing in the existing suite could have caught it: both faults need two concurrent runs of the loader, which no test was exercising.

`./verify.sh` passes (54 pytest, 146 vitest, 69 Deno).

| Mutation | Failed |
|---|---|
| loader registers src only after it loads | 3 |
| beacon loses its double-evaluation guard | 2 |
| a failed load is cached as done | 1 |

No zero rows - but the first row WAS zero until the harness was fixed, which is the finding worth keeping.
