### PR TITLE
feat(admin): record refused admin actions, not only writes

### DIFF
--- a/supabase/functions/admin-api/lib/accounts.ts
+++ b/supabase/functions/admin-api/lib/accounts.ts
@@ -5,6 +5,7 @@ import {
   type UserQuery,
 } from "./identity.ts";
 import { type GoTrueDeps, listUsersByFilter } from "./gotrue.ts";
+import { recordRefusal, REFUSAL } from "./audit.ts";
 
 export interface AccountUser {
   id: string;
@@ -220,12 +221,35 @@ export async function resetProgress(
   confirmEmail: string,
 ): Promise<{ status: number; body: unknown }> {
   const user = await findUserById(supabaseAdmin, userId);
-  if (user === null) return { status: 404, body: { error: "no such user" } };
+  if (user === null) {
+    await recordRefusal(
+      supabaseAdmin,
+      actorId,
+      "progress.reset",
+      userId,
+      REFUSAL.noSuchUser,
+    );
+    return { status: 404, body: { error: REFUSAL.noSuchUser } };
+  }
 
   if (!confirmsAccount(user.email, confirmEmail)) {
+    // The refusal the issue was opened for. An attempt to wipe an account's
+    // progress with the wrong confirmation is worth more on the record than a
+    // successful one, and it left no trace at all.
+    //
+    // The submitted address is NOT stored. It is the field most likely to hold
+    // the wrong person's email - that is exactly why this refused - and this
+    // table records ids, never addresses.
+    await recordRefusal(
+      supabaseAdmin,
+      actorId,
+      "progress.reset",
+      userId,
+      REFUSAL.confirmationMismatch,
+    );
     return {
       status: 403,
-      body: { error: "confirmation email does not match that user id" },
+      body: { error: REFUSAL.confirmationMismatch },
     };
   }
 

--- a/supabase/functions/admin-api/lib/audit.ts
+++ b/supabase/functions/admin-api/lib/audit.ts
@@ -1,0 +1,58 @@
+/**
+ * Recording refused admin actions.
+ *
+ * Successful writes are audited inside the database functions that perform
+ * them, in the same transaction, so a missing row proves the write did not
+ * happen. A refusal has no write to be atomic with, so it is recorded here on
+ * its way out.
+ */
+
+/** The fixed vocabulary. Every value is a constant, never user input. */
+export const REFUSAL = {
+  noSuchUser: "no such user",
+  confirmationMismatch: "confirmation email does not match that user id",
+  selfRevoke: "cannot revoke yourself",
+  notAnAdmin: "not an admin",
+  lastAdmin: "cannot remove the last admin",
+  alreadyAnAdmin: "already an admin",
+  ambiguousAddress:
+    "too many candidate accounts for that address to resolve it safely",
+} as const;
+
+export type RefusalReason = typeof REFUSAL[keyof typeof REFUSAL];
+
+/**
+ * Record one refusal.
+ *
+ * Never throws, and never changes the caller's answer. The action was refused
+ * whether or not the log accepted the row, and turning a clean 403 into a 500
+ * because the audit insert failed would tell the admin their request MIGHT have
+ * gone through - which is the opposite of what a refusal means. The failure is
+ * logged instead of swallowed, because a log that quietly stops recording looks
+ * exactly like a period with nothing to record.
+ */
+export async function recordRefusal(
+  supabaseAdmin: any,
+  actorId: string,
+  action: string,
+  targetId: string | null,
+  reason: RefusalReason,
+): Promise<void> {
+  try {
+    const { error } = await supabaseAdmin.rpc("admin_record_refusal", {
+      p_actor: actorId,
+      p_action: action,
+      p_target: targetId,
+      p_reason: reason,
+    });
+    if (error) {
+      console.warn(
+        `[admin-api] refusal not audited (${action}): ${error.message ?? error}`,
+      );
+    }
+  } catch (e) {
+    console.warn(
+      `[admin-api] refusal not audited (${action}): ${(e as Error).message}`,
+    );
+  }
+}

--- a/supabase/functions/admin-api/lib/roster.ts
+++ b/supabase/functions/admin-api/lib/roster.ts
@@ -1,5 +1,6 @@
 import { gotrueFilter, LOOKUP_PAGE_SIZE, narrowToExactEmail } from "./identity.ts";
 import { type GoTrueDeps, listUsersByFilter } from "./gotrue.ts";
+import { recordRefusal, REFUSAL, type RefusalReason } from "./audit.ts";
 
 export interface AdminRow {
   userId: string;
@@ -18,7 +19,10 @@ export interface AdminRow {
 
 export type RevokeCheck =
   | { ok: true }
-  | { ok: false; status: number; error: string };
+  // The refusal strings ARE the audit vocabulary, one type rather than two
+  // copies: a message reworded on the way to the caller but not in the log
+  // would leave the log describing a refusal the admin never saw.
+  | { ok: false; status: number; error: RefusalReason };
 
 /**
  * Guard a revoke before touching the database.
@@ -45,13 +49,13 @@ export function checkRevoke(args: {
   rosterSize: number;
 }): RevokeCheck {
   if (args.actorId === args.targetId) {
-    return { ok: false, status: 403, error: "cannot revoke yourself" };
+    return { ok: false, status: 403, error: REFUSAL.selfRevoke };
   }
   if (!args.isMember) {
-    return { ok: false, status: 404, error: "not an admin" };
+    return { ok: false, status: 404, error: REFUSAL.notAnAdmin };
   }
   if (args.rosterSize <= 1) {
-    return { ok: false, status: 409, error: "cannot remove the last admin" };
+    return { ok: false, status: 409, error: REFUSAL.lastAdmin };
   }
   return { ok: true };
 }
@@ -111,21 +115,43 @@ export async function grantAdmin(
   if (user === null) {
     // An unmatched page-1 with more pages behind it is not "no such user" - the
     // account may be on a page we never asked for. Say so rather than 404.
+    //
+    // Both refusals are recorded with a null target: there is no account id to
+    // name, which is the whole reason they were refused. The address itself is
+    // deliberately not stored - the audit table holds ids, never emails.
     if (hasMore) {
+      await recordRefusal(
+        supabaseAdmin,
+        actorId,
+        "admin.grant",
+        null,
+        REFUSAL.ambiguousAddress,
+      );
       return {
         status: 409,
-        body: {
-          error:
-            "too many candidate accounts for that address to resolve it safely",
-        },
+        body: { error: REFUSAL.ambiguousAddress },
       };
     }
-    return { status: 404, body: { error: "no such user" } };
+    await recordRefusal(
+      supabaseAdmin,
+      actorId,
+      "admin.grant",
+      null,
+      REFUSAL.noSuchUser,
+    );
+    return { status: 404, body: { error: REFUSAL.noSuchUser } };
   }
 
   const existing = await rosterRows(supabaseAdmin);
   if (existing.some((r) => r.user_id === user.id)) {
-    return { status: 409, body: { error: "already an admin" } };
+    await recordRefusal(
+      supabaseAdmin,
+      actorId,
+      "admin.grant",
+      user.id,
+      REFUSAL.alreadyAnAdmin,
+    );
+    return { status: 409, body: { error: REFUSAL.alreadyAnAdmin } };
   }
 
   // The insert and its audit row go in one transaction. Written as two requests,
@@ -142,7 +168,14 @@ export async function grantAdmin(
     // That is the same conflict the check reports, so it gets the same answer
     // rather than surfacing as a 500. Mirrors the revoke path's P0001 mapping.
     if ((insErr as { code?: string }).code === "23505") {
-      return { status: 409, body: { error: "already an admin" } };
+      await recordRefusal(
+        supabaseAdmin,
+        actorId,
+        "admin.grant",
+        user.id,
+        REFUSAL.alreadyAnAdmin,
+      );
+      return { status: 409, body: { error: REFUSAL.alreadyAnAdmin } };
     }
     throw insErr;
   }
@@ -162,7 +195,20 @@ export async function revokeAdmin(
     isMember: rows.some((r) => r.user_id === targetId),
     rosterSize: rows.length,
   });
-  if (!check.ok) return { status: check.status, body: { error: check.error } };
+  if (!check.ok) {
+    // The refusals worth having on record: a self-revoke, a revoke that would
+    // have emptied the roster, and a revoke of an id that was never on it. All
+    // three leave the roster exactly as it was, so without this they leave no
+    // trace of having been attempted.
+    await recordRefusal(
+      supabaseAdmin,
+      actorId,
+      "admin.revoke",
+      targetId,
+      check.error,
+    );
+    return { status: check.status, body: { error: check.error } };
+  }
 
   // Delete and audit in one transaction, so a failed audit insert can never
   // leave an admin revoked with no record of it - nor report a completed revoke
@@ -176,14 +222,33 @@ export async function revokeAdmin(
     // The trigger fired: this delete would have emptied the roster, even though
     // our own count said otherwise. The trigger is authoritative.
     if (error.code === "P0001") {
-      return { status: 409, body: { error: "cannot remove the last admin" } };
+      await recordRefusal(
+        supabaseAdmin,
+        actorId,
+        "admin.revoke",
+        targetId,
+        REFUSAL.lastAdmin,
+      );
+      return { status: 409, body: { error: REFUSAL.lastAdmin } };
     }
     // The membership check above is check-then-act too: a concurrent revoke of
     // the same account commits in between and this delete matches no row. The
     // function refuses to audit a revoke it did not perform, and says so.
     if (error.code === "P0002") {
-      return { status: 404, body: { error: "not an admin" } };
+      await recordRefusal(
+        supabaseAdmin,
+        actorId,
+        "admin.revoke",
+        targetId,
+        REFUSAL.notAnAdmin,
+      );
+      return { status: 404, body: { error: REFUSAL.notAnAdmin } };
     }
+    // Deliberately NOT recorded as a refusal: nothing refused this revoke. It
+    // lost a race, and the same request repeated a second later succeeds. A log
+    // of blocked attempts that fills with transient lock noise is a log nobody
+    // reads.
+    //
     // Two admins revoking each other at the same instant is a lock cycle, and
     // Postgres breaks it by aborting one side (40P01) - or by giving up on the
     // lock, should a lock_timeout ever be set (55P03). Either way this

--- a/supabase/functions/admin-api/tests/accounts_test.ts
+++ b/supabase/functions/admin-api/tests/accounts_test.ts
@@ -35,6 +35,9 @@ function stubClient(opts: {
   progress?: any;
   deleted?: string[];
   rpcError?: unknown;
+  // Applies to the refusal audit only, so a failing audit cannot be mistaken
+  // for a failing delete.
+  refusalError?: unknown;
 } = {}) {
   const calls: Array<{ table: string; op: string; payload?: unknown }> = [];
   const deleted = opts.deleted ?? [];
@@ -64,6 +67,9 @@ function stubClient(opts: {
     // "nothing was deleted" assertions still mean what they say.
     rpc(name: string, params: Record<string, unknown>) {
       calls.push({ table: `rpc:${name}`, op: "rpc", payload: params });
+      if (name === "admin_record_refusal") {
+        return Promise.resolve({ data: null, error: opts.refusalError ?? null });
+      }
       if (opts.rpcError) return Promise.resolve({ data: null, error: opts.rpcError });
       if (name === "admin_reset_progress") deleted.push(params.p_target as string);
       return Promise.resolve({ data: null, error: null });
@@ -112,6 +118,21 @@ function stubGoTrue(opts: { users?: any[]; headers?: Record<string, string> } = 
     }) as typeof fetch,
   };
   return { deps, urls };
+}
+
+/**
+ * Did a WRITE happen? Auditing a refusal is itself an rpc, so "no rpc at all"
+ * no longer means "nothing was written".
+ */
+function wrote(c: { calls: Array<{ table: string; op: string }> }): boolean {
+  return c.calls.some((x) => x.op === "rpc" && x.table !== "rpc:admin_record_refusal");
+}
+
+/** The refusal rows this call recorded, in order. */
+function refusals(c: { calls: Array<{ table: string; op: string; payload?: unknown }> }) {
+  return c.calls
+    .filter((x) => x.table === "rpc:admin_record_refusal")
+    .map((x) => x.payload as Record<string, unknown>);
 }
 
 Deno.test("findUser by email discards substring-only candidates", async () => {
@@ -274,7 +295,7 @@ Deno.test("resetProgress refuses when confirmEmail belongs to another account", 
   );
   assertEquals(res.status, 403);
   assertEquals(c.deleted.length, 0);
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 Deno.test("resetProgress deletes and audits when the pair agrees", async () => {
@@ -282,7 +303,7 @@ Deno.test("resetProgress deletes and audits when the pair agrees", async () => {
   const res = await resetProgress(c as any, "actor", USER.id, USER.email);
   assertEquals(res.status, 200);
   assertEquals(c.deleted, [USER.id]);
-  const write = c.calls.find((x) => x.op === "rpc");
+  const write = c.calls.find((x) => x.table === "rpc:admin_reset_progress");
   assertEquals(write?.table, "rpc:admin_reset_progress");
   assertEquals((write?.payload as any).p_actor, "actor");
   assertEquals((write?.payload as any).p_target, USER.id);
@@ -295,7 +316,7 @@ Deno.test("resetProgress writes the row and its audit entry in one call", async 
   // Two separate database calls here would be that bug back.
   const c = stubClient({ byId: USER });
   await resetProgress(c as any, "actor", USER.id, USER.email);
-  const writes = c.calls.filter((x) => x.op !== "select");
+  const writes = c.calls.filter((x) => x.op !== "select" && x.table !== "rpc:admin_record_refusal");
   assertEquals(writes.length, 1);
   assertEquals(writes[0].op, "rpc");
 });
@@ -333,7 +354,7 @@ Deno.test("resetProgress never sends an email to the audit write", async () => {
   // must not travel to the database function that writes it.
   const c = stubClient({ byId: USER });
   await resetProgress(c as any, "actor", USER.id, USER.email);
-  const write = c.calls.find((x) => x.op === "rpc");
+  const write = c.calls.find((x) => x.table === "rpc:admin_reset_progress");
   assertEquals(JSON.stringify(write?.payload).includes("@"), false);
 });
 
@@ -359,7 +380,7 @@ Deno.test("resetProgress refuses a matching-looking confirmEmail when the accoun
   const res = await resetProgress(c as any, "actor", USER.id, "\t\n");
   assertEquals(res.status, 403);
   assertEquals(c.deleted.length, 0);
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 // GoTrue serializes an account with no address as "" rather than null, so
@@ -392,7 +413,7 @@ Deno.test("resetProgress refuses a blank confirmEmail against an empty-string ac
   const res = await resetProgress(c as any, "actor", USER.id, "");
   assertEquals(res.status, 403);
   assertEquals(c.deleted.length, 0);
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 Deno.test("resetProgress refuses a whitespace-only confirmEmail against an empty-string account email", async () => {
@@ -400,7 +421,7 @@ Deno.test("resetProgress refuses a whitespace-only confirmEmail against an empty
   const res = await resetProgress(c as any, "actor", USER.id, "   ");
   assertEquals(res.status, 403);
   assertEquals(c.deleted.length, 0);
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 Deno.test("resetProgress refuses a real address against an empty-string account email", async () => {
@@ -408,7 +429,7 @@ Deno.test("resetProgress refuses a real address against an empty-string account 
   const res = await resetProgress(c as any, "actor", USER.id, "someone@example.com");
   assertEquals(res.status, 403);
   assertEquals(c.deleted.length, 0);
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 
@@ -461,4 +482,62 @@ Deno.test("lookupAccount reports no progress row as null, never as zero pages", 
   const res = await lookupAccount(c as any, deps, { kind: "id", id: USER.id });
   assertEquals(res.status, 200);
   assertEquals((res.body as any).progress, null);
+});
+
+Deno.test("resetProgress records a wrong-confirmation attempt", async () => {
+  // The refusal the audit change exists for: someone tried to wipe an
+  // account's progress and confirmed with an address that belongs to someone
+  // else. Nothing was deleted, so nothing recorded it.
+  const c = stubClient({ byId: USER });
+  const res = await resetProgress(
+    c as any,
+    "actor-1",
+    USER.id,
+    "someone-else@example.com",
+  );
+  assertEquals(res.status, 403);
+  assertEquals(c.deleted.length, 0);
+  const r = refusals(c);
+  assertEquals(r.length, 1);
+  assertEquals(r[0].p_actor, "actor-1");
+  assertEquals(r[0].p_action, "progress.reset");
+  assertEquals(r[0].p_target, USER.id);
+  assertEquals(r[0].p_reason, "confirmation email does not match that user id");
+});
+
+Deno.test("resetProgress never stores the submitted confirmation address", async () => {
+  // The submitted address is the field most likely to hold the WRONG person's
+  // email - that is why this path refused - and this table records ids, never
+  // addresses. Scoped to the audit payload, not the whole call log, so the
+  // account's own fixture email cannot make it pass by accident.
+  const c = stubClient({ byId: USER });
+  await resetProgress(c as any, "actor-1", USER.id, "typo@example.com");
+  assertEquals(JSON.stringify(refusals(c)).includes("typo@example.com"), false);
+  assertEquals(JSON.stringify(refusals(c)).includes("@"), false);
+});
+
+Deno.test("resetProgress records an attempt against an unknown id", async () => {
+  const c = stubClient({});
+  const res = await resetProgress(c as any, "actor-1", USER.id, "x@example.com");
+  assertEquals(res.status, 404);
+  assertEquals(refusals(c)[0].p_reason, "no such user");
+});
+
+Deno.test("resetProgress records nothing when the reset goes through", async () => {
+  // Success is audited inside admin_reset_progress, in the same transaction as
+  // the delete. A refusal row here as well would describe an action that was
+  // not refused.
+  const c = stubClient({ byId: USER });
+  const res = await resetProgress(c as any, "actor-1", USER.id, USER.email);
+  assertEquals(res.status, 200);
+  assertEquals(refusals(c).length, 0);
+});
+
+Deno.test("resetProgress still refuses when the refusal cannot be audited", async () => {
+  // A failed audit must not upgrade a refusal into a 500: that would tell the
+  // admin the reset MIGHT have happened, about a row that is still there.
+  const c = stubClient({ byId: USER, refusalError: { message: "audit unavailable" } });
+  const res = await resetProgress(c as any, "actor-1", USER.id, "wrong@example.com");
+  assertEquals(res.status, 403);
+  assertEquals(c.deleted.length, 0);
 });

--- a/supabase/functions/admin-api/tests/roster_test.ts
+++ b/supabase/functions/admin-api/tests/roster_test.ts
@@ -87,6 +87,10 @@ function stubClient(opts: {
   deleteError?: { code?: string; message: string };
   insertError?: { code?: string; message: string };
   users?: Array<{ id: string; email: string | null }>;
+  // Error returned by the refusal audit function only. Separate from the write
+  // errors: a failed audit of a refusal must not be able to masquerade as the
+  // write failing.
+  refusalError?: { code?: string; message: string };
   // Ids whose getUserById fails outright, as opposed to resolving to an
   // account with no address.
   lookupErrors?: Record<string, { message: string }>;
@@ -111,7 +115,9 @@ function stubClient(opts: {
     },
     rpc(name: string, params: Record<string, unknown>) {
       calls.push({ table: `rpc:${name}`, op: "rpc", payload: params });
-      const error = name === "admin_grant_admin"
+      const error = name === "admin_record_refusal"
+        ? (opts.refusalError ?? null)
+        : name === "admin_grant_admin"
         ? (opts.insertError ?? null)
         : (opts.deleteError ?? null);
       return Promise.resolve({ data: null, error });
@@ -128,6 +134,23 @@ function stubClient(opts: {
       };
     },
   };
+}
+
+/**
+ * Did a WRITE happen? The audit of a refusal is also an rpc, so "no rpc at all"
+ * stopped meaning "nothing was written" the moment refusals started being
+ * recorded - and a test asserting the looser thing would fail for the right
+ * reason today and pass for the wrong one tomorrow.
+ */
+function wrote(c: { calls: Array<{ table: string; op: string }> }): boolean {
+  return c.calls.some((x) => x.op === "rpc" && x.table !== "rpc:admin_record_refusal");
+}
+
+/** The refusal rows this call recorded, in order. */
+function refusals(c: { calls: Array<{ table: string; op: string; payload?: unknown }> }) {
+  return c.calls
+    .filter((x) => x.table === "rpc:admin_record_refusal")
+    .map((x) => x.payload as Record<string, unknown>);
 }
 
 Deno.test("revokeAdmin removes the row and audits it in one call", async () => {
@@ -155,7 +178,7 @@ Deno.test("revokeAdmin writes nothing when the guard refuses", async () => {
   });
   const res = await revokeAdmin(c as any, "a", "a");
   assertEquals(res.status, 403);
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 Deno.test("revokeAdmin 404s a non-admin on a single-admin roster", async () => {
@@ -169,7 +192,7 @@ Deno.test("revokeAdmin 404s a non-admin on a single-admin roster", async () => {
   const res = await revokeAdmin(c as any, "a", "stranger");
   assertEquals(res.status, 404);
   assertEquals((res.body as any).error, "not an admin");
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 Deno.test("revokeAdmin still refuses to empty a roster of one", async () => {
@@ -181,7 +204,7 @@ Deno.test("revokeAdmin still refuses to empty a roster of one", async () => {
   const res = await revokeAdmin(c as any, "a", "solo");
   assertEquals(res.status, 409);
   assertEquals((res.body as any).error, "cannot remove the last admin");
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 Deno.test("revokeAdmin maps P0002 to 404 rather than reporting a revoke it did not make", async () => {
@@ -249,7 +272,7 @@ Deno.test("grantAdmin 404s when no candidate matches exactly", async () => {
   assertEquals(res.status, 404);
   // The status alone would also pass for a grant that wrote the row and then
   // answered 404, which leaves the account genuinely an admin.
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 Deno.test("grantAdmin 409s rather than 404s when the candidates span more than one page", async () => {
@@ -264,7 +287,7 @@ Deno.test("grantAdmin 409s rather than 404s when the candidates span more than o
   });
   const res = await grantAdmin(c as any, deps, "a", "new@example.com");
   assertEquals(res.status, 409);
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 Deno.test("grantAdmin 409s an existing admin without a second insert", async () => {
@@ -274,7 +297,7 @@ Deno.test("grantAdmin 409s an existing admin without a second insert", async () 
   const { deps } = stubGoTrue({ users: [{ id: "dup", email: "dup@example.com" }] });
   const res = await grantAdmin(c as any, deps, "a", "dup@example.com");
   assertEquals(res.status, 409);
-  assertEquals(c.calls.some((x) => x.op === "rpc"), false);
+  assertEquals(wrote(c), false);
 });
 
 
@@ -388,4 +411,179 @@ Deno.test("listAdmins keeps returning the roster when one lookup fails", async (
   assertEquals(rows.length, 2);
   assertEquals(rows[1].email, "someone@example.com");
   assertEquals(rows[1].note, "keeper");
+});
+
+Deno.test("revokeAdmin records the refusal that changed nothing", async () => {
+  // A self-revoke leaves the roster identical, so before this it left no trace
+  // of having been attempted at all. The attempt is the interesting event.
+  const c = stubClient({
+    admins: [
+      { user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { user_id: "b", note: null, created_at: "2026-01-01T00:00:00Z" },
+    ],
+  });
+  const res = await revokeAdmin(c as any, "a", "a");
+  assertEquals(res.status, 403);
+  assertEquals(wrote(c), false);
+  const r = refusals(c);
+  assertEquals(r.length, 1);
+  assertEquals(r[0].p_actor, "a");
+  assertEquals(r[0].p_action, "admin.revoke");
+  assertEquals(r[0].p_target, "a");
+  assertEquals(r[0].p_reason, "cannot revoke yourself");
+});
+
+Deno.test("revokeAdmin records the last-admin refusal with that reason, not another", async () => {
+  // The reason is the whole value of the row. All three revoke refusals share
+  // an action and a target shape, so a log that recorded them interchangeably
+  // would answer "was someone blocked" but never "from doing what".
+  const c = stubClient({
+    admins: [{ user_id: "solo", note: null, created_at: "2026-01-01T00:00:00Z" }],
+  });
+  await revokeAdmin(c as any, "a", "solo");
+  assertEquals(refusals(c)[0].p_reason, "cannot remove the last admin");
+});
+
+Deno.test("revokeAdmin records a revoke of an id that was never an admin", async () => {
+  const c = stubClient({
+    admins: [{ user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" }],
+  });
+  await revokeAdmin(c as any, "a", "stranger");
+  const r = refusals(c);
+  assertEquals(r[0].p_reason, "not an admin");
+  assertEquals(r[0].p_target, "stranger");
+});
+
+Deno.test("revokeAdmin records the trigger's refusal too", async () => {
+  // The API's own count said the revoke was fine and the trigger disagreed.
+  // That is the case where a record matters most: the refusal came from a layer
+  // the caller cannot see.
+  const c = stubClient({
+    admins: [
+      { user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { user_id: "b", note: null, created_at: "2026-01-01T00:00:00Z" },
+    ],
+    deleteError: { code: "P0001", message: "cannot remove the last admin" },
+  });
+  await revokeAdmin(c as any, "a", "b");
+  assertEquals(refusals(c)[0].p_reason, "cannot remove the last admin");
+});
+
+Deno.test("revokeAdmin does not record a lost lock race as a refusal", async () => {
+  // Nothing refused this revoke - it lost a race and the same request succeeds
+  // a moment later. Logging transient lock noise as blocked attempts makes the
+  // refusal log unreadable exactly when someone needs to read it.
+  const c = stubClient({
+    admins: [
+      { user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { user_id: "b", note: null, created_at: "2026-01-01T00:00:00Z" },
+    ],
+    deleteError: { code: "40P01", message: "deadlock detected" },
+  });
+  const res = await revokeAdmin(c as any, "a", "b");
+  assertEquals(res.status, 409);
+  assertEquals(refusals(c).length, 0);
+});
+
+Deno.test("revokeAdmin still answers the caller when the refusal cannot be audited", async () => {
+  // The action was refused whether or not the log accepted the row. Turning a
+  // clean 403 into a 500 would tell the admin their revoke MIGHT have gone
+  // through, which is the one thing a refusal is not.
+  const c = stubClient({
+    admins: [
+      { user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { user_id: "b", note: null, created_at: "2026-01-01T00:00:00Z" },
+    ],
+    refusalError: { message: "audit unavailable" },
+  });
+  const res = await revokeAdmin(c as any, "a", "a");
+  assertEquals(res.status, 403);
+  assertEquals((res.body as any).error, "cannot revoke yourself");
+});
+
+Deno.test("revokeAdmin records nothing on a successful revoke", async () => {
+  // Success is audited inside the transaction that performs it. A second row
+  // from out here would double-count it and weaken what a refusal row means.
+  const c = stubClient({
+    admins: [
+      { user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { user_id: "b", note: null, created_at: "2026-01-01T00:00:00Z" },
+    ],
+  });
+  await revokeAdmin(c as any, "a", "b");
+  assertEquals(refusals(c).length, 0);
+});
+
+Deno.test("grantAdmin records a refused grant without storing the address", async () => {
+  // The audit table holds ids, never emails. An unmatched address has no id to
+  // record, so the target is null - the address must not fill the gap.
+  const c = stubClient({
+    admins: [{ user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" }],
+  });
+  const { deps } = stubGoTrue({ users: [{ id: "wrong", email: "xnew@example.com" }] });
+  await grantAdmin(c as any, deps, "a", "new@example.com");
+  const r = refusals(c);
+  assertEquals(r.length, 1);
+  assertEquals(r[0].p_action, "admin.grant");
+  assertEquals(r[0].p_target, null);
+  assertEquals(r[0].p_reason, "no such user");
+  assertEquals(JSON.stringify(r).includes("new@example.com"), false);
+});
+
+Deno.test("grantAdmin records an already-an-admin refusal against the real id", async () => {
+  // Here there IS an account, so the row names it: this refusal is about a
+  // specific person, and the id is what makes it findable later.
+  const c = stubClient({
+    admins: [{ user_id: "dup", note: null, created_at: "2026-01-01T00:00:00Z" }],
+  });
+  const { deps } = stubGoTrue({ users: [{ id: "dup", email: "dup@example.com" }] });
+  await grantAdmin(c as any, deps, "a", "dup@example.com");
+  const r = refusals(c);
+  assertEquals(r[0].p_target, "dup");
+  assertEquals(r[0].p_reason, "already an admin");
+});
+
+Deno.test("grantAdmin records an ambiguous address without storing the address", async () => {
+  // Asserted separately from the no-such-user path: it is its own call site
+  // with its own arguments, and it is the one holding an address that matched
+  // several accounts - the most tempting one to describe in the log.
+  const c = stubClient({
+    admins: [{ user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" }],
+  });
+  const { deps } = stubGoTrue({
+    users: [{ id: "wrong", email: "xnew@example.com" }],
+    headers: { link: '</admin/users?page=2>; rel="next"' },
+  });
+  await grantAdmin(c as any, deps, "a", "new@example.com");
+  const r = refusals(c);
+  assertEquals(r.length, 1);
+  assertEquals(r[0].p_target, null);
+  assertEquals(
+    r[0].p_reason,
+    "too many candidate accounts for that address to resolve it safely",
+  );
+  assertEquals(JSON.stringify(r).includes("new@example.com"), false);
+  assertEquals(JSON.stringify(r).includes("@"), false);
+});
+
+Deno.test("a refusal audit that throws does not become the caller's answer", async () => {
+  // Distinct from an rpc that RETURNS an error: a transport failure throws, and
+  // an unguarded call would turn a clean 403 into a 500 - telling the admin
+  // their revoke might have gone through.
+  const c = stubClient({
+    admins: [
+      { user_id: "a", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { user_id: "b", note: null, created_at: "2026-01-01T00:00:00Z" },
+    ],
+  });
+  const throwing = {
+    ...c,
+    rpc(name: string, params: Record<string, unknown>) {
+      if (name === "admin_record_refusal") throw new Error("connection reset");
+      return c.rpc(name, params);
+    },
+  };
+  const res = await revokeAdmin(throwing as any, "a", "a");
+  assertEquals(res.status, 403);
+  assertEquals((res.body as any).error, "cannot revoke yourself");
 });

--- a/supabase/migrations/20260731210000_admin_audit_refusals.sql
+++ b/supabase/migrations/20260731210000_admin_audit_refusals.sql
@@ -1,0 +1,98 @@
+-- Record refused admin actions, not only successful writes.
+--
+-- Until now a row in admin_audit meant "a write happened", so a destructive
+-- action that was REFUSED left no trace at all: a reset submitted with the
+-- wrong confirmation address, a self-revoke, a revoke that would have emptied
+-- the roster. Those are the events most worth having on record - a successful
+-- reset is an admin doing their job, an attempted one that was blocked is the
+-- thing you want to find later.
+--
+-- Two changes make room for them without weakening what the table already
+-- claims:
+--
+--   * `outcome` splits the two kinds of row. It defaults to 'succeeded', so
+--     every row written before this migration keeps exactly the meaning it had,
+--     and the invariant "a succeeded row means the write committed" survives -
+--     it is still only written inside the atomic write functions.
+--   * `reason` says why a refusal was refused, as one of a fixed set of
+--     strings the edge function already returns to the caller. It is nullable
+--     and must stay null on success: "why did this succeed" has no answer.
+--
+-- `reason` carries no user input. The refusal that is most tempting to
+-- describe in detail - a confirmation address that did not match - must record
+-- only that it did not match. Storing the submitted address would put an email
+-- in this table, which is the one thing its comment promises it does not do,
+-- and would do it on the path where the address is most likely to be the wrong
+-- person's.
+
+alter table public.admin_audit
+  add column outcome text not null default 'succeeded',
+  add column reason text;
+
+-- A free-text outcome would let a future caller invent a third value and
+-- silently divide the log into groups no query knows to look for.
+alter table public.admin_audit
+  add constraint admin_audit_outcome_check
+  check (outcome in ('succeeded', 'refused'));
+
+-- A refusal without a reason is barely more useful than no row, and a success
+-- with one implies something went wrong that did not.
+alter table public.admin_audit
+  add constraint admin_audit_reason_matches_outcome
+  check (
+    (outcome = 'refused' and reason is not null) or
+    (outcome = 'succeeded' and reason is null)
+  );
+
+-- Refusals are read as "what was blocked recently", which is a scan by outcome
+-- over a time window. The existing created_at index alone would have to read
+-- every successful write to find them.
+create index idx_admin_audit_refusals
+  on public.admin_audit (created_at desc)
+  where outcome = 'refused';
+
+-- Retention: refusals are kept exactly as long as writes, which is to say
+-- indefinitely, and deliberately.
+--
+-- analytics_events gets a 400-day prune because it holds a row per page view
+-- from every reader. This table holds a row per deliberate action by an
+-- account that is already an admin, and there is one admin. Its growth rate is
+-- bounded by human effort, so a retention window would be solving a problem
+-- that cannot occur while removing the record that makes the log worth having.
+-- Expiring refusals SOONER than writes would be the worst of the options: the
+-- security-interesting half would be the half that disappears.
+
+create or replace function public.admin_record_refusal(
+  p_actor uuid,
+  p_action text,
+  p_target uuid,
+  p_reason text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if p_reason is null or btrim(p_reason) = '' then
+    raise exception 'a refusal must carry a reason' using errcode = 'P0003';
+  end if;
+  insert into public.admin_audit (actor_user_id, action, target_user_id, outcome, reason)
+  values (p_actor, p_action, p_target, 'refused', p_reason);
+end;
+$$;
+
+-- Deliberately cannot write a 'succeeded' row. Success is recorded only inside
+-- the functions that perform the write it is claiming, in the same transaction,
+-- and a second door into the log that skips the write would make every success
+-- row a claim rather than a fact.
+revoke all on function public.admin_record_refusal(uuid, text, uuid, text) from public, anon, authenticated;
+grant execute on function public.admin_record_refusal(uuid, text, uuid, text) to service_role;
+
+comment on function public.admin_record_refusal is
+  'Records a refused admin action. Cannot record a success. Service-role only.';
+
+comment on column public.admin_audit.outcome is
+  'succeeded (the write committed, written only inside the atomic write functions) or refused (a guard blocked it).';
+comment on column public.admin_audit.reason is
+  'Why a refusal was refused. Null on success. Never contains user input.';


### PR DESCRIPTION
Closes #178.

A refused destructive action left no trace. `recordAudit` only ran after a write committed, so a reset submitted with the wrong confirmation address, a self-revoke, and a revoke that would have emptied the roster were all refused silently - and those attempts are more interesting than the successes.

## Schema

`admin_audit` gains two columns:

- `outcome`, defaulting to `succeeded`, so every row written before this keeps exactly the meaning it had, and "a succeeded row means the write committed" still holds - those rows are still only written inside the atomic write functions.
- `reason`, the fixed string explaining a refusal.

A check constraint ties them together (a refusal must carry a reason, a success must not), plus a partial index on `created_at where outcome = 'refused'`, because "what was blocked recently" would otherwise scan every successful write.

`admin_record_refusal()` is the only new writer and it **cannot record a success**. A second door into the log that skips the write would turn every success row from a fact into a claim.

## Behaviour

Refusals recorded: `progress.reset` (unknown id, confirmation mismatch), `admin.revoke` (self, not an admin, last admin, and the trigger's own P0001 - the case where the refusal came from a layer the caller cannot see), `admin.grant` (no such user, ambiguous address, already an admin).

Deliberately **not** recorded: a lost lock race (40P01/55P03). Nothing refused that revoke; it lost a race and the same request succeeds a moment later. Filling the blocked-attempts log with transient lock noise makes it unreadable exactly when someone needs to read it.

Two invariants the tests pin hard:

- **No refusal stores user input.** The submitted confirmation address is the field most likely to hold the wrong person's email - that is why the path refused - and this table records ids, never addresses. Grant refusals with no matching account record a null target rather than filling the gap with the address.
- **Auditing a refusal never changes the caller's answer.** The action was refused whether or not the log accepted the row; a 500 there would tell the admin their reset might have gone through. Covered for both an rpc that returns an error and one that throws.

The refusal reasons are a single vocabulary shared with the API responses (`RevokeCheck.error` is now typed as `RefusalReason`), so the log cannot describe a refusal in words the admin never saw.

## Retention

Refusals are kept as long as writes: indefinitely, and deliberately. `analytics_events` gets a 400-day prune because it holds a row per page view from every reader; this table grows by deliberate action from an account that is already an admin, and there is one admin. Expiring refusals sooner than writes would be the worst option available - the security-interesting half would be the half that disappears.

## Verification

`./verify.sh` passes; migration applied to prod (no drift, only this one pending). Mutation-checked, 11 rows: each refusal call site removed, the revoke refusal recorded with the wrong reason, a lost lock race logged as a refusal, a successful revoke logged as refused, the address stored as the target or as the reason, and the audit's error guard removed.

Two rows initially returned **zero failures** and both were real gaps: the ambiguous-address grant path had no test of its own (only the no-such-user path did), and nothing pinned the try/catch, because the existing stub returned an error rather than throwing. Added both rather than accepting the rows.