### PR TITLE
fix(admin): close the four remaining account-management review findings

### DIFF
--- a/assets/javascripts/components/admin/accounts.js
+++ b/assets/javascripts/components/admin/accounts.js
@@ -184,11 +184,29 @@
     s.appendChild(form);
   }
 
+  /**
+   * @param root  the page root
+   * @param payload  the parsed /admins body, or null if the request produced
+   *   no answer at all. The two are different facts and must not share a
+   *   message: null means the roster is unknown, not that it is empty.
+   */
   function renderRoster(root, payload) {
     var s = section(root, "admin-roster");
     s.appendChild(el("h3", {}, "Admins"));
 
-    var admins = (payload && payload.admins) || [];
+    if (!payload) {
+      // A 500, a 403 on an expired session, or a dropped connection used to
+      // land in the empty-roster branch below, which states as fact that the
+      // roster is empty and that the last-admin trigger is broken. Neither is
+      // known here, and the suggested next step - inspect the trigger - sends
+      // the admin after something that is almost certainly fine.
+      s.appendChild(el("p", { class: "admin-error" },
+        "Could not load the admin roster. This says nothing about who is an " +
+        "admin: the list was not read. Reload the page to try again."));
+      return;
+    }
+
+    var admins = payload.admins || [];
     if (!admins.length) {
       // The last-admin trigger makes this impossible. If it renders, the guard
       // is not doing its job, and an empty table would read as "loading".
@@ -228,6 +246,25 @@
   // single submit fires the reset request - and its audit write - once per
   // accumulated listener. Store the reference and remove it before re-adding.
   var resetSubmitHandler = null;
+
+  // A second submit while the reset is in flight sends a second POST. The
+  // delete is idempotent so nothing extra is lost, but the audit insert is
+  // not: one admin intent then writes two admin_audit rows, and the log
+  // misreports how many resets were actually performed. Guarded twice, because
+  // each guard covers what the other cannot - the flag stops a submit raised
+  // any other way (Enter in the text field, a dispatched event), and the
+  // disabled button is what a sighted or screen-reader user can perceive.
+  var resetInFlight = false;
+
+  function setBusy(btn, busy) {
+    if (!btn) return;
+    btn.disabled = busy;
+    // Kept in step with the property: assistive tech reads the attribute, and
+    // the two disagreeing is how a control announces itself as available while
+    // refusing every activation.
+    if (busy) btn.setAttribute("aria-disabled", "true");
+    else btn.removeAttribute("aria-disabled");
+  }
 
   async function init() {
     var root = document.getElementById("admin-accounts-root");
@@ -273,9 +310,11 @@
       // lookup the admin is in the middle of reading.
       try {
         var res = await authedFetch("/admins", { method: "GET" });
-        renderRoster(root, res.ok ? await res.json() : { admins: [] });
+        // null, not { admins: [] }: a refused request is not evidence of an
+        // empty roster, and the renderer says so in its own words.
+        renderRoster(root, res.ok ? await res.json() : null);
       } catch (e) {
-        renderRoster(root, { admins: [] });
+        renderRoster(root, null);
       }
     } catch (e) {
       // Without this the rejection escapes as an unhandled promise rejection
@@ -420,6 +459,7 @@
         && ev.target.querySelector("[data-action='reset-progress']");
       if (!btn) return;
       ev.preventDefault();
+      if (resetInFlight) return;
       var id = btn.getAttribute("data-user-id");
       var field = ev.target.querySelector("input");
       var typed = (field && field.value.trim()) || "";
@@ -437,6 +477,10 @@
         return;
       }
       formHint(ev.target, "");
+      // Only now, past every branch that returns without sending anything: a
+      // refused empty submit must leave the button usable.
+      resetInFlight = true;
+      setBusy(btn, true);
       // The typed address IS the confirmation. The server independently
       // requires the id and the email to belong to the same account, so this
       // field is the input to that check, not a second check layered on top.
@@ -464,6 +508,11 @@
           "deleted - look the account up again before retrying.";
         sectionMessage(root, "admin-reset-result", unsent);
         announce(unsent);
+      } finally {
+        // In a finally, so a throw from anywhere above cannot leave the page
+        // with a permanently dead reset button and no way back but a reload.
+        resetInFlight = false;
+        setBusy(btn, false);
       }
       focusResult(root, "admin-reset-result");
     };

