### PR TITLE
fix(admin): announce one sentence per dashboard refresh, not the whole page

### DIFF
--- a/admin.md
+++ b/admin.md
@@ -8,6 +8,7 @@ search:
 
 # Admin
 
-<div id="admin-root" role="region" aria-label="Admin dashboard" aria-live="polite">
-<p id="admin-status">Checking authorization...</p>
+<div id="admin-root" role="region" aria-label="Admin dashboard">
+<p id="admin-dashboard-status" class="sr-only" role="status"></p>
+<p id="admin-status" role="status">Checking authorization...</p>
 </div>

--- a/assets/javascripts/components/admin/dashboard.js
+++ b/assets/javascripts/components/admin/dashboard.js
@@ -46,40 +46,107 @@
     return t;
   }
 
+  // One live region for the whole page, present in the page shell from first
+  // render and never removed or rebuilt. It replaces the blanket aria-live that
+  // used to sit on #admin-root: a live region wrapping a subtree that gets
+  // cleared and rebuilt announces the ENTIRE dashboard on every refresh - every
+  // table, every number - instead of the one thing that changed. Same shape the
+  // accounts page uses.
+  var LIVE_ID = "admin-dashboard-status";
+
+  function liveRegion(root) {
+    var region = document.getElementById(LIVE_ID);
+    if (region) return region;
+    // Only reached if the shell markup lost the element. Created empty and
+    // never populated in the same step: assistive tech watches a region it
+    // already knows about for changes, so a region created already holding its
+    // text may never be announced at all.
+    region = el("p", { id: LIVE_ID, class: "sr-only", role: "status" });
+    root.insertBefore(region, root.firstChild);
+    return region;
+  }
+
+  var pendingAnnounce = null;
+
+  /**
+   * Announce one sentence for one load. Exactly one write per load: a second
+   * announcing node reads the same thing twice.
+   *
+   * Assistive tech fires on a CHANGE to the region, so repeating a sentence
+   * verbatim announces nothing - and a refresh that produces the same summary
+   * is the common case here. An identical message is therefore cleared and
+   * re-set in a later task; done synchronously the two writes coalesce back
+   * into "no change" before the accessibility tree is read.
+   */
+  function announce(message) {
+    var region = document.getElementById(LIVE_ID);
+    if (!region) return;
+    if (pendingAnnounce) {
+      clearTimeout(pendingAnnounce);
+      pendingAnnounce = null;
+    }
+    if (region.textContent !== message) {
+      region.textContent = message;
+      return;
+    }
+    region.textContent = "";
+    pendingAnnounce = setTimeout(function () {
+      pendingAnnounce = null;
+      region.textContent = message;
+    }, 0);
+  }
+
+  /**
+   * The rebuilt part of the page, kept separate from the live region and the
+   * status line so clearing it cannot take either of them with it. Rendering
+   * straight into the root is what made the region impossible to keep.
+   */
+  function content(root) {
+    var c = root.querySelector("#admin-content");
+    if (c) return c;
+    c = el("div", { id: "admin-content" });
+    root.appendChild(c);
+    return c;
+  }
+
   function renderPayload(root, payload) {
-    root.textContent = "";
+    // Only the content container is cleared. root.textContent = "" took the
+    // live region and the status line with it, which is why neither could
+    // survive a refresh.
+    var out = content(root);
+    out.textContent = "";
 
     var freshness = payload.stale
       ? "Showing cached data, " + Math.round(payload.ageSeconds / 60) +
         " minutes old, because the live fetch failed."
       : "Live data as of " + payload.generatedAt + ".";
-    root.appendChild(el("p", { class: "admin-freshness" }, freshness));
-    root.appendChild(el("p", {}, "Range: " + payload.range));
+    out.appendChild(el("p", { class: "admin-freshness" }, freshness));
+    out.appendChild(el("p", {}, "Range: " + payload.range));
 
     var ga4 = payload.ga4 || {};
-    root.appendChild(el("h2", {}, "Traffic (" + ga4.population + ")"));
+    out.appendChild(el("h2", {}, "Traffic (" + ga4.population + ")"));
     if (ga4.error) {
-      root.appendChild(
+      out.appendChild(
         el("p", { class: "admin-error" },
           "Google Analytics data is " + ga4.error + ". The figures below cover signed-in users only.")
       );
     } else {
-      root.appendChild(table("Traffic totals", ["Metric", "Value"], [
+      out.appendChild(table("Traffic totals", ["Metric", "Value"], [
         ["Active users", ga4.activeUsers],
         ["Sessions", ga4.sessions],
       ]));
-      root.appendChild(table("Top pages by views", ["Page", "Views"],
+      out.appendChild(table("Top pages by views", ["Page", "Views"],
         (ga4.topPages || []).map(function (p) { return [p.path, p.views]; })));
-      root.appendChild(table("Event counts", ["Event", "Count"],
+      out.appendChild(table("Event counts", ["Event", "Count"],
         Object.keys(ga4.events || {}).map(function (k) { return [k, ga4.events[k]]; })));
     }
 
     var pr = payload.progress || {};
-    root.appendChild(el("h2", {}, "Progress (" + pr.population + ")"));
-    root.appendChild(table("Registered users", ["Metric", "Value"], [
+    out.appendChild(el("h2", {}, "Progress (" + pr.population + ")"));
+    out.appendChild(table("Registered users", ["Metric", "Value"], [
       ["Registered users", pr.registeredUsers],
     ]));
-    root.appendChild(table(
+    out.appendChild(table(
       "Per-guide progress",
       ["Guide", "Users", "Sections read", "Quizzes attempted", "Quizzes passed", "Exercises completed"],
       (pr.pages || []).map(function (p) {
@@ -100,20 +167,23 @@
    * sections and saying what each one covers.
    */
   function renderTraffic(root, traffic) {
-    root.appendChild(el("h2", {}, "Traffic (all readers, first-party)"));
+    // Appended to the same container renderPayload wrote, never cleared: this
+    // section is added after the overview has already rendered.
+    var out = content(root);
+    out.appendChild(el("h2", {}, "Traffic (all readers, first-party)"));
 
     if (!traffic || traffic.error) {
-      root.appendChild(el("p", { class: "admin-error" },
+      out.appendChild(el("p", { class: "admin-error" },
         "First-party traffic is unavailable. The Google Analytics section above " +
         "covers consenting, non-blocking readers only."));
       return;
     }
 
-    root.appendChild(el("p", {}, traffic.from + " to " + traffic.to + "."));
+    out.appendChild(el("p", {}, traffic.from + " to " + traffic.to + "."));
 
     var totals = traffic.totals || {};
     var perDay = totals.visitorsPerDay || {};
-    root.appendChild(table("Traffic totals", ["Metric", "Value"], [
+    out.appendChild(table("Traffic totals", ["Metric", "Value"], [
       ["Page views", totals.pageviews],
       ["Visitors per day (average)", perDay.avg],
       ["Visitors per day (busiest day)", perDay.peak],
@@ -125,29 +195,29 @@
     // exists to report - summing the daily column would count one person once
     // per day they visited. Saying so beats leaving a reader to assume the
     // omission is an oversight.
-    root.appendChild(el("p", { class: "admin-note" },
+    out.appendChild(el("p", { class: "admin-note" },
       "There is no total visitor count for the whole range. Visitors are " +
       "identified per day and that identifier is discarded nightly, so the " +
       "same person cannot be recognised across two days. Page views add up; " +
       "visitors do not."));
 
-    root.appendChild(table("Daily traffic", ["Day", "Visitors", "Page views", "Signed in"],
+    out.appendChild(table("Daily traffic", ["Day", "Visitors", "Page views", "Signed in"],
       (traffic.daily || []).map(function (d) {
         return [d.day, d.visitors, d.pageviews, d.signedIn];
       })));
 
-    root.appendChild(table("Top pages by views", ["Page", "Topic", "Views"],
+    out.appendChild(table("Top pages by views", ["Page", "Topic", "Views"],
       (traffic.topPages || []).map(function (p) {
         return [p.path, p.topic || "", p.views];
       })));
 
-    root.appendChild(table("Entry pages", ["Page", "Entries"],
+    out.appendChild(table("Entry pages", ["Page", "Entries"],
       (traffic.topEntryPages || []).map(function (p) {
         return [p.path, p.entries];
       })));
 
     var referrers = traffic.topReferrers || [];
-    root.appendChild(referrers.length
+    out.appendChild(referrers.length
       ? table("Referrers", ["Source", "Views"],
           referrers.map(function (r) { return [r.host, r.views]; }))
       // An empty referrer table reads as broken collection. It usually means
@@ -157,12 +227,37 @@
           "arrived directly, or their browser sent no referrer."));
   }
 
+  /**
+   * Report a page-level outcome. Uses the status line while it is still on the
+   * page; once a successful render has removed it the message goes into the
+   * content container instead, so the text always lands somewhere a reader can
+   * reach it.
+   *
+   * The status line is itself a live region in the page shell, so writing to it
+   * announces. Once it is gone the announcement goes through the persistent
+   * region instead - never both, or the message is read twice.
+   */
+  function fail(root, status, message) {
+    if (status && status.isConnected) {
+      status.textContent = message;
+      return;
+    }
+    var out = content(root);
+    out.textContent = "";
+    out.appendChild(el("p", { class: "admin-error" }, message));
+    announce(message);
+  }
+
   var inFlight = false;
 
   async function init() {
     var root = document.getElementById("admin-root");
     if (!root) return;
     if (inFlight) return;
+    // Established before anything can have an outcome, and idempotent, so the
+    // re-init that follows every runbook:auth-changed neither duplicates the
+    // region nor makes it announce on its own.
+    liveRegion(root);
     var status = document.getElementById("admin-status");
 
     // No RunbookAuth, or no client behind it, means the auth chain itself
@@ -170,10 +265,8 @@
     // something the reader can act on.
     var client = window.RunbookAuth && window.RunbookAuth.getClient();
     if (!client) {
-      if (status) {
-        status.textContent =
-          "Sign-in is unavailable right now. Reload the page to try again.";
-      }
+      fail(root, status,
+        "Sign-in is unavailable right now. Reload the page to try again.");
       return;
     }
 
@@ -189,23 +282,29 @@
     var session = await client.auth.getSession();
     var token = session.data.session && session.data.session.access_token;
     if (!token) {
-      if (status) status.textContent = "Sign in to view this page.";
+      fail(root, status, "Sign in to view this page.");
       return;
     }
 
     var headers = { Authorization: "Bearer " + token };
     var health = await fetch(API + "/health", { headers });
     if (!health.ok) {
-      if (status) status.textContent = "Not authorized.";
+      fail(root, status, "Not authorized.");
       return;
     }
 
     var res = await fetch(API + "/overview?range=28d", { headers });
     if (!res.ok) {
-      if (status) status.textContent = "Failed to load dashboard data.";
+      fail(root, status, "Failed to load dashboard data.");
       return;
     }
-    renderPayload(root, await res.json());
+    var payload = await res.json();
+    // Removed before the render, not after: it says "Checking authorization..."
+    // and authorization is settled. Leaving it would sit a stale sentence above
+    // live figures, and it is a role="status" node, so a later write to it
+    // would announce alongside the persistent region.
+    if (status && status.isConnected) status.remove();
+    renderPayload(root, payload);
 
     // Fetched after the overview has already rendered, and failure is confined
     // to its own section: first-party traffic is the newest and least proven
@@ -219,6 +318,27 @@
       traffic = null;
     }
     renderTraffic(root, traffic);
+
+    // One sentence, once, after both sections exist. Announced here rather than
+    // per section, because two announcements for one refresh is the same defect
+    // as announcing the whole page, just smaller: the reader has to sit through
+    // the first to hear the second.
+    announce(summarize(payload, traffic));
+  }
+
+  /**
+   * The whole refresh in one sentence: whether the figures are live, and
+   * whether either half is missing. A reader who hears this knows whether to
+   * trust the numbers without being read the numbers.
+   */
+  function summarize(payload, traffic) {
+    var parts = [payload.stale
+      ? "Dashboard updated with cached data, " +
+        Math.round(payload.ageSeconds / 60) + " minutes old."
+      : "Dashboard updated with live data."];
+    if ((payload.ga4 || {}).error) parts.push("Google Analytics data is unavailable.");
+    if (!traffic || traffic.error) parts.push("First-party traffic is unavailable.");
+    return parts.join(" ");
   }
 
   window.RunbookAdminDashboard = {

--- a/tests/js/admin-dashboard.test.js
+++ b/tests/js/admin-dashboard.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { loadComponent, cleanup } from "./helpers.js";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 
 const PAYLOAD = {
   range: "28d",
@@ -87,8 +89,17 @@ describe("admin dashboard auth states", () => {
   function mountAdminRoot() {
     const el = document.createElement("div");
     el.id = "admin-root";
+    // Mirrors the shipped markup in admin.md, including the persistent live
+    // region. A test that mounts a root without it would exercise the
+    // create-it-on-demand fallback rather than the path readers get.
+    const live = document.createElement("p");
+    live.id = "admin-dashboard-status";
+    live.className = "sr-only";
+    live.setAttribute("role", "status");
+    el.appendChild(live);
     status = document.createElement("p");
     status.id = "admin-status";
+    status.setAttribute("role", "status");
     status.textContent = "Checking authorization...";
     el.appendChild(status);
     document.body.appendChild(el);
@@ -145,6 +156,175 @@ describe("admin dashboard auth states", () => {
     expect(calls[0]).toContain("/health");
     expect(status.textContent).toBe("Not authorized.");
     delete global.fetch;
+  });
+});
+
+describe("admin dashboard announcements", () => {
+  let root;
+
+  function mountShell() {
+    const el = document.createElement("div");
+    el.id = "admin-root";
+    el.setAttribute("role", "region");
+    const live = document.createElement("p");
+    live.id = "admin-dashboard-status";
+    live.className = "sr-only";
+    live.setAttribute("role", "status");
+    el.appendChild(live);
+    const status = document.createElement("p");
+    status.id = "admin-status";
+    status.setAttribute("role", "status");
+    status.textContent = "Checking authorization...";
+    el.appendChild(status);
+    document.body.appendChild(el);
+    return el;
+  }
+
+  const live = () => document.getElementById("admin-dashboard-status");
+
+  function scriptedFetch(payload, traffic) {
+    global.fetch = async (url) => {
+      if (String(url).includes("/health")) return { ok: true, json: async () => ({ admin: true }) };
+      if (String(url).includes("/overview")) return { ok: true, json: async () => payload };
+      if (String(url).includes("/traffic")) {
+        if (traffic === undefined) return { ok: false };
+        return { ok: true, json: async () => traffic };
+      }
+      return { ok: false };
+    };
+  }
+
+  beforeEach(async () => {
+    root = mountShell();
+    await loadComponent("admin/dashboard");
+    window.RunbookAuth = {
+      getClient: () => ({
+        auth: { getSession: async () => ({ data: { session: { access_token: "jwt" } } }) },
+      }),
+    };
+  });
+
+  afterEach(() => {
+    delete window.RunbookAuth;
+    delete global.fetch;
+    cleanup();
+  });
+
+  it("keeps the live region out of the rebuilt subtree", async () => {
+    // The defect this fixes: renderPayload cleared #admin-root, which contained
+    // the region, so nothing could survive a refresh to announce through.
+    scriptedFetch(PAYLOAD, TRAFFIC);
+    await window.RunbookAdminDashboard.init();
+
+    expect(live()).toBeTruthy();
+    expect(live().isConnected).toBe(true);
+    // And the figures still rendered, so this is not passing by rendering
+    // nothing at all.
+    expect(root.textContent).toContain("1234");
+  });
+
+  it("announces one sentence for a refresh, not the whole dashboard", async () => {
+    scriptedFetch(PAYLOAD, TRAFFIC);
+    await window.RunbookAdminDashboard.init();
+
+    const spoken = live().textContent;
+    expect(spoken).toBe("Dashboard updated with live data.");
+    // The numbers are on the page but must not be inside the announcement:
+    // that is precisely what a blanket aria-live on the root produced.
+    expect(spoken).not.toContain("1234");
+    expect(spoken).not.toContain("Per-guide progress");
+  });
+
+  it("says in the announcement when the figures are cached", async () => {
+    // Staleness changes whether the reader should trust what follows, so it is
+    // the one detail worth spending the sentence on.
+    scriptedFetch({ ...PAYLOAD, stale: true, ageSeconds: 900 }, TRAFFIC);
+    await window.RunbookAdminDashboard.init();
+
+    expect(live().textContent).toContain("cached data");
+    expect(live().textContent).toContain("15 minutes old");
+  });
+
+  it("names each missing half in the announcement", async () => {
+    // A reader who cannot see the page has no other way to tell a section that
+    // is empty from one that failed.
+    scriptedFetch({ ...PAYLOAD, ga4: { ...PAYLOAD.ga4, error: "unavailable" } }, undefined);
+    await window.RunbookAdminDashboard.init();
+
+    expect(live().textContent).toContain("Google Analytics data is unavailable");
+    expect(live().textContent).toContain("First-party traffic is unavailable");
+  });
+
+  it("announces a repeated refresh that produced the same sentence", async () => {
+    // Assistive tech fires on a CHANGE, so writing identical text announces
+    // nothing - and an unchanged dashboard is the common case on a refresh.
+    scriptedFetch(PAYLOAD, TRAFFIC);
+    await window.RunbookAdminDashboard.init();
+    expect(live().textContent).toBe("Dashboard updated with live data.");
+
+    // Deliberately NOT cleared by the test. Clearing it here would put the
+    // region in a state where a plain write is already a change, so the
+    // deferred re-set would never run and this test would pass against code
+    // that dropped it entirely - which is exactly what it did until a mutation
+    // row came back with zero failures.
+    await window.RunbookAdminDashboard.init();
+    expect(live().textContent).toBe("");
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(live().textContent).toBe("Dashboard updated with live data.");
+  });
+
+  it("removes the authorization line once the figures are up", async () => {
+    // "Checking authorization..." above live numbers is a stale claim, and it
+    // is a role="status" node, so leaving it gives the page two announcers.
+    scriptedFetch(PAYLOAD, TRAFFIC);
+    await window.RunbookAdminDashboard.init();
+
+    expect(document.getElementById("admin-status")).toBe(null);
+  });
+
+  it("still reports a later failure after the status line is gone", async () => {
+    // init() re-runs on runbook:auth-changed, so a sign-out after a successful
+    // render has no status line left to write to.
+    scriptedFetch(PAYLOAD, TRAFFIC);
+    await window.RunbookAdminDashboard.init();
+    expect(document.getElementById("admin-status")).toBe(null);
+
+    window.RunbookAuth = {
+      getClient: () => ({
+        auth: { getSession: async () => ({ data: { session: null } }) },
+      }),
+    };
+    await window.RunbookAdminDashboard.init();
+
+    expect(root.textContent).toContain("Sign in to view this page.");
+    expect(live().textContent).toContain("Sign in to view this page.");
+    // The stale figures go with it: leaving them under a sign-in message reads
+    // as though they are still current.
+    expect(root.textContent).not.toContain("1234");
+  });
+
+  it("does not announce on a load that rendered nothing", async () => {
+    // init() runs on every page load, including for a reader who is not an
+    // admin. An announcement there would be noise about a page with no content.
+    global.fetch = async () => ({ ok: false });
+    await window.RunbookAdminDashboard.init();
+
+    expect(live().textContent).toBe("");
+  });
+});
+
+describe("admin dashboard page shell", () => {
+  it("ships the live region in the markup and no blanket aria-live", () => {
+    // A region created by the script at the moment it is first needed may never
+    // be announced, so this asserts the shipped markup rather than what the
+    // component can patch up. The blanket aria-live is the defect itself: a
+    // live region wrapping a rebuilt subtree announces every table in it.
+    const shell = readFileSync(resolve(__dirname, "../../admin.md"), "utf-8");
+    expect(shell).toContain('id="admin-dashboard-status"');
+    expect(shell).toContain('class="sr-only"');
+    expect(shell).toContain('role="status"');
+    expect(shell).not.toContain("aria-live");
   });
 });
 


### PR DESCRIPTION
Closes #183.

`#admin-root` carried a blanket `aria-live="polite"` and `renderPayload()` opened with `root.textContent = ""`, rebuilding the whole dashboard inside that region. One refresh therefore announced every table and every number instead of the thing that changed - and because the region was the root, each render also destroyed anything that could have announced a single outcome.

## What changed

- The blanket `aria-live` comes off `#admin-root`; a persistent `sr-only` `role="status"` region ships in `admin.md`, present from first render.
- The rebuilt figures move into their own `#admin-content` container, so clearing them cannot take the live region or the status line with them.
- Each load announces **one** sentence: live or cached (with age), plus a clause naming either half that is unavailable. A reader hears whether to trust the numbers without being read the numbers.
- A repeat refresh producing an identical sentence is cleared and re-set in a later task, because assistive tech fires on a change, not on a write.
- The "Checking authorization..." line is removed once figures render, so the page has one announcer rather than two. A failure arriving after that - `runbook:auth-changed` fires on sign-out - still lands in the content container and the live region, and clears the stale figures rather than leaving them under a sign-in message.

This is the shape `admin-accounts.md` and `components/admin/accounts.js` already use.

## Verification

`./verify.sh` passes. Ten mutation rows, each a separate run with the mutation asserted as applied and the tree restored afterwards:

| mutation | result |
| --- | --- |
| blanket `aria-live` back on the root | 1 failed |
| live region dropped from the shell | 1 failed |
| render clears the whole root again | 6 failed |
| announcement carries the page instead of a sentence | 2 failed |
| staleness dropped from the sentence | 1 failed |
| missing halves not named | 1 failed |
| identical sentence never re-announced | 1 failed |
| stale authorization line left in place | 2 failed |
| failure after the status line is gone goes nowhere | 1 failed |
| announces even when nothing rendered | 1 failed |

The repeat-announcement row initially came back **zero**, which is a finding rather than a pass. The test had cleared the region by hand before the second load, so a plain write was already a change and the deferred re-set never ran - it passed against code that dropped the branch entirely. Rewritten to leave the region holding its text and assert the intermediate empty state, it now fails as it should.