### PR TITLE
fix(admin): let the dashboard say GA4 answered with nothing

### DIFF
--- a/assets/javascripts/components/admin/dashboard.js
+++ b/assets/javascripts/components/admin/dashboard.js
@@ -131,6 +131,19 @@
           "Google Analytics data is " + ga4.error + ". The figures below cover signed-in users only.")
       );
     } else {
+      // An all-zero GA4 section is byte-for-byte what a broken query produces,
+      // and for months it was read as one. Saying which property answered, and
+      // that it answered with no rows, is what separates "nobody was counted"
+      // from "nothing was asked properly".
+      if (ga4.reported === false) {
+        out.appendChild(el("p", { class: "admin-note" },
+          "Google Analytics returned no rows for this range" +
+          (ga4.propertyId ? " (property " + ga4.propertyId + ")" : "") +
+          ". The query worked; nobody in this population was counted. Only " +
+          "readers who accept the cookie banner and do not block the tag reach " +
+          "GA at all, so compare the first-party traffic section below before " +
+          "concluding the site had no visitors."));
+      }
       out.appendChild(table("Traffic totals", ["Metric", "Value"], [
         ["Active users", ga4.activeUsers],
         ["Sessions", ga4.sessions],
@@ -336,7 +349,13 @@
       ? "Dashboard updated with cached data, " +
         Math.round(payload.ageSeconds / 60) + " minutes old."
       : "Dashboard updated with live data."];
-    if ((payload.ga4 || {}).error) parts.push("Google Analytics data is unavailable.");
+    var ga4 = payload.ga4 || {};
+    if (ga4.error) parts.push("Google Analytics data is unavailable.");
+    // Distinct from unavailable, and worth hearing: one is a fault, the other
+    // is an answer.
+    else if (ga4.reported === false) {
+      parts.push("Google Analytics counted nobody in this range.");
+    }
     if (!traffic || traffic.error) parts.push("First-party traffic is unavailable.");
     return parts.join(" ");
   }

--- a/supabase/functions/admin-api/lib/ga4.ts
+++ b/supabase/functions/admin-api/lib/ga4.ts
@@ -1,8 +1,55 @@
-interface Ga4Section {
+export interface Ga4Section {
   activeUsers: number;
   sessions: number;
   topPages: Array<{ path: string; views: number }>;
   events: Record<string, number>;
+  /**
+   * The property that answered. An all-zero section used to be unattributable:
+   * the first question anyone asks of it is "which property is this reading",
+   * and the payload could not say. It is not a secret - this endpoint is
+   * admin-only, and the id identifies a report source, not a credential.
+   */
+  propertyId: string;
+  /**
+   * Did the Data API return any rows at all?
+   *
+   * Zero rows is a successful answer, and the section it produces is identical
+   * to the one a broken query would produce: every number zero, every list
+   * empty, no error. Recording it separately is the only way the page can tell
+   * "nobody was counted" from "nothing was asked properly" - which is exactly
+   * what cost an afternoon of chasing credentials that were fine.
+   */
+  reported: boolean;
+}
+
+/**
+ * Fold the three report responses into the section. Pure, so the shape this
+ * produces - especially the empty one - is testable without a network.
+ */
+export function toSection(
+  propertyId: string,
+  totals: any,
+  pages: any,
+  events: any,
+): Ga4Section {
+  const row = totals?.rows?.[0]?.metricValues ?? [];
+  const rowCount = (totals?.rows?.length ?? 0) + (pages?.rows?.length ?? 0) +
+    (events?.rows?.length ?? 0);
+  return {
+    activeUsers: Number(row[0]?.value ?? 0),
+    sessions: Number(row[1]?.value ?? 0),
+    topPages: (pages?.rows ?? []).map((r: any) => ({
+      path: r.dimensionValues[0].value,
+      views: Number(r.metricValues[0].value),
+    })),
+    events: Object.fromEntries(
+      (events?.rows ?? []).map((
+        r: any,
+      ) => [r.dimensionValues[0].value, Number(r.metricValues[0].value)]),
+    ),
+    propertyId,
+    reported: rowCount > 0,
+  };
 }
 
 /** Mint a Google OAuth access token from the service account via JWT bearer grant. */
@@ -59,8 +106,11 @@ async function accessToken(): Promise<string> {
   return (await res.json()).access_token;
 }
 
-async function runReport(token: string, body: unknown): Promise<any> {
-  const property = Deno.env.get("GA4_PROPERTY_ID");
+async function runReport(
+  token: string,
+  property: string,
+  body: unknown,
+): Promise<any> {
   const res = await fetch(
     `https://analyticsdata.googleapis.com/v1beta/properties/${property}:runReport`,
     {
@@ -82,22 +132,23 @@ async function runReport(token: string, body: unknown): Promise<any> {
  */
 export async function fetchGa4(days: number): Promise<Ga4Section | null> {
   try {
+    const property = Deno.env.get("GA4_PROPERTY_ID") ?? "";
     const token = await accessToken();
     const dateRanges = [{ startDate: `${days}daysAgo`, endDate: "today" }];
 
     const [totals, pages, events] = await Promise.all([
-      runReport(token, {
+      runReport(token, property, {
         dateRanges,
         metrics: [{ name: "activeUsers" }, { name: "sessions" }],
       }),
-      runReport(token, {
+      runReport(token, property, {
         dateRanges,
         dimensions: [{ name: "pagePath" }],
         metrics: [{ name: "screenPageViews" }],
         orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
         limit: 20,
       }),
-      runReport(token, {
+      runReport(token, property, {
         dateRanges,
         dimensions: [{ name: "eventName" }],
         metrics: [{ name: "eventCount" }],
@@ -105,21 +156,7 @@ export async function fetchGa4(days: number): Promise<Ga4Section | null> {
       }),
     ]);
 
-    const row = totals.rows?.[0]?.metricValues ?? [];
-    return {
-      activeUsers: Number(row[0]?.value ?? 0),
-      sessions: Number(row[1]?.value ?? 0),
-      topPages: (pages.rows ?? []).map((r: any) => ({
-        path: r.dimensionValues[0].value,
-        views: Number(r.metricValues[0].value),
-      })),
-      events: Object.fromEntries(
-        (events.rows ?? []).map((r: any) => [
-          r.dimensionValues[0].value,
-          Number(r.metricValues[0].value),
-        ]),
-      ),
-    };
+    return toSection(property, totals, pages, events);
   } catch (e) {
     console.warn("[admin-api] GA4 fetch failed:", (e as Error).message);
     return null;

--- a/supabase/functions/admin-api/lib/merge.ts
+++ b/supabase/functions/admin-api/lib/merge.ts
@@ -1,9 +1,17 @@
 /**
- * Assemble the dashboard payload. The two sections are labelled with their
- * population because they describe different groups: GA4 covers all visitors,
- * progress covers only signed-in users. The same quiz appears in both and the
- * numbers will never agree.
+ * Assemble the dashboard payload. The three sections are labelled with their
+ * population because they describe different groups and their numbers will
+ * never agree.
+ *
+ * GA4's label used to read "all visitors", which is the one thing it is not:
+ * the site gates the tag behind a cookie banner, so GA4 counts only readers who
+ * accepted analytics cookies AND are not blocking googletagmanager. That label
+ * is why an all-zero GA4 section read as a broken pipeline rather than as a
+ * true statement about a small population - the section was answering a
+ * narrower question than the one its own heading asked (#163).
  */
+export const GA4_POPULATION =
+  "readers who accepted analytics cookies and do not block the tag";
 export function buildPayload(
   range: string,
   ga4: unknown | null,
@@ -14,8 +22,8 @@ export function buildPayload(
     range,
     generatedAt: now.toISOString(),
     ga4: ga4 === null
-      ? { population: "all visitors", error: "unavailable" }
-      : { population: "all visitors", ...(ga4 as Record<string, unknown>) },
+      ? { population: GA4_POPULATION, error: "unavailable" }
+      : { population: GA4_POPULATION, ...(ga4 as Record<string, unknown>) },
     progress: {
       population: "signed-in users only",
       ...(progress as Record<string, unknown>),

--- a/supabase/functions/admin-api/tests/ga4_test.ts
+++ b/supabase/functions/admin-api/tests/ga4_test.ts
@@ -1,0 +1,64 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import { toSection } from "../lib/ga4.ts";
+
+const TOTALS = { rows: [{ metricValues: [{ value: "42" }, { value: "57" }] }] };
+const PAGES = {
+  rows: [{ dimensionValues: [{ value: "/Git/" }], metricValues: [{ value: "9" }] }],
+};
+const EVENTS = {
+  rows: [{ dimensionValues: [{ value: "page_view" }], metricValues: [{ value: "12" }] }],
+};
+
+Deno.test("toSection folds the three reports into one section", () => {
+  const s = toSection("525117219", TOTALS, PAGES, EVENTS);
+  assertEquals(s.activeUsers, 42);
+  assertEquals(s.sessions, 57);
+  assertEquals(s.topPages, [{ path: "/Git/", views: 9 }]);
+  assertEquals(s.events, { page_view: 12 });
+  assertEquals(s.propertyId, "525117219");
+  assertEquals(s.reported, true);
+});
+
+Deno.test("toSection marks a rowless answer as reporting nothing", () => {
+  // The case that made #163 unreadable: three successful responses, every one
+  // of them empty. The numbers below are indistinguishable from a query that
+  // asked the wrong property, so the flag is the only thing carrying the
+  // difference.
+  const s = toSection("525117219", { rows: [] }, { rows: [] }, { rows: [] });
+  assertEquals(s.reported, false);
+  assertEquals(s.activeUsers, 0);
+  assertEquals(s.sessions, 0);
+  assertEquals(s.topPages, []);
+  assertEquals(s.events, {});
+});
+
+Deno.test("toSection treats a response with no rows key as rowless", () => {
+  // The Data API omits `rows` entirely rather than sending an empty array when
+  // a report matches nothing, so the absent key has to count the same way.
+  const s = toSection("525117219", {}, {}, {});
+  assertEquals(s.reported, false);
+});
+
+Deno.test("toSection reports rows even when every metric is zero", () => {
+  // A real row carrying zero is not the same as no row: the property answered
+  // about a population it knows, and it counted none of them that period. Only
+  // the missing row means "nothing came back at all".
+  const s = toSection("525117219", {
+    rows: [{ metricValues: [{ value: "0" }, { value: "0" }] }],
+  }, { rows: [] }, { rows: [] });
+  assertEquals(s.reported, true);
+  assertEquals(s.activeUsers, 0);
+});
+
+Deno.test("toSection reports rows when only the events report matched", () => {
+  // Any one of the three is enough. Keying the flag off the totals report alone
+  // would call a section empty while its own event table listed counts.
+  const s = toSection("525117219", { rows: [] }, { rows: [] }, EVENTS);
+  assertEquals(s.reported, true);
+});
+
+Deno.test("toSection carries the property id through the empty case", () => {
+  // The empty case is exactly when someone needs to know which property was
+  // asked, so it must not be the case that drops the attribution.
+  assertEquals(toSection("999", {}, {}, {}).propertyId, "999");
+});

--- a/supabase/functions/admin-api/tests/merge_test.ts
+++ b/supabase/functions/admin-api/tests/merge_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "jsr:@std/assert@1";
-import { buildPayload } from "../lib/merge.ts";
+import { buildPayload, GA4_POPULATION } from "../lib/merge.ts";
 
 const NOW = new Date("2026-07-24T12:00:00Z");
 
@@ -8,7 +8,10 @@ Deno.test("buildPayload labels both sections with their population", () => {
     registeredUsers: 3,
     pages: [],
   }, NOW) as any;
-  assertEquals(out.ga4.population, "all visitors");
+  // Not "all visitors": the tag sits behind a cookie banner, so a label that
+  // claims everyone turns a small true number into an apparently broken one.
+  assertEquals(out.ga4.population, GA4_POPULATION);
+  assertEquals(out.ga4.population.includes("all visitors"), false);
   assertEquals(out.progress.population, "signed-in users only");
 });
 
@@ -22,4 +25,26 @@ Deno.test("buildPayload records the range and timestamp", () => {
   const out = buildPayload("7d", null, { registeredUsers: 0, pages: [] }, NOW) as any;
   assertEquals(out.range, "7d");
   assertEquals(out.generatedAt, "2026-07-24T12:00:00.000Z");
+});
+
+Deno.test("buildPayload labels the GA4 error case with the same population", () => {
+  // The heading is on screen either way. A failure that widens the claimed
+  // population re-creates the confusion the label exists to prevent.
+  const out = buildPayload("28d", null, { registeredUsers: 0, pages: [] }, NOW) as any;
+  assertEquals(out.ga4.population, GA4_POPULATION);
+});
+
+Deno.test("buildPayload passes the reported flag through untouched", () => {
+  // The merge layer must not invent it: a section that answered with no rows
+  // has to arrive at the page still saying so.
+  const out = buildPayload("28d", {
+    activeUsers: 0,
+    sessions: 0,
+    topPages: [],
+    events: {},
+    propertyId: "525117219",
+    reported: false,
+  }, { registeredUsers: 1, pages: [] }, NOW) as any;
+  assertEquals(out.ga4.reported, false);
+  assertEquals(out.ga4.propertyId, "525117219");
 });

--- a/tests/js/admin-dashboard.test.js
+++ b/tests/js/admin-dashboard.test.js
@@ -9,11 +9,16 @@ const PAYLOAD = {
   stale: false,
   ageSeconds: 0,
   ga4: {
-    population: "all visitors",
+    // The population the server actually sends. GA4 sits behind the cookie
+    // banner, so a fixture claiming "all visitors" would be testing a label
+    // the API stopped making.
+    population: "readers who accepted analytics cookies and do not block the tag",
     activeUsers: 1234,
     sessions: 2000,
     topPages: [{ path: "/Git/git-basics/", views: 500 }],
     events: { quiz_answer: 42 },
+    propertyId: "525117219",
+    reported: true,
   },
   progress: {
     population: "signed-in users only",
@@ -51,7 +56,7 @@ describe("admin dashboard renderer", () => {
 
   it("labels each section with its population", () => {
     window.RunbookAdminDashboard.renderPayload(root, PAYLOAD);
-    expect(root.textContent).toContain("all visitors");
+    expect(root.textContent).toContain("accepted analytics cookies");
     expect(root.textContent).toContain("signed-in users only");
   });
 
@@ -221,6 +226,21 @@ describe("admin dashboard announcements", () => {
     // And the figures still rendered, so this is not passing by rendering
     // nothing at all.
     expect(root.textContent).toContain("1234");
+  });
+
+  it("announces that GA counted nobody, distinctly from GA being unavailable", async () => {
+    // The two sound alike and mean opposite things: one is a fault to chase,
+    // the other is a fact about the audience. A reader hearing the wrong one
+    // goes to check credentials that are working.
+    scriptedFetch({
+      ...PAYLOAD,
+      ga4: { ...PAYLOAD.ga4, activeUsers: 0, sessions: 0, reported: false },
+    }, TRAFFIC);
+    await window.RunbookAdminDashboard.init();
+
+    const spoken = live().textContent;
+    expect(spoken).toContain("counted nobody");
+    expect(spoken).not.toContain("unavailable");
   });
 
   it("announces one sentence for a refresh, not the whole dashboard", async () => {
@@ -429,7 +449,7 @@ describe("admin dashboard first-party traffic", () => {
     window.RunbookAdminDashboard.renderPayload(root, PAYLOAD);
     window.RunbookAdminDashboard.renderTraffic(root, null);
     expect(root.textContent).toContain("1234");
-    expect(root.textContent).toContain("all visitors");
+    expect(root.textContent).toContain("accepted analytics cookies");
   });
 
   it("keeps the two populations in separate sections", () => {
@@ -439,7 +459,69 @@ describe("admin dashboard first-party traffic", () => {
     // Two distinct traffic headings, each naming its own population. One
     // merged table would imply the numbers are the same quantity.
     expect(headings.filter((h) => h.startsWith("Traffic")).length).toBe(2);
-    expect(headings.some((h) => h.includes("all visitors"))).toBe(true);
+    expect(headings.some((h) => h.includes("accepted analytics cookies"))).toBe(true);
     expect(headings.some((h) => h.includes("first-party"))).toBe(true);
+  });
+});
+
+describe("admin dashboard GA4 emptiness", () => {
+  let root;
+
+  const EMPTY_GA4 = {
+    ...PAYLOAD,
+    ga4: {
+      population: "readers who accepted analytics cookies and do not block the tag",
+      activeUsers: 0,
+      sessions: 0,
+      topPages: [],
+      events: {},
+      propertyId: "525117219",
+      reported: false,
+    },
+  };
+
+  beforeEach(async () => {
+    root = document.createElement("div");
+    document.body.appendChild(root);
+    await loadComponent("admin/dashboard");
+  });
+
+  afterEach(() => cleanup());
+
+  it("says a rowless GA4 answer is an answer, and names the property", () => {
+    // An all-zero section is byte-identical to what a query against the wrong
+    // property produces. Without this the page leaves the reader to guess
+    // which one they are looking at, which is what #163 actually cost.
+    window.RunbookAdminDashboard.renderPayload(root, EMPTY_GA4);
+    const text = root.textContent;
+    expect(text).toContain("returned no rows");
+    expect(text).toContain("525117219");
+    expect(text).toContain("first-party");
+  });
+
+  it("does not call a rowless answer unavailable", () => {
+    // "Unavailable" is the failure branch. Reporting a working query as a
+    // failure sends the admin to check credentials that are fine.
+    window.RunbookAdminDashboard.renderPayload(root, EMPTY_GA4);
+    expect(root.textContent).not.toContain("Google Analytics data is unavailable");
+    // The tables still render: zero is a number the admin asked for.
+    expect(root.querySelectorAll("table").length).toBeGreaterThan(1);
+  });
+
+  it("stays quiet about emptiness when rows came back", () => {
+    window.RunbookAdminDashboard.renderPayload(root, PAYLOAD);
+    expect(root.textContent).not.toContain("returned no rows");
+  });
+
+  it("keeps the note out of the way when GA4 failed outright", () => {
+    // Both branches would otherwise fire: an error section has no rows either,
+    // and telling the admin both "unavailable" and "the query worked" in one
+    // render is worse than telling them neither.
+    window.RunbookAdminDashboard.renderPayload(root, {
+      ...PAYLOAD,
+      ga4: { population: "x", error: "unavailable", reported: false },
+    });
+    expect(root.textContent).toContain("unavailable");
+    expect(root.textContent).not.toContain("returned no rows");
   });
 });


### PR DESCRIPTION
Closes #163.

## What the investigation found

The pipeline is fine. Probing GA as the same service account the edge function uses:

- The key reaches exactly **one** property, `525117219` "The Runbook", under the Firebase default account.
- That property's only web stream is `G-56L2QXTFGR`, which is the tag in `mkdocs.yml`. The tag and the query point at the same place, so candidate cause 1 (wrong property) is out - and a mismatched id would have produced a 403, which surfaces as the `error` field the issue notes was absent.
- The property's entire twelve-month history is about 100 page views: 68 in February, 22 in April, 12 in March, 2 in July. The 28-day window now reads 1 user / 2 sessions, and those are from testing this dashboard yesterday.

The reason is candidate cause 2, and stronger than the issue guessed: the site gates analytics behind Material's cookie consent banner (`extra.consent` in `mkdocs.yml`), so gtag never loads for a visitor who ignores it - before ad blockers are considered at all. First-party collection, live since 2026-07-30, agrees: 1 visitor and 3 page views on the one day both have data for.

So the zeros were true. There is no data bug to fix.

## What is fixed

The defect is that the payload could not tell anyone that. A rowless answer produced a section byte-identical to one built against the wrong property - every number zero, every list empty, no error - and the heading claimed the population was "all visitors", which is the one thing GA4 cannot cover here.

- `ga4.ts`: the section carries `propertyId` (which property answered) and `reported` (did the API return any rows). The three-report fold is extracted as a pure `toSection`, so the empty shape is testable without a network.
- `merge.ts`: the population label is now `readers who accepted analytics cookies and do not block the tag`, exported so the error branch cannot drift from the success branch.
- `dashboard.js`: the rowless case renders a note naming the property and pointing at the first-party section, and announces "counted nobody" rather than "unavailable" - a fact about the audience, not a fault to chase.

## Verification

`./verify.sh` passes. Mutation-checked, 10 rows, all failing: `reported` hardcoded true, keyed off the totals report alone, or treating a zero-metric row as no rows; property dropped from the section and from the note; the population label reverted and dropped from the error branch; the note never rendering, firing on the error branch too, and the announcement conflating empty with unavailable.

The zero-metric row case is the subtle one - a real row carrying `0` means the property answered about a population it knows, which is not the same as no row at all.