### PR TITLE
fix(admin): announce an empty submit instead of returning in silence

### DIFF
--- a/assets/javascripts/components/admin/accounts.js
+++ b/assets/javascripts/components/admin/accounts.js
@@ -62,13 +62,49 @@
     return region;
   }
 
+  var pendingAnnounce = null;
+
   /**
    * Announce one sentence for one user action. Exactly one write per action:
    * writing the same text into a second role="status" node reads it twice.
+   *
+   * Assistive tech fires on a CHANGE to the region, so repeating a sentence
+   * verbatim announces nothing - and repeating is exactly what an admin does
+   * after not hearing the first one. An identical message is therefore cleared
+   * and re-set in a later task: done synchronously the two writes coalesce back
+   * into "no change" before the accessibility tree is read. The clearing write
+   * is silent on its own, so this is still one announcement per action.
    */
   function announce(message) {
     var region = document.getElementById(LIVE_ID);
-    if (region) region.textContent = message;
+    if (!region) return;
+    if (pendingAnnounce) {
+      clearTimeout(pendingAnnounce);
+      pendingAnnounce = null;
+    }
+    if (region.textContent !== message) {
+      region.textContent = message;
+      return;
+    }
+    region.textContent = "";
+    pendingAnnounce = setTimeout(function () {
+      pendingAnnounce = null;
+      region.textContent = message;
+    }, 0);
+  }
+
+  /**
+   * The one outcome with nothing to render: a submit refused before it was
+   * sent. Every other branch leaves a visible section behind, so without this
+   * a sighted admin who submits whitespace sees the page not change at all -
+   * the same "did it stop responding?" ambiguity, in the other modality.
+   *
+   * Deliberately carries no role: the sentence is announced through the
+   * persistent region, and a second announcing node would read it twice.
+   */
+  function formHint(form, message) {
+    var hint = form.querySelector(".admin-form-hint");
+    if (hint) hint.textContent = message;
   }
 
   /**
@@ -144,6 +180,7 @@
       "data-user-id": u.id,
       "aria-describedby": warnId,
     }, "Reset this account's progress"));
+    form.appendChild(el("p", { class: "admin-error admin-form-hint" }));
     s.appendChild(form);
   }
 
@@ -315,6 +352,7 @@
     form.appendChild(label);
     form.appendChild(input);
     form.appendChild(submit);
+    form.appendChild(el("p", { class: "admin-error admin-form-hint" }));
     s.appendChild(form);
 
     form.addEventListener("submit", async function (ev) {
@@ -323,13 +361,19 @@
       if (!v) {
         // An empty submit used to return here having rendered nothing and
         // announced nothing, so a screen-reader user got total silence and no
-        // way to tell the submit from a page that had stopped responding. The
-        // announcement is the whole feedback for that user; focus goes to the
-        // field so acting on it does not mean hunting for it again.
-        announce("Type an address or user id first.");
+        // way to tell the submit from a page that had stopped responding.
+        //
+        // Focus moves BEFORE the announcement, not after. A focus change
+        // produces its own announcement, and a polite region written first can
+        // be preempted by it and never spoken; written second, it queues behind
+        // the focus announcement and is still heard.
+        var hint = "Type an address or user id first.";
+        formHint(form, hint);
         input.focus();
+        announce(hint);
         return;
       }
+      formHint(form, "");
       var key = v.indexOf("@") === -1 ? "id" : "email";
       try {
         var res = await authedFetch(
@@ -382,11 +426,17 @@
       if (!typed) {
         // Same silence as the lookup, on the destructive form, where an
         // unexplained non-response is worst: the natural reading is that the
-        // reset may or may not have gone through.
-        announce("Type the account's email address to confirm the reset.");
+        // reset may or may not have gone through. Focus before announcing, for
+        // the reason above - and it matters more here, because focusing this
+        // input also reads the three-sentence deletion warning it is described
+        // by, which would otherwise talk over the instruction.
+        var typeIt = "Type the account's email address to confirm the reset.";
+        formHint(ev.target, typeIt);
         if (field) field.focus();
+        announce(typeIt);
         return;
       }
+      formHint(ev.target, "");
       // The typed address IS the confirmation. The server independently
       // requires the id and the email to belong to the same account, so this
       // field is the input to that check, not a second check layered on top.

--- a/assets/javascripts/components/admin/accounts.js
+++ b/assets/javascripts/components/admin/accounts.js
@@ -320,7 +320,16 @@
     form.addEventListener("submit", async function (ev) {
       ev.preventDefault();
       var v = input.value.trim();
-      if (!v) return;
+      if (!v) {
+        // An empty submit used to return here having rendered nothing and
+        // announced nothing, so a screen-reader user got total silence and no
+        // way to tell the submit from a page that had stopped responding. The
+        // announcement is the whole feedback for that user; focus goes to the
+        // field so acting on it does not mean hunting for it again.
+        announce("Type an address or user id first.");
+        input.focus();
+        return;
+      }
       var key = v.indexOf("@") === -1 ? "id" : "email";
       try {
         var res = await authedFetch(
@@ -370,7 +379,14 @@
       var id = btn.getAttribute("data-user-id");
       var field = ev.target.querySelector("input");
       var typed = (field && field.value.trim()) || "";
-      if (!typed) return;
+      if (!typed) {
+        // Same silence as the lookup, on the destructive form, where an
+        // unexplained non-response is worst: the natural reading is that the
+        // reset may or may not have gone through.
+        announce("Type the account's email address to confirm the reset.");
+        if (field) field.focus();
+        return;
+      }
       // The typed address IS the confirmation. The server independently
       // requires the id and the email to belong to the same account, so this
       // field is the input to that check, not a second check layered on top.

--- a/tests/js/admin-accounts.test.js
+++ b/tests/js/admin-accounts.test.js
@@ -459,6 +459,80 @@ describe("admin accounts reset listener idempotency", () => {
     expect(document.activeElement).toBe(result);
   });
 
+  it("announces an empty lookup submit instead of returning in silence", async () => {
+    // The early return rendered nothing and announced nothing, so a screen
+    // reader user could not tell a rejected submit from a page that had
+    // stopped responding. No request may be sent either.
+    let requested = false;
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      if (String(url).includes("/admins")) return { ok: true, json: async () => ({ admins: [] }) };
+      requested = true;
+      return { ok: true, json: async () => ({}) };
+    };
+    await window.RunbookAdminAccounts.init();
+    expect(liveRegion().textContent).toBe("");
+
+    const form = root.querySelector("#admin-lookup-form");
+    const input = form.querySelector("input");
+    input.value = "   ";
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(liveRegion().textContent).not.toBe("");
+    expect(requested).toBe(false);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("announces an empty reset confirmation instead of returning in silence", async () => {
+    // Worse here than on the lookup: an unexplained non-response to a
+    // destructive form reads as "it may or may not have gone through".
+    let requested = false;
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      if (String(url).includes("/admins")) return { ok: true, json: async () => ({ admins: [] }) };
+      requested = true;
+      return { ok: true, json: async () => ({ reset: true }) };
+    };
+    await window.RunbookAdminAccounts.init();
+    window.RunbookAdminAccounts.renderUser(root, USER);
+    expect(liveRegion().textContent).toBe("");
+
+    const form = root.querySelector(".admin-reset-form");
+    const input = form.querySelector("input");
+    input.value = "";
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(liveRegion().textContent).not.toBe("");
+    expect(requested).toBe(false);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("still writes the live region exactly once for a refused empty submit", async () => {
+    // The empty path must not announce through two nodes any more than the
+    // outcome paths do.
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      return { ok: true, json: async () => ({ admins: [] }) };
+    };
+    await window.RunbookAdminAccounts.init();
+
+    const records = [];
+    const observer = new MutationObserver((list) => records.push(...list));
+    observer.observe(liveRegion(), { childList: true, characterData: true, subtree: true });
+
+    const form = root.querySelector("#admin-lookup-form");
+    form.querySelector("input").value = "";
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    observer.takeRecords().forEach((r) => records.push(r));
+    observer.disconnect();
+
+    expect(records.length).toBe(1);
+    expect(root.querySelectorAll('[role="status"], [aria-live]').length).toBe(1);
+  });
+
   it("announces a reset outcome and lands focus on it", async () => {
     global.fetch = async (url) => {
       if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };

--- a/tests/js/admin-accounts.test.js
+++ b/tests/js/admin-accounts.test.js
@@ -479,9 +479,68 @@ describe("admin accounts reset listener idempotency", () => {
     form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(liveRegion().textContent).not.toBe("");
+    // Pinned to the sentence, not merely to "something": announcing the reset
+    // form's instruction here would be wrong and would pass a not-empty check.
+    expect(liveRegion().textContent).toContain("address or user id");
+    // Visible too. The empty path is the only outcome that renders nothing, so
+    // a sighted admin submitting whitespace would otherwise see no change.
+    expect(form.querySelector(".admin-form-hint").textContent)
+      .toContain("address or user id");
     expect(requested).toBe(false);
     expect(document.activeElement).toBe(input);
+  });
+
+  it("clears the visible hint once a real lookup goes out", async () => {
+    const form = await initPastHealth({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "no such user" }),
+    });
+    form.querySelector("input").value = "";
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(form.querySelector(".admin-form-hint").textContent).not.toBe("");
+
+    await submitLookup(form);
+
+    // A stale "type an address first" sitting under a real result contradicts
+    // the result.
+    expect(form.querySelector(".admin-form-hint").textContent).toBe("");
+  });
+
+  it("re-announces the same sentence when the empty submit is repeated", async () => {
+    // Assistive tech fires on a change, so writing an identical string is
+    // silent - and repeating the submit is exactly what an admin does after
+    // not hearing the first one.
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      return { ok: true, json: async () => ({ admins: [] }) };
+    };
+    await window.RunbookAdminAccounts.init();
+    const form = root.querySelector("#admin-lookup-form");
+    form.querySelector("input").value = "";
+
+    const submitEmpty = async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    };
+
+    await submitEmpty();
+    const first = liveRegion().textContent;
+    expect(first).toContain("address or user id");
+
+    const changes = [];
+    const observer = new MutationObserver(() => changes.push(liveRegion().textContent));
+    observer.observe(liveRegion(), { childList: true, characterData: true, subtree: true });
+    await submitEmpty();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    observer.takeRecords();
+    observer.disconnect();
+
+    // The region must have gone empty and back, so the repeat is a real change
+    // rather than a write the accessibility tree cannot distinguish.
+    expect(changes).toContain("");
+    expect(liveRegion().textContent).toContain("address or user id");
   });
 
   it("announces an empty reset confirmation instead of returning in silence", async () => {
@@ -504,9 +563,53 @@ describe("admin accounts reset listener idempotency", () => {
     form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(liveRegion().textContent).not.toBe("");
+    expect(liveRegion().textContent).toContain("confirm the reset");
+    expect(form.querySelector(".admin-form-hint").textContent)
+      .toContain("confirm the reset");
     expect(requested).toBe(false);
     expect(document.activeElement).toBe(input);
+  });
+
+  it("focuses the reset field before announcing, not after", async () => {
+    // Focusing this input also reads the deletion warning it is described by.
+    // Announcing first lets that warning talk over the instruction, and a
+    // polite region preempted by a focus announcement can be dropped entirely.
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      return { ok: true, json: async () => ({ admins: [] }) };
+    };
+    await window.RunbookAdminAccounts.init();
+    window.RunbookAdminAccounts.renderUser(root, USER);
+
+    const order = [];
+    const form = root.querySelector(".admin-reset-form");
+    const input = form.querySelector("input");
+    input.addEventListener("focus", () => order.push("focus"));
+
+    // The write is spied synchronously, through the property itself. A
+    // MutationObserver cannot answer this question: its callback is a
+    // microtask, so it always records after the focus listener no matter which
+    // order the code used, and the test passes against either.
+    const region = liveRegion();
+    const textContent = Object.getOwnPropertyDescriptor(Node.prototype, "textContent");
+    Object.defineProperty(region, "textContent", {
+      configurable: true,
+      get() { return textContent.get.call(this); },
+      set(value) {
+        order.push("announce");
+        textContent.set.call(this, value);
+      },
+    });
+
+    try {
+      input.value = "";
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      delete region.textContent;
+    }
+
+    expect(order).toEqual(["focus", "announce"]);
   });
 
   it("still writes the live region exactly once for a refused empty submit", async () => {


### PR DESCRIPTION
Closes #189.

Submitting the lookup form or the reset confirmation empty did `preventDefault()` and then `return`, rendering nothing and announcing nothing. On screen the empty field explains itself. Through a screen reader it is indistinguishable from a page that has stopped responding - and on the reset form, the natural reading of an unexplained non-response is that the delete may or may not have gone through.

Both paths now write one sentence into the persistent `#admin-lookup-status` region and move focus to the field that needs attention. Still exactly one write per action, so nothing is announced twice.

## Verification

Proven structurally in jsdom rather than by eye - three new tests assert the region's text changes, that no request is sent, that focus lands on the input, and that only one live region is written.

Mutation matrix, 4 rows, each failing exactly the intended tests with no collateral:

| mutation | failures |
|---|---|
| lookup returns in silence again (the #189 bug) | 2 |
| reset confirmation returns in silence again | 1 |
| announces but drops focus | 1 |
| empty submit falls through and sends the request | 2 |

`./verify.sh` passes; `tests/js/admin-accounts.test.js` 25 -> 28 cases.