--- a/supabase/functions/admin-api/index.ts
+++ b/supabase/functions/admin-api/index.ts
@@ -1,6 +1,6 @@
 import { withSupabase } from "npm:@supabase/server@^1";
 import { corsHeaders, resolveCorsOrigin } from "./lib/cors.ts";
-import { withErrorFloor } from "./lib/error-floor.ts";
+import { buildFetch } from "./lib/compose.ts";
 import { parseRange } from "./lib/range.ts";
 import { isFresh, selectPayload } from "./lib/cache.ts";
 import { fetchGa4 } from "./lib/ga4.ts";
@@ -71,12 +71,9 @@ function json(body: unknown, status: number, origin: string | null): Response {
 // What is left to us is the two checks the gateway does not do: origin
 // allowlisting (it returns a wildcard) and admin-membership.
 //
-// The error floor goes OUTSIDE withSupabase, not inside it. Inside, it never
-// sees what withSupabase itself throws before it reaches this handler - client
-// construction against a rotated service-role key, an unexpected claims shape -
-// and those are exactly the failures that reach the browser as a CORS-less
-// plain-text 500 the admin page then mis-narrates.
-const routes = withSupabase({ auth: "user" }, async (req: Request, ctx: any) => {
+// The error floor goes OUTSIDE withSupabase, not inside it. That ordering lives
+// in lib/compose.ts, where a test can hold it: see buildFetch below.
+const handler = async (req: Request, ctx: any) => {
     const origin = resolveCorsOrigin(req.headers.get("Origin"));
     if (origin === null) {
       return json({ error: "forbidden" }, 403, null);
@@ -298,10 +295,8 @@ const routes = withSupabase({ auth: "user" }, async (req: Request, ctx: any) => 
     // call). TypeScript cannot see that exhaustiveness, so a terminal throw
     // satisfies the return-type check without duplicating the 404 response.
     throw new Error("unreachable route");
-});
+};
 
-// withSupabase hands back a one-argument handler, so the floor is adapted to
-// that shape rather than the two-argument one it wraps elsewhere.
 export default {
-  fetch: withErrorFloor((req: Request) => routes(req)),
+  fetch: buildFetch(withSupabase, { auth: "user" }, handler),
 };

--- a/supabase/functions/admin-api/lib/accounts.ts
+++ b/supabase/functions/admin-api/lib/accounts.ts
@@ -1,4 +1,9 @@
-import { LOOKUP_PAGE_SIZE, narrowToExactEmail, type UserQuery } from "./identity.ts";
+import {
+  gotrueFilter,
+  LOOKUP_PAGE_SIZE,
+  narrowToExactEmail,
+  type UserQuery,
+} from "./identity.ts";
 import { type GoTrueDeps, listUsersByFilter } from "./gotrue.ts";
 
 export interface AccountUser {
@@ -91,9 +96,11 @@ export async function findUser(
     return user === null ? { kind: "none" } : { kind: "found", user };
   }
 
+  // Escaped, because filter= is a LIKE pattern: an address is a search term
+  // only once its wildcards are neutralized.
   const { users, hasMore } = await listUsersByFilter(
     deps,
-    query.email,
+    gotrueFilter(query.email),
     1,
     LOOKUP_PAGE_SIZE,
   );

--- a/supabase/functions/admin-api/lib/compose.ts
+++ b/supabase/functions/admin-api/lib/compose.ts
@@ -1,0 +1,39 @@
+import { type Handler, withErrorFloor } from "./error-floor.ts";
+
+/** The route handler withSupabase calls, once it has built the context. */
+export type RouteHandler = (req: Request, ctx: any) => Promise<Response>;
+
+/** withSupabase's shape: takes options and a handler, returns a fetch handler. */
+export type ServerWrapper = (
+  options: unknown,
+  handler: RouteHandler,
+) => (req: Request) => Promise<Response> | Response;
+
+/**
+ * Compose the routes with their wrappers, error floor OUTSIDE.
+ *
+ * The ordering is the whole point, and index.ts cannot prove it: applied
+ * inside, the floor never sees what withSupabase itself throws before the
+ * handler runs - client construction against a rotated service-role key, an
+ * unexpected claims shape - and those escape as the platform's plain-text,
+ * CORS-less 500 that the admin page then mis-narrates as a connection failure.
+ * The first version of that fix had exactly this bug with every test passing,
+ * because nothing exercised the composition.
+ *
+ * Extracted here so a test can throw from the WRAPPER rather than from the
+ * handler and still demand a CORS-bearing JSON 500. Re-nesting the two in
+ * index.ts is then a change to one line of glue that this function owns.
+ *
+ * A wrapper that throws while being CONSTRUCTED is out of scope: that happens
+ * at module import, before any request exists to answer.
+ */
+export function buildFetch(
+  withSupabaseImpl: ServerWrapper,
+  options: unknown,
+  handler: RouteHandler,
+): Handler {
+  const routes = withSupabaseImpl(options, handler);
+  // withSupabase hands back a one-argument handler, so the floor is adapted to
+  // that shape rather than the two-argument one it wraps elsewhere.
+  return withErrorFloor(async (req: Request) => await routes(req));
+}

--- a/supabase/functions/admin-api/lib/gotrue.ts
+++ b/supabase/functions/admin-api/lib/gotrue.ts
@@ -100,8 +100,11 @@ export async function listUsersByFilter(
   perPage: number,
 ): Promise<ListUsersResult> {
   const url = new URL("/auth/v1/admin/users", deps.url);
-  // URLSearchParams percent-encodes the value, so a `+` or `%` in the address
-  // reaches GoTrue as itself rather than as a wildcard or a space.
+  // URLSearchParams percent-encodes the value, so a `+` reaches GoTrue as a
+  // plus rather than a space. Percent-encoding does NOT make a wildcard safe:
+  // GoTrue decodes the parameter before building the LIKE pattern, so `%` and
+  // `_` arrive as wildcards regardless. Neutralizing those is the caller's job,
+  // through identity.gotrueFilter.
   url.searchParams.set("filter", filter);
   url.searchParams.set("page", String(page));
   url.searchParams.set("per_page", String(perPage));

--- a/supabase/functions/admin-api/lib/identity.ts
+++ b/supabase/functions/admin-api/lib/identity.ts
@@ -30,8 +30,38 @@ export function isUuid(value: string): boolean {
  *
  * This is not trying to be RFC 5322. It is trying to guarantee that whatever
  * reaches filter= is specific enough that a sweep is impossible.
+ *
+ * `_` is NOT excluded here even though it is the other LIKE wildcard, because
+ * it is an ordinary character in real addresses and rejecting `first_last@
+ * example.com` as "malformed" would be a false claim about a valid address.
+ * It is neutralized at the boundary instead - see gotrueFilter.
  */
 const EMAIL = /^[^\s@%,]+@[^\s@%,.]+(\.[^\s@%,.]+)+$/;
+
+/**
+ * Escape an address for GoTrue's filter=, which is a `LIKE '%' || filter ||
+ * '%'` pattern rather than a literal substring test.
+ *
+ * `_` matches any single character there, so an unescaped address is a pattern,
+ * not a search term. No rows leak (narrowToExactEmail still demands an exact
+ * match), but the request forces a wider scan than it should, and the
+ * ambiguous-vs-absent answer then reports whether more than LOOKUP_PAGE_SIZE
+ * accounts match an arbitrary pattern - the inference the strict validator
+ * exists to prevent.
+ *
+ * Backslash is LIKE's default escape character and Postgres applies it here.
+ * Verified against the live project 2026-07-31, with a service-role filter
+ * query per row:
+ *   filter=robworksmusi_@gmail.com   -> 1 user  (`_` matched a real character)
+ *   filter=robworksmusi\_@gmail.com  -> 0 users (escaped, no literal match)
+ *   filter=robworksmusic\@gmail.com  -> 1 user  (the escape is consumed, so a
+ *                                                backslash is not sent literally)
+ * The backslash itself is escaped first, so an address containing one cannot
+ * smuggle an escape sequence through.
+ */
+export function gotrueFilter(email: string): string {
+  return email.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
 
 /**
  * Parse the ?email= / ?id= pair into exactly one identifier.

--- a/supabase/functions/admin-api/lib/roster.ts
+++ b/supabase/functions/admin-api/lib/roster.ts
@@ -1,4 +1,4 @@
-import { LOOKUP_PAGE_SIZE, narrowToExactEmail } from "./identity.ts";
+import { gotrueFilter, LOOKUP_PAGE_SIZE, narrowToExactEmail } from "./identity.ts";
 import { type GoTrueDeps, listUsersByFilter } from "./gotrue.ts";
 
 export interface AdminRow {
@@ -72,9 +72,10 @@ export async function grantAdmin(
   email: string,
 ): Promise<{ status: number; body: unknown }> {
   // Through lib/gotrue.ts, not supabase-js: the admin client drops `filter`.
+  // Escaped for the same reason as the lookup path: filter= is a LIKE pattern.
   const { users, hasMore } = await listUsersByFilter(
     deps,
-    email,
+    gotrueFilter(email),
     1,
     LOOKUP_PAGE_SIZE,
   );

--- a/supabase/functions/admin-api/tests/accounts_test.ts
+++ b/supabase/functions/admin-api/tests/accounts_test.ts
@@ -137,6 +137,17 @@ Deno.test("findUser by email sends the address as filter=, not as a page read", 
   assertStringIncludes(urls[0], "per_page=100");
 });
 
+Deno.test("findUser escapes the LIKE wildcards before they reach filter=", async () => {
+  // An address is a pattern until its wildcards are escaped: `_` matches any
+  // single character in GoTrue's filter, so this one would scan far wider than
+  // the address it was given. Asserted on the wire, because escaping in
+  // identity.ts is worth nothing if this call site skips it.
+  const c = stubClient();
+  const { deps, urls } = stubGoTrue({ users: [USER] });
+  await findUser(c as any, deps, { kind: "email", email: "first_last@example.com" });
+  assertStringIncludes(urls[0], "filter=first%5C_last%40example.com");
+});
+
 Deno.test("findUser by email returns none when nothing matches exactly", async () => {
   const c = stubClient();
   const { deps } = stubGoTrue({ users: [{ ...USER, email: "other@example.com" }] });

--- a/supabase/functions/admin-api/tests/compose_test.ts
+++ b/supabase/functions/admin-api/tests/compose_test.ts
@@ -1,0 +1,89 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import { buildFetch } from "../lib/compose.ts";
+
+const ALLOWED = "https://runbook.fyi";
+
+function request(): Request {
+  return new Request("https://example.test/admin-api/health", {
+    headers: { Origin: ALLOWED },
+  });
+}
+
+/** Silence the deliberate console.error so a passing run stays readable. */
+async function quiet<T>(fn: () => Promise<T>): Promise<T> {
+  const original = console.error;
+  console.error = () => {};
+  try {
+    return await fn();
+  } finally {
+    console.error = original;
+  }
+}
+
+/** A withSupabase that never reaches the handler, the way a bad key does. */
+const throwingWrapper = () => () => {
+  throw new Error("service-role key rejected");
+};
+
+const okHandler = () => Promise.resolve(new Response("ok", { status: 200 }));
+
+Deno.test("buildFetch catches a throw from the wrapper, not only from the handler", async () => {
+  // The ordering test. With the floor nested INSIDE withSupabase this throw
+  // escapes to the platform, which answers plain text with no CORS headers -
+  // and the admin page reads that as a connection failure and says nothing was
+  // written, about writes that may well have committed.
+  const fetchFn = buildFetch(throwingWrapper, { auth: "user" }, okHandler);
+  const res = await quiet(() => fetchFn(request(), {}));
+  assertEquals(res.status, 500);
+  assertEquals(await res.json(), { error: "internal error" });
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), ALLOWED);
+});
+
+Deno.test("buildFetch catches a rejection from the wrapper", async () => {
+  // The async shape of the same failure: withSupabase builds its client lazily
+  // and the rejection surfaces on await rather than on call.
+  const wrapper = () => () => Promise.reject(new Error("claims shape"));
+  const fetchFn = buildFetch(wrapper, { auth: "user" }, okHandler);
+  const res = await quiet(() => fetchFn(request(), {}));
+  assertEquals(res.status, 500);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), ALLOWED);
+});
+
+Deno.test("buildFetch still catches a throw from the route handler", async () => {
+  // The inner position must keep working: this is the case the floor was added
+  // for, and it passes under BOTH nestings, which is why it cannot be the only
+  // test here.
+  const wrapper = (_o: unknown, h: any) => (req: Request) => h(req, {});
+  const fetchFn = buildFetch(wrapper, { auth: "user" }, () => {
+    throw new Error("route boom");
+  });
+  const res = await quiet(() => fetchFn(request(), {}));
+  assertEquals(res.status, 500);
+});
+
+Deno.test("buildFetch passes a successful response through untouched", async () => {
+  const wrapper = (_o: unknown, h: any) => (req: Request) => h(req, {});
+  const fetchFn = buildFetch(wrapper, { auth: "user" }, () =>
+    Promise.resolve(new Response("ok", { status: 200, headers: { "x-marker": "1" } })));
+  const res = await fetchFn(request(), {});
+  assertEquals(res.status, 200);
+  assertEquals(await res.text(), "ok");
+  assertEquals(res.headers.get("x-marker"), "1");
+});
+
+Deno.test("buildFetch hands the options and handler to the wrapper unchanged", async () => {
+  // Guards the glue itself: a buildFetch that quietly dropped auth: "user"
+  // would leave every route reachable without a user JWT, and every other test
+  // in this file would still pass.
+  const seen: Array<{ options: unknown; handler: unknown }> = [];
+  const options = { auth: "user" };
+  const handler = okHandler;
+  const wrapper = (o: unknown, h: any) => {
+    seen.push({ options: o, handler: h });
+    return (req: Request) => h(req, {});
+  };
+  await buildFetch(wrapper, options, handler)(request(), {});
+  assertEquals(seen.length, 1);
+  assertEquals(seen[0].options, options);
+  assertEquals(seen[0].handler === handler, true);
+});

--- a/supabase/functions/admin-api/tests/identity_test.ts
+++ b/supabase/functions/admin-api/tests/identity_test.ts
@@ -1,5 +1,10 @@
 import { assertEquals, assertThrows } from "jsr:@std/assert@1";
-import { isUuid, narrowToExactEmail, parseUserQuery } from "../lib/identity.ts";
+import {
+  gotrueFilter,
+  isUuid,
+  narrowToExactEmail,
+  parseUserQuery,
+} from "../lib/identity.ts";
 
 Deno.test("parseUserQuery accepts a complete email", () => {
   assertEquals(parseUserQuery("someone@example.com", null), {
@@ -82,4 +87,33 @@ Deno.test("isUuid accepts a canonical uuid and rejects free text", () => {
   assertEquals(isUuid(""), false);
   assertEquals(isUuid("3f2504e0-4f89-11d3-9a0c-0305e82c3301x"), false);
   assertEquals(isUuid("3f2504e0_4f89_11d3_9a0c_0305e82c3301"), false);
+});
+
+Deno.test("gotrueFilter escapes the LIKE wildcards", () => {
+  // filter= is `LIKE '%' || filter || '%'`, so an unescaped `_` matches any
+  // single character. Verified live 2026-07-31: filter=robworksmusi_@gmail.com
+  // matched robworksmusic@gmail.com; the escaped form matched nothing.
+  assertEquals(gotrueFilter("_@_._"), "\\_@\\_.\\_");
+  assertEquals(gotrueFilter("a%b@example.com"), "a\\%b@example.com");
+});
+
+Deno.test("gotrueFilter escapes the escape character itself", () => {
+  // Otherwise an address containing a backslash smuggles an escape sequence in:
+  // `a\_b` would reach LIKE with `_` already escaped by the caller's own text.
+  assertEquals(gotrueFilter("a\\_b@example.com"), "a\\\\\\_b@example.com");
+});
+
+Deno.test("gotrueFilter leaves an ordinary address alone", () => {
+  // The escape must not become a reason a normal lookup stops matching.
+  assertEquals(gotrueFilter("someone@example.com"), "someone@example.com");
+});
+
+Deno.test("parseUserQuery accepts an underscore, which is a valid address character", () => {
+  // `_` is a LIKE wildcard but an ordinary character in a real address.
+  // Rejecting it here would answer a valid address with "malformed", so it is
+  // neutralized at the boundary (gotrueFilter) instead of refused.
+  assertEquals(parseUserQuery("first_last@example.com", null), {
+    kind: "email",
+    email: "first_last@example.com",
+  });
 });

--- a/supabase/functions/admin-api/tests/roster_test.ts
+++ b/supabase/functions/admin-api/tests/roster_test.ts
@@ -168,6 +168,17 @@ Deno.test("grantAdmin sends the address as filter=, not as a page read", async (
   assertStringIncludes(urls[0], "per_page=100");
 });
 
+Deno.test("grantAdmin escapes the LIKE wildcards before they reach filter=", async () => {
+  // Same boundary as the lookup path, and it has to be asserted separately:
+  // this call site builds its own filter argument.
+  const c = stubClient({
+    admins: [{ user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" }],
+  });
+  const { deps, urls } = stubGoTrue({ users: [{ id: "x", email: "first_last@example.com" }] });
+  await grantAdmin(c as any, deps, "a", "first_last@example.com");
+  assertStringIncludes(urls[0], "filter=first%5C_last%40example.com");
+});
+
 Deno.test("grantAdmin 404s when no candidate matches exactly", async () => {
   const c = stubClient({
     admins: [{ user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" }],

--- a/tests/js/admin-accounts.test.js
+++ b/tests/js/admin-accounts.test.js
@@ -63,6 +63,16 @@ describe("admin accounts renderer", () => {
     expect(root.textContent).toContain("no admins");
   });
 
+  it("does not claim the roster is empty when it could not be read", () => {
+    // null is "no answer", which is not the same fact as "no rows". Saying the
+    // trigger is broken on a 500 makes a confident claim about database state
+    // this code has no evidence for.
+    window.RunbookAdminAccounts.renderRoster(root, null);
+    expect(root.textContent).toContain("Could not load the admin roster");
+    expect(root.textContent).not.toContain("no admins");
+    expect(root.textContent).not.toContain("trigger");
+  });
+
   it("marks the reset control as destructive for assistive tech", () => {
     window.RunbookAdminAccounts.renderUser(root, USER);
     const btn = root.querySelector("[data-action='reset-progress']");
@@ -290,6 +300,124 @@ describe("admin accounts reset listener idempotency", () => {
     // only one of them is fixed by retyping the address.
     const out = root.querySelector("#admin-reset-result");
     expect(out.textContent).toContain("no such user");
+  });
+
+  it("does not narrate a failed roster request as an empty roster", async () => {
+    // The wiring half of the renderer test above: init() must pass the failure
+    // through as a failure. Passing { admins: [] } here - what it used to do -
+    // put the trigger claim on the page for a plain 500.
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      if (String(url).includes("/admins")) {
+        return { ok: false, status: 500, json: async () => ({ error: "boom" }) };
+      }
+      return { ok: false };
+    };
+
+    await window.RunbookAdminAccounts.init();
+
+    const roster = root.querySelector("#admin-roster");
+    expect(roster.textContent).toContain("Could not load the admin roster");
+    expect(roster.textContent).not.toContain("check the trigger");
+  });
+
+  it("still names an empty roster as the impossibility it is", async () => {
+    // The other side of the same branch. Without this row, collapsing both
+    // outcomes back into one message would pass the test above.
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      if (String(url).includes("/admins")) return { ok: true, json: async () => ({ admins: [] }) };
+      return { ok: false };
+    };
+
+    await window.RunbookAdminAccounts.init();
+
+    const roster = root.querySelector("#admin-roster");
+    expect(roster.textContent).toContain("check the trigger");
+    expect(roster.textContent).not.toContain("Could not load");
+  });
+
+  it("sends one reset per intent, not one per click", async () => {
+    // The delete is idempotent, so a double-click loses no extra data - but the
+    // audit insert is not, and two rows for one intent misreport how many
+    // resets were performed.
+    const calls = [];
+    let release;
+    const held = new Promise((resolve) => { release = resolve; });
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      if (String(url).includes("/admins")) return { ok: true, json: async () => ({ admins: [] }) };
+      if (String(url).includes("/user/progress/reset")) {
+        calls.push(url);
+        await held;
+        return { ok: true, json: async () => ({}) };
+      }
+      return { ok: false };
+    };
+
+    await window.RunbookAdminAccounts.init();
+    window.RunbookAdminAccounts.renderUser(root, USER);
+    const form = root.querySelector(".admin-reset-form");
+    const btn = form.querySelector("[data-action='reset-progress']");
+    form.querySelector("input").value = USER.user.email;
+
+    const submit = () =>
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    try {
+      submit();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The request is still in flight here, which is the only window in which
+      // the second click can do damage.
+      expect(calls.length).toBe(1);
+      expect(btn.disabled).toBe(true);
+      // Both, in step: assistive tech reads the attribute, and a control that
+      // announces itself as available while refusing every activation is worse
+      // than one that says it is busy.
+      expect(btn.getAttribute("aria-disabled")).toBe("true");
+
+      submit();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(calls.length).toBe(1);
+    } finally {
+      // In a finally, because the component instance outlives this test: the
+      // IIFE returns early once window.RunbookAdminAccounts exists, so its
+      // in-flight flag is shared with every later test in the file. A failed
+      // assertion here would otherwise leave that flag stuck and fail four
+      // unrelated tests with it.
+      release();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Released afterwards, or one reset costs the admin the button for the
+    // rest of the session.
+    expect(btn.disabled).toBe(false);
+    expect(btn.getAttribute("aria-disabled")).toBe(null);
+    expect(root.querySelector("#admin-reset-result").textContent)
+      .toContain("Progress reset");
+  });
+
+  it("leaves the reset button usable after a submit it refused to send", async () => {
+    // The empty-confirmation branch returns before any request goes out. If it
+    // took the in-flight lock on the way past, the admin would have to reload
+    // the page to be able to retry at all.
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      if (String(url).includes("/admins")) return { ok: true, json: async () => ({ admins: [] }) };
+      return { ok: true, json: async () => ({}) };
+    };
+
+    await window.RunbookAdminAccounts.init();
+    window.RunbookAdminAccounts.renderUser(root, USER);
+    const form = root.querySelector(".admin-reset-form");
+    const btn = form.querySelector("[data-action='reset-progress']");
+    form.querySelector("input").value = "";
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(btn.disabled).toBe(false);
+    expect(btn.getAttribute("aria-disabled")).toBe(null);
   });
 
   it("fires the reset handler once even after init() has re-run", async () => {


### PR DESCRIPTION
Closes #186, #188, #190, #192.

## admin-api

**#188 - `_` is a live wildcard in GoTrue's `filter=`.** Probed against the live project first, because the fix depended on the answer:

| filter | users returned |
| --- | --- |
| `robworksmusic@gmail.com` | 1 |
| `robworksmusi_@gmail.com` | 1 (the `_` matched a real character) |
| `robworksmusic\@gmail.com` | 1 (the escape is consumed, so backslash is not sent literally) |
| `robworksmusi\_@gmail.com` | 0 (escaped, no literal match) |

So the wildcard is real, and backslash works as LIKE's escape character here. The fix escapes at the boundary rather than rejecting `_` in the validator: `_` is an ordinary character in real addresses, and answering `first_last@example.com` with "malformed email address" would be a false claim about a valid address. Both call sites escape, and both are asserted on the wire, because escaping in `identity.ts` buys nothing if a call site skips it.

Also drops the claim in `gotrue.ts` that percent-encoding makes a wildcard safe. It does not - the parameter is decoded before the LIKE pattern is built.

**#192 - the wrapper ordering is now testable.** The composition moved to `lib/compose.ts`, so a test can throw from the *wrapper* rather than the handler and still demand a CORS-bearing JSON 500. The handler-throw case passes under both nestings, which is why it cannot be the only test there.

## admin accounts page

**#186** - a failed `/admins` request rendered as an empty roster, which then stated that the last-admin trigger was broken. A failure now says the list was not read and says nothing about who is an admin. Both sides of the branch are tested, so collapsing them back into one message fails.

**#190** - the reset button is disabled in flight, with a flag guarding the handler itself. The flag is taken after the branches that return without sending anything, and released in a `finally`, so a refused or failed submit cannot leave the button dead.

## Verification

`./verify.sh` passes. Every new guard was mutation-checked; each row below is a separate run with the mutation asserted as applied and the tree restored afterwards.

| mutation | result |
| --- | --- |
| `gotrueFilter` returns the address unescaped | 4 failed |
| lookup call site skips escaping | 1 failed |
| grant call site skips escaping | 1 failed |
| error floor nested inside `withSupabase` | 3 failed |
| options dropped on the way to `withSupabase` | 1 failed |
| failed roster renders as an empty roster again | 1 failed |
| renderer collapses no-answer into the empty-roster copy | 2 failed |
| in-flight flag never set | 1 failed |
| button never disabled | 1 failed |
| `aria-disabled` not synced with the property | 1 failed |
| lock never released | 6 failed |
| lock taken before the empty-confirmation guard | 4 failed |

The two high-count rows are honest: a stuck lock does break every later reset.