### PR TITLE
fix(admin): answer the question the caller actually asked

### DIFF
--- a/assets/javascripts/components/admin/accounts.js
+++ b/assets/javascripts/components/admin/accounts.js
@@ -219,7 +219,18 @@
     s.appendChild(table("Current admins",
       ["Email", "User id", "Note", "Granted"],
       admins.map(function (a) {
-        return [a.email || "(unknown)", a.userId, a.note || "", a.createdAt];
+        // Three different facts, three different cells. "(unknown)" for all of
+        // them told an admin the account has no address on file when the server
+        // had actually failed to read it - a fault worth retrying, dressed as a
+        // settled property of the account.
+        return [
+          a.email || (a.emailUnavailable
+            ? "(could not be read)"
+            : "(no address on file)"),
+          a.userId,
+          a.note || "",
+          a.createdAt,
+        ];
       })));
   }
 

--- a/check-site.sh
+++ b/check-site.sh
@@ -28,10 +28,30 @@ if [ ! -d "$SITE" ]; then
   exit 1
 fi
 
+# The sitemap is parsed as XML, once, into a list of URL paths. Grepping it for
+# "<loc>" answered a different question than the one being asked: the count was
+# of matching lines rather than of entries, and the per-page absence check
+# matched a substring of a URL, so a page at /guides/admin/ would have satisfied
+# "admin is absent from the sitemap" while being listed in it. Pretty-printing,
+# a namespace change, or an entry split across lines defeat the grep silently -
+# and silently, here, means passing.
+SITEMAP_PATHS=$(python3 -c '
+import sys, xml.etree.ElementTree as ET
+from urllib.parse import urlparse
+root = ET.parse(sys.argv[1] + "/sitemap.xml").getroot()
+# Matched on local name: the sitemaps namespace arrives as part of the tag
+# ({http://...}loc), and hardcoding the full name would make a namespace change
+# read as "no entries" rather than as a parse failure.
+for node in root.iter():
+    if node.tag.split("}")[-1] == "loc" and (node.text or "").strip():
+        print(urlparse(node.text.strip()).path)
+' "$SITE" 2>/dev/null)
+
 # Precondition: prove we are reading a real sitemap with real entries, so a
-# passing "admin is absent" check cannot be an empty-file false negative.
-sitemap_entries() { [ "$(grep -c '<loc>' "$SITE/sitemap.xml" 2>/dev/null || echo 0)" -gt 50 ]; }
-check "sitemap.xml exists and has >50 entries" sitemap_entries
+# passing "admin is absent" check cannot be an empty-file false negative. A
+# sitemap that does not parse at all lands here as zero entries.
+sitemap_entries() { [ "$(printf '%s\n' "$SITEMAP_PATHS" | grep -c .)" -gt 50 ]; }
+check "sitemap.xml parses as XML and has >50 entries" sitemap_entries
 
 # Precondition: prove we can actually parse search_index.json and that it has
 # a plausible number of entries, so a passing "page is absent" check below
@@ -60,8 +80,41 @@ check "search_index.json parses and has a plausible number of entries" search_in
 ADMIN_PAGES=("admin" "admin-accounts")
 
 page_built() { [ -f "$SITE/$1/index.html" ]; }
-page_not_in_sitemap() { ! grep -q "<loc>[^<]*/$1/</loc>" "$SITE/sitemap.xml"; }
-page_noindex() { grep -qi 'name="robots" content="noindex' "$SITE/$1/index.html"; }
+
+# Whole-path comparison against the parsed sitemap, not a substring of the raw
+# file.
+page_not_in_sitemap() { ! printf '%s\n' "$SITEMAP_PATHS" | grep -qx "/$1/"; }
+
+# The robots meta is parsed out of the HTML and its content split into
+# directives. The grep it replaces required one exact spelling - name before
+# content, double quotes, noindex first - so reordering the attributes, which
+# is a theme's business and not ours, would have reported the admin pages as
+# indexable; and it matched anywhere in the file, so the word appearing in page
+# text or in a code sample counted as a robots directive.
+page_noindex() {
+  python3 -c '
+import sys
+from html.parser import HTMLParser
+
+class Robots(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.directives = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() != "meta":
+            return
+        a = {k.lower(): (v or "") for k, v in attrs}
+        if a.get("name", "").lower() == "robots":
+            self.directives += [d.strip().lower() for d in a["content"].split(",")]
+
+p = Robots()
+with open(sys.argv[1], encoding="utf-8") as f:
+    p.feed(f.read())
+# Whole directive, not a substring: "noindexing" is not noindex.
+sys.exit(0 if "noindex" in p.directives else 1)
+' "$SITE/$1/index.html"
+}
 
 # mkdocs-material emits compact JSON with no space after the colon
 # ("location":"admin/"), so a naive grep for "location": " never matches and

--- a/supabase/functions/admin-api/lib/roster.ts
+++ b/supabase/functions/admin-api/lib/roster.ts
@@ -4,6 +4,14 @@ import { type GoTrueDeps, listUsersByFilter } from "./gotrue.ts";
 export interface AdminRow {
   userId: string;
   email: string | null;
+  /**
+   * True when the address could not be read at all, as opposed to being read
+   * and found absent. Both leave `email` null, and collapsing them tells an
+   * admin an account has no address on file when the truth is that nobody
+   * knows - which is the wrong thing to act on, because one is a property of
+   * the account and the other is a fault to retry.
+   */
+  emailUnavailable: boolean;
   note: string | null;
   createdAt: string;
 }
@@ -19,16 +27,28 @@ export type RevokeCheck =
  * authoritative check because this one is a check-then-act race. This exists so
  * the common case returns a clean 409 rather than a raw Postgres error.
  *
- * Self-revoke is checked first: when both conditions hold, "you cannot revoke
- * yourself" is the message the admin can act on.
+ * The order of the three checks is the whole point of this function:
+ *
+ * 1. Self-revoke. An actor is an admin by definition of having reached here, so
+ *    this can never be the non-member case, and it is the message the admin can
+ *    act on when the roster is also down to one.
+ * 2. Membership. Revoking an account that is not on the roster removes nothing,
+ *    so it cannot empty the roster - answering "cannot remove the last admin"
+ *    describes a consequence that was never on the table and sends the admin
+ *    looking for a second admin to grant when the address was simply wrong.
+ * 3. Roster size, which is only meaningful once the target is known to be on it.
  */
 export function checkRevoke(args: {
   actorId: string;
   targetId: string;
+  isMember: boolean;
   rosterSize: number;
 }): RevokeCheck {
   if (args.actorId === args.targetId) {
     return { ok: false, status: 403, error: "cannot revoke yourself" };
+  }
+  if (!args.isMember) {
+    return { ok: false, status: 404, error: "not an admin" };
   }
   if (args.rosterSize <= 1) {
     return { ok: false, status: 409, error: "cannot remove the last admin" };
@@ -54,10 +74,17 @@ export async function listAdmins(supabaseAdmin: any): Promise<AdminRow[]> {
   for (const r of rows) {
     // getUserById, not a list+filter: the id is exact, so there is nothing to
     // narrow and no reason to pull other accounts into memory.
-    const { data } = await supabaseAdmin.auth.admin.getUserById(r.user_id);
+    const { data, error } = await supabaseAdmin.auth.admin.getUserById(r.user_id);
+    // A failed lookup is reported, not thrown: one unreadable address must not
+    // cost the admin the whole roster, which is the part that decides who can
+    // revoke whom. It is also not silently flattened to null - see
+    // emailUnavailable on AdminRow.
+    const failed = Boolean(error);
+    const email = failed ? null : (data?.user?.email ?? null);
     out.push({
       userId: r.user_id,
-      email: data?.user?.email ?? null,
+      email: email === "" ? null : email,
+      emailUnavailable: failed,
       note: r.note,
       createdAt: r.created_at,
     });
@@ -132,13 +159,10 @@ export async function revokeAdmin(
   const check = checkRevoke({
     actorId,
     targetId,
+    isMember: rows.some((r) => r.user_id === targetId),
     rosterSize: rows.length,
   });
   if (!check.ok) return { status: check.status, body: { error: check.error } };
-
-  if (!rows.some((r) => r.user_id === targetId)) {
-    return { status: 404, body: { error: "not an admin" } };
-  }
 
   // Delete and audit in one transaction, so a failed audit insert can never
   // leave an admin revoked with no record of it - nor report a completed revoke

--- a/supabase/functions/admin-api/tests/accounts_test.ts
+++ b/supabase/functions/admin-api/tests/accounts_test.ts
@@ -411,3 +411,54 @@ Deno.test("resetProgress refuses a real address against an empty-string account 
   assertEquals(c.calls.some((x) => x.op === "rpc"), false);
 });
 
+
+Deno.test("lookupAccount counts the pages in the progress blob", async () => {
+  const c = stubClient({
+    byId: USER,
+    progress: {
+      progress: { "Git/branching": {}, "Git/merging": {}, "Nginx/tls": {} },
+      updated_at: "2026-07-01T00:00:00Z",
+    },
+  });
+  const { deps } = stubGoTrue();
+  const res = await lookupAccount(c as any, deps, { kind: "id", id: USER.id });
+  assertEquals(res.status, 200);
+  assertEquals((res.body as any).progress.pageCount, 3);
+  assertEquals((res.body as any).progress.updatedAt, "2026-07-01T00:00:00Z");
+});
+
+Deno.test("lookupAccount reports a stored but empty blob as zero pages", async () => {
+  // A row that exists with nothing in it is not the same as no row, and the
+  // two must not collapse: one account has signed in and read nothing, the
+  // other has no progress record at all.
+  const c = stubClient({
+    byId: USER,
+    progress: { progress: {}, updated_at: "2026-07-01T00:00:00Z" },
+  });
+  const { deps } = stubGoTrue();
+  const res = await lookupAccount(c as any, deps, { kind: "id", id: USER.id });
+  assertEquals((res.body as any).progress.pageCount, 0);
+});
+
+Deno.test("lookupAccount reports a null progress column as zero pages, not a crash", async () => {
+  // The column is nullable, so a row can carry updated_at with a null blob.
+  // Object.keys(null) throws; the ?? is what keeps this a number.
+  const c = stubClient({
+    byId: USER,
+    progress: { progress: null, updated_at: "2026-07-01T00:00:00Z" },
+  });
+  const { deps } = stubGoTrue();
+  const res = await lookupAccount(c as any, deps, { kind: "id", id: USER.id });
+  assertEquals(res.status, 200);
+  assertEquals((res.body as any).progress.pageCount, 0);
+});
+
+Deno.test("lookupAccount reports no progress row as null, never as zero pages", async () => {
+  // null and 0 are different answers: one says the account has no progress
+  // record, the other says it has one holding nothing.
+  const c = stubClient({ byId: USER, progress: null });
+  const { deps } = stubGoTrue();
+  const res = await lookupAccount(c as any, deps, { kind: "id", id: USER.id });
+  assertEquals(res.status, 200);
+  assertEquals((res.body as any).progress, null);
+});

--- a/supabase/functions/admin-api/tests/roster_test.ts
+++ b/supabase/functions/admin-api/tests/roster_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertRejects, assertStringIncludes } from "jsr:@std/assert@1";
-import { checkRevoke, grantAdmin, revokeAdmin } from "../lib/roster.ts";
+import { checkRevoke, grantAdmin, listAdmins, revokeAdmin } from "../lib/roster.ts";
 import type { GoTrueDeps } from "../lib/gotrue.ts";
 
 /**
@@ -27,24 +27,51 @@ function stubGoTrue(opts: {
 }
 
 Deno.test("checkRevoke refuses self-revoke", () => {
-  const r = checkRevoke({ actorId: "a", targetId: "a", rosterSize: 5 });
+  const r = checkRevoke({ actorId: "a", targetId: "a", isMember: true, rosterSize: 5 });
   assertEquals(r, { ok: false, status: 403, error: "cannot revoke yourself" });
 });
 
 Deno.test("checkRevoke refuses emptying the roster", () => {
-  const r = checkRevoke({ actorId: "a", targetId: "b", rosterSize: 1 });
+  const r = checkRevoke({ actorId: "a", targetId: "b", isMember: true, rosterSize: 1 });
   assertEquals(r, { ok: false, status: 409, error: "cannot remove the last admin" });
 });
 
 Deno.test("checkRevoke allows a normal revoke", () => {
-  assertEquals(checkRevoke({ actorId: "a", targetId: "b", rosterSize: 2 }), { ok: true });
+  assertEquals(
+    checkRevoke({ actorId: "a", targetId: "b", isMember: true, rosterSize: 2 }),
+    { ok: true },
+  );
 });
 
 Deno.test("checkRevoke checks self before roster size", () => {
   // Both conditions hold. Self-revoke is the more actionable message, and the
   // one the admin can actually fix.
-  const r = checkRevoke({ actorId: "a", targetId: "a", rosterSize: 1 });
+  const r = checkRevoke({ actorId: "a", targetId: "a", isMember: true, rosterSize: 1 });
   assertEquals(r, { ok: false, status: 403, error: "cannot revoke yourself" });
+});
+
+Deno.test("checkRevoke checks self before membership", () => {
+  // Only reachable when the actor was revoked by someone else between the admin
+  // gate and the roster read. Both answers are true; "cannot revoke yourself" is
+  // the one that stays true on a retry, and a retry is what "not an admin" about
+  // your own id invites.
+  const r = checkRevoke({ actorId: "a", targetId: "a", isMember: false, rosterSize: 3 });
+  assertEquals(r, { ok: false, status: 403, error: "cannot revoke yourself" });
+});
+
+Deno.test("checkRevoke reports a non-member as a 404 even on a one-admin roster", () => {
+  // Both the membership and the roster-size condition hold, and the roster-size
+  // answer is the wrong one: removing an account that is not on the roster
+  // removes nothing, so it could never have emptied it. "Cannot remove the last
+  // admin" sends the admin off to grant a second admin when the id was simply
+  // not one.
+  const r = checkRevoke({ actorId: "a", targetId: "b", isMember: false, rosterSize: 1 });
+  assertEquals(r, { ok: false, status: 404, error: "not an admin" });
+});
+
+Deno.test("checkRevoke reports a non-member as a 404 on a healthy roster too", () => {
+  const r = checkRevoke({ actorId: "a", targetId: "b", isMember: false, rosterSize: 5 });
+  assertEquals(r, { ok: false, status: 404, error: "not an admin" });
 });
 
 /**
@@ -59,7 +86,10 @@ function stubClient(opts: {
   admins?: Array<{ user_id: string; note: string | null; created_at: string }>;
   deleteError?: { code?: string; message: string };
   insertError?: { code?: string; message: string };
-  users?: Array<{ id: string; email: string }>;
+  users?: Array<{ id: string; email: string | null }>;
+  // Ids whose getUserById fails outright, as opposed to resolving to an
+  // account with no address.
+  lookupErrors?: Record<string, { message: string }>;
 }) {
   const calls: Array<{ table: string; op: string; payload?: unknown }> = [];
   const admins = opts.admins ?? [];
@@ -67,11 +97,16 @@ function stubClient(opts: {
     calls,
     auth: {
       admin: {
-        getUserById: (id: string) =>
-          Promise.resolve({
+        getUserById: (id: string) => {
+          const failure = (opts.lookupErrors ?? {})[id];
+          if (failure) {
+            return Promise.resolve({ data: { user: null }, error: failure });
+          }
+          return Promise.resolve({
             data: { user: (opts.users ?? []).find((u) => u.id === id) ?? null },
             error: null,
-          }),
+          });
+        },
       },
     },
     rpc(name: string, params: Record<string, unknown>) {
@@ -120,6 +155,32 @@ Deno.test("revokeAdmin writes nothing when the guard refuses", async () => {
   });
   const res = await revokeAdmin(c as any, "a", "a");
   assertEquals(res.status, 403);
+  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+});
+
+Deno.test("revokeAdmin 404s a non-admin on a single-admin roster", async () => {
+  // The end-to-end shape of the ordering bug: an admin pastes an id that was
+  // never on the roster, and the answer describes the roster's size instead of
+  // the id. Asserted through revokeAdmin, not only through checkRevoke, because
+  // the call site is what decides the order of the arguments it passes.
+  const c = stubClient({
+    admins: [{ user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" }],
+  });
+  const res = await revokeAdmin(c as any, "a", "stranger");
+  assertEquals(res.status, 404);
+  assertEquals((res.body as any).error, "not an admin");
+  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+});
+
+Deno.test("revokeAdmin still refuses to empty a roster of one", async () => {
+  // The other side of the same ordering: the last-admin refusal has to survive
+  // the fix, for a target that IS on the roster.
+  const c = stubClient({
+    admins: [{ user_id: "solo", note: null, created_at: "2026-01-01T00:00:00Z" }],
+  });
+  const res = await revokeAdmin(c as any, "a", "solo");
+  assertEquals(res.status, 409);
+  assertEquals((res.body as any).error, "cannot remove the last admin");
   assertEquals(c.calls.some((x) => x.op === "rpc"), false);
 });
 
@@ -289,4 +350,42 @@ Deno.test("revokeAdmin maps the trigger's P0001 to a 409", async () => {
   });
   const res = await revokeAdmin(c as any, "a", "b");
   assertEquals(res.status, 409);
+});
+
+Deno.test("listAdmins distinguishes an unreadable address from an absent one", async () => {
+  // Both rows end up with email null. Only one of them is a fact about the
+  // account; the other is a fault. Reporting them identically told an admin
+  // "no address on file" about an account whose address nobody managed to read.
+  const c = stubClient({
+    admins: [
+      { user_id: "reads", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { user_id: "absent", note: null, created_at: "2026-01-02T00:00:00Z" },
+      { user_id: "fails", note: null, created_at: "2026-01-03T00:00:00Z" },
+    ],
+    users: [
+      { id: "reads", email: "someone@example.com" },
+      { id: "absent", email: null },
+    ],
+    lookupErrors: { fails: { message: "connection reset" } },
+  });
+  const rows = await listAdmins(c as any);
+  assertEquals(rows.map((r) => r.email), ["someone@example.com", null, null]);
+  assertEquals(rows.map((r) => r.emailUnavailable), [false, false, true]);
+});
+
+Deno.test("listAdmins keeps returning the roster when one lookup fails", async () => {
+  // Containment: the roster decides who can revoke whom, so one unreadable
+  // address must not cost the caller the whole list.
+  const c = stubClient({
+    admins: [
+      { user_id: "fails", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { user_id: "reads", note: "keeper", created_at: "2026-01-02T00:00:00Z" },
+    ],
+    users: [{ id: "reads", email: "someone@example.com" }],
+    lookupErrors: { fails: { message: "connection reset" } },
+  });
+  const rows = await listAdmins(c as any);
+  assertEquals(rows.length, 2);
+  assertEquals(rows[1].email, "someone@example.com");
+  assertEquals(rows[1].note, "keeper");
 });

--- a/tests/js/admin-accounts.test.js
+++ b/tests/js/admin-accounts.test.js
@@ -73,6 +73,34 @@ describe("admin accounts renderer", () => {
     expect(root.textContent).not.toContain("trigger");
   });
 
+  it("separates an unreadable address from an account with none on file", () => {
+    // Both rows carry email null. One is a property of the account, the other
+    // is a failed lookup worth retrying, and a shared placeholder tells the
+    // admin the wrong one half the time.
+    window.RunbookAdminAccounts.renderRoster(root, {
+      admins: [
+        {
+          userId: "absent",
+          email: null,
+          emailUnavailable: false,
+          note: "",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          userId: "failed",
+          email: null,
+          emailUnavailable: true,
+          note: "",
+          createdAt: "2026-01-02T00:00:00Z",
+        },
+      ],
+    });
+    const cells = [...root.querySelectorAll("tbody tr")].map(
+      (tr) => tr.firstElementChild.textContent
+    );
+    expect(cells).toEqual(["(no address on file)", "(could not be read)"]);
+  });
+
   it("marks the reset control as destructive for assistive tech", () => {
     window.RunbookAdminAccounts.renderUser(root, USER);
     const btn = root.querySelector("[data-action='reset-progress']");


### PR DESCRIPTION
Closes #179, closes #180, closes #181, closes #182.

Four fixes of the same shape: a response that was true of something other than what was asked.

**#179 - revoke ordering.** `revokeAdmin` ran the roster-size check before the membership test, so revoking an account that was never an admin answered `409 cannot remove the last admin` whenever the roster held exactly one admin. Removing a non-member removes nothing, so it could never have emptied the roster - the answer sent the admin looking for a second admin to grant when the id was simply wrong. Membership is now an argument to `checkRevoke`, ordered after the self-revoke refusal and before the size check.

**#182 - unreadable vs absent address.** `listAdmins` read only `data` from `getUserById`, so a failed lookup and an account with genuinely no address both arrived as `email: null` and rendered as `(unknown)`. The row now carries `emailUnavailable`, and the roster table prints `(could not be read)` and `(no address on file)` separately. One failed lookup still costs only its own cell, never the whole roster.

**#181 - site invariants parse instead of grep.** The sitemap check grepped for a substring of a URL (so a page at `/guides/admin/` satisfied "admin is absent") and missed a `<loc>` split across lines. The noindex check required one exact attribute order and matched the word anywhere in the file, page text included. Both are parsed now - XML via ElementTree, HTML via html.parser - and compared whole.

**#180 - pageCount coverage.** Four cases, including the nullable `progress` column that `Object.keys` would throw on, and the null-row case that must stay `null` rather than becoming `0`.

## Verification

`./verify.sh` passes. Both changes were mutation-checked before they were trusted:

- Edge function and front end, 7 rows: membership after size (the original bug), membership dropped, membership before self, a constant `isMember` at the call site, the `error` read reverted, `emailUnavailable` pinned false, and the front end collapsing both placeholders. All 7 fail.
- Site invariants, 9 rows against the built `site/`: admin listed in the sitemap, listed with the loc split across lines, sitemap unparseable, noindex dropped, robots meta removed, `noindexing` as a substring, the word appearing only in page text - all fail; an unrelated `/guides/admin/` entry and a robots meta with its attributes reordered both still pass, which is the strictness the greps did not have.

The self-before-membership row initially returned zero failures - nothing pinned that ordering, because every existing self-revoke case also passed `isMember: true`. Added the test for the both-hold case rather than accepting the row